### PR TITLE
fix: Run yarn build in before_deploy hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
   - yarn test:all --coverage --runInBand
 
 before_deploy:
+  - yarn build
   - yarn build:demo
   - npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
 


### PR DESCRIPTION
## Description

🤦‍♂️ Turns out it's useful to build the assets before you publish to npm.

## Detail

We only ran `yarn build:demo` in the `before_deploy` hook so npm published the tarball with no `dist` folder.

I'll run a `lerna publish --force-publish=*` to do a forced patch update.