### PR TITLE
chore: fix malformed Code of Conduct links

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -14,22 +14,22 @@ religion, or sexual identity and orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual
+- The use of sexualized language or imagery and unwelcome sexual
   attention or advances
-* Trolling, insulting/derogatory comments, and personal or political
+- Trolling, insulting/derogatory comments, and personal or political
   attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or
+- Public or private harassment
+- Publishing others' private information, such as a physical or
   electronic address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Our Responsibilities
@@ -71,8 +71,5 @@ by other members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor
-Covenant][homepage], version 1.4, available at
-[http://contributor-covenant.org/version/1/4][version]
-
-[homepage]: http://contributor-covenant.org [version]:
-http://contributor-covenant.org/version/1/4/
+Covenant](https://contributor-covenant.org), version 1.4, available at
+[https://www.contributor-covenant.org/version/1/4/](https://www.contributor-covenant.org/version/1/4/)


### PR DESCRIPTION
* [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Fix code of conduct links that got munged by prettier.

## Checklist

* [ ] :ok_hand: ~design updates are Garden Designer approved (add the
      designer as a reviewer)~
* [ ] :nail_care: ~view component styling is based on a Garden CSS
  component~
* [ ] :globe_with_meridians: ~Styleguidist demo is up-to-date (`yarn start`)~
* [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
* [ ] :guardsman: ~includes new unit and snapshot tests~
* [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
