### PR TITLE
chore: fix inconsistencies with packages

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,7 +36,6 @@
     "react/display-name": "off",
     "jsx-a11y/label-has-for": "off",
     "jsx-a11y/label-has-associated-control": "off",
-    "jest/no-disabled-tests": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn"
   }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,7 @@
     "PACKAGE_VERSION": true,
     "COMPONENT_IDS": true
   },
-  "plugins": ["prettier", "react", "jest", "jsx-a11y"],
+  "plugins": ["prettier", "react", "jest", "jsx-a11y", "react-hooks"],
   "env": {
     "es6": true,
     "browser": true,
@@ -36,6 +36,8 @@
     "react/display-name": "off",
     "jsx-a11y/label-has-for": "off",
     "jsx-a11y/label-has-associated-control": "off",
-    "jest/no-disabled-tests": "off"
+    "jest/no-disabled-tests": "off",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn"
   }
 }

--- a/README.md
+++ b/README.md
@@ -14,22 +14,32 @@ to install.
 
 | Package                                                            | Version                                                             | Dependencies                                                                           |
 | ------------------------------------------------------------------ | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| [`@zendeskgarden/container-breadcrumb`](packages/breadcrumb)       | [![npm version][breadcrumb npm version]][breadcrumb npm link]       | [![Dependency Status][breadcrumb dependency status]][breadcrumb dependency link]       |
 | [`@zendeskgarden/container-field`](packages/field)                 | [![npm version][field npm version]][field npm link]                 | [![Dependency Status][field dependency status]][field dependency link]                 |
-| [`@zendeskgarden/container-schedule`](packages/schedule)           | [![npm version][schedule npm version]][schedule npm link]           | [![Dependency Status][schedule dependency status]][schedule dependency link]           |
+| [`@zendeskgarden/container-selection`](packages/selection)         | [![npm version][selection npm version]][selection npm link]         | [![Dependency Status][selection dependency status]][selection dependency link]         |
 | [`@zendeskgarden/container-keyboardfocus`](packages/keyboardfocus) | [![npm version][keyboardfocus npm version]][keyboardfocus npm link] | [![Dependency Status][keyboardfocus dependency status]][keyboardfocus dependency link] |
+| [`@zendeskgarden/container-schedule`](packages/schedule)           | [![npm version][schedule npm version]][schedule npm link]           | [![Dependency Status][schedule dependency status]][schedule dependency link]           |
 
+[breadcrumb npm version]: https://img.shields.io/npm/v/@zendeskgarden/container-breadcrumb.svg?style=flat-square
+[breadcrumb npm link]: https://www.npmjs.com/package/@zendeskgarden/container-breadcrumb
+[breadcrumb dependency status]: https://img.shields.io/david/zendeskgarden/react-containers.svg?path=packages/breadcrumb&style=flat-square
+[breadcrumb dependency link]: https://david-dm.org/zendeskgarden/react-containers?path=packages/breadcrumb
 [field npm version]: https://img.shields.io/npm/v/@zendeskgarden/container-field.svg?style=flat-square
 [field npm link]: https://www.npmjs.com/package/@zendeskgarden/container-field
 [field dependency status]: https://img.shields.io/david/zendeskgarden/react-containers.svg?path=packages/field&style=flat-square
 [field dependency link]: https://david-dm.org/zendeskgarden/react-containers?path=packages/field
-[schedule npm version]: https://img.shields.io/npm/v/@zendeskgarden/container-schedule.svg?style=flat-square
-[schedule npm link]: https://www.npmjs.com/package/@zendeskgarden/container-schedule
-[schedule dependency status]: https://img.shields.io/david/zendeskgarden/react-containers.svg?path=packages/schedule&style=flat-square
-[schedule dependency link]: https://david-dm.org/zendeskgarden/react-containers?path=packages/schedule
+[selection npm version]: https://img.shields.io/npm/v/@zendeskgarden/container-selection.svg?style=flat-square
+[selection npm link]: https://www.npmjs.com/package/@zendeskgarden/container-selection
+[selection dependency status]: https://img.shields.io/david/zendeskgarden/react-containers.svg?path=packages/selection&style=flat-square
+[selection dependency link]: https://david-dm.org/zendeskgarden/react-containers?path=packages/selection
 [keyboardfocus npm version]: https://img.shields.io/npm/v/@zendeskgarden/container-keyboardfocus.svg?style=flat-square
 [keyboardfocus npm link]: https://www.npmjs.com/package/@zendeskgarden/container-keyboardfocus
 [keyboardfocus dependency status]: https://img.shields.io/david/zendeskgarden/react-containers.svg?path=packages/keyboardfocus&style=flat-square
 [keyboardfocus dependency link]: https://david-dm.org/zendeskgarden/react-containers?path=packages/keyboardfocus
+[schedule npm version]: https://img.shields.io/npm/v/@zendeskgarden/container-schedule.svg?style=flat-square
+[schedule npm link]: https://www.npmjs.com/package/@zendeskgarden/container-schedule
+[schedule dependency status]: https://img.shields.io/david/zendeskgarden/react-containers.svg?path=packages/schedule&style=flat-square
+[schedule dependency link]: https://david-dm.org/zendeskgarden/react-containers?path=packages/schedule
 
 ## Usage
 
@@ -45,6 +55,28 @@ package.
 ```sh
 # Install garden package
 npm install @zendeskgarden/container-schedule
+```
+
+### Using as a hook
+
+```jsx
+import React from 'react';
+import { render } from 'react-dom';
+
+/** Consume throughout app */
+import { useSchedule } from '@zendeskgarden/container-schedule';
+
+const App = () => {
+  const elapsed = useSchedule({duration: 1000});
+  const x = 900;
+  const styles = {
+transform: translateX(`${900*elapsed}`px)
+  };
+
+  return <div style={styles} />;
+}
+
+render(<App />, document.getElementById('root'));
 ```
 
 ### Using as a render prop container
@@ -71,28 +103,6 @@ class App extends Component {
       </ScheduleContainer>
     );
   }
-}
-
-render(<App />, document.getElementById('root'));
-```
-
-### Using as a hook
-
-```jsx
-import React from 'react';
-import { render } from 'react-dom';
-
-/** Consume throughout app */
-import { useSchedule } from '@zendeskgarden/container-schedule';
-
-const App = () => {
-  const elapsed = useSchedule({duration: 1000});
-  const x = 900;
-  const styles = {
-    transform: translateX(`${900*elapsed}`px)
-  };
-
-  return <div style={styles} />;
 }
 
 render(<App />, document.getElementById('root'));

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-notice": "0.7.7",
     "eslint-plugin-prettier": "3.0.0",
     "eslint-plugin-react": "7.11.1",
-    "eslint-plugin-react-hooks": "^1.5.0",
+    "eslint-plugin-react-hooks": "1.5.0",
     "handlebars": "4.0.12",
     "handlebars-helpers": "0.10.0",
     "husky": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint-plugin-notice": "0.7.7",
     "eslint-plugin-prettier": "3.0.0",
     "eslint-plugin-react": "7.11.1",
+    "eslint-plugin-react-hooks": "^1.5.0",
     "handlebars": "4.0.12",
     "handlebars-helpers": "0.10.0",
     "husky": "1.2.0",

--- a/packages/.template/README.md
+++ b/packages/.template/README.md
@@ -11,6 +11,22 @@ npm install @zendeskgarden/container-{{component}}
 
 ## Usage
 
+For live examples check out our [storybook](https://zendeskgarden.github.io/react-containers).
+
+### useExample
+
+```jsx static
+import { useExample } from '@zendeskgarden/container-{{component}}';
+
+const Example = () => {
+  const { getExampleProps } = useExample();
+
+  return <div {...getExampleProps()} />;
+};
+```
+
+### ExampleContainer
+
 ```jsx static
 import { ExampleContainer } from '@zendeskgarden/container-{{component}}';
 

--- a/packages/.template/package.json
+++ b/packages/.template/package.json
@@ -18,8 +18,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.6.1",
-    "react": "16.8.0-alpha.0",
-    "react-dom": "16.8.0-alpha.0"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
   },
   "keywords": [
     "a11y",
@@ -32,5 +32,6 @@
   ],
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "zendeskgarden:src": "src/index.js"
 }

--- a/packages/.template/src/Example.js
+++ b/packages/.template/src/Example.js
@@ -5,21 +5,16 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-export default class ExampleContainer extends Component {
-  static propTypes = {
-    coolProp: PropTypes.bool
-  };
+import { useExample } from './useExample';
 
-  getCoolProps = ({ coolProp = 'cool', ...other }) => ({ coolProp, ...other });
-
-  render() {
-    const { children, render = children } = this.props;
-
-    render({
-      getCoolProps: props => this.getCoolProps(prop)
-    });
-  }
+export function ExampleContainer({ children, render = children, coolProp }) {
+  return render(useExample({ coolProp }));
 }
+
+ExampleContainer.propTypes = {
+  children: PropTypes.func,
+  render: PropTypes.func,
+  coolProp: PropTypes.string
+};

--- a/packages/.template/src/ExampleContainer.spec.js
+++ b/packages/.template/src/ExampleContainer.spec.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { ExampleContainer } from './ExampleContainer';
+
+describe('ExampleContainer', () => {
+  let wrapper;
+
+  const basicExample = () => (
+    <ExampleContainer>
+      {({ getCoolProps }) => <div {...getCoolProps({ 'data-test-id': 'div' })} />}
+    </ExampleContainer>
+  );
+
+  beforeEach(() => {
+    wrapper = mount(basicExample());
+  });
+
+  const findDiv = enzymeWrapper => enzymeWrapper.find('[data-test-id="div"]');
+
+  describe('getCoolProps', () => {
+    it('applies correct accessibility role', () => {
+      const div = findDiv(wrapper);
+
+      expect(div).toHaveProp('cool', true);
+    });
+  });
+});

--- a/packages/.template/src/useExample.js
+++ b/packages/.template/src/useExample.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { useState } from 'react';
+
+export function useExample({ coolProp }) {
+  const [example, setExample] = useState(0);
+
+  const getCoolProps = ({ coolProp = 'cool', ...other }) => ({ coolProp, ...other });
+
+  return {
+    getCoolProps
+  };
+}

--- a/packages/.template/stories.js
+++ b/packages/.template/stories.js
@@ -10,8 +10,19 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs } from '@storybook/addon-knobs';
 
-import { Button } from '@storybook/react/demo';
+import { ExampleContainer, useExample } from './src';
 
 storiesOf('Example Container', module)
   .addDecorator(withKnobs)
-  .add('with some text', () => <Button onClick={action('clicked')}>Click</Button>);
+  .add('useExample', () => {
+    const Example = ({ coolProp }) => {
+      const { getCoolProps } = useExample({ coolProp });
+
+      return <div {...getCoolProps()} />;
+    };
+
+    return <Example coolProp />;
+  })
+  .add('ExampleContainer', () => (
+    <ExampleContainer>{({ getCoolProps }) => <div {...getCoolProps()} />}</ExampleContainer>
+  ));

--- a/packages/breadcrumb/README.md
+++ b/packages/breadcrumb/README.md
@@ -11,6 +11,8 @@ npm install @zendeskgarden/container-breadcrumb
 
 ## Usage
 
+For live examples check out our [storybook](https://zendeskgarden.github.io/react-containers?selectedKind=Bread%20Container).
+
 ### As a Render Prop Component
 
 ```jsx static

--- a/packages/breadcrumb/package.json
+++ b/packages/breadcrumb/package.json
@@ -35,5 +35,6 @@
   ],
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "zendeskgarden:src": "src/index.js"
 }

--- a/packages/breadcrumb/stories.js
+++ b/packages/breadcrumb/stories.js
@@ -16,21 +16,7 @@ import '@zendeskgarden/css-breadcrumbs';
 
 storiesOf('Breadcrumb Container', module)
   .addDecorator(withKnobs)
-  .add('as a render prop container', () => (
-    <BreadcrumbContainer>
-      {({ getContainerProps, getCurrentPageProps }) => (
-        <div {...getContainerProps({ className: 'c-breadcrumb' })}>
-          <a href="#foo" className="c-breadcrumb__item">
-            Home
-          </a>
-          <a {...getCurrentPageProps({ href: '#foo', className: 'c-breadcrumb__item is-current' })}>
-            Items
-          </a>
-        </div>
-      )}
-    </BreadcrumbContainer>
-  ))
-  .add('as a hook', () => {
+  .add('useBreadcrumb', () => {
     const Breadcrumb = () => {
       const { getContainerProps, getCurrentPageProps } = useBreadcrumb();
 
@@ -47,4 +33,18 @@ storiesOf('Breadcrumb Container', module)
     };
 
     return <Breadcrumb />;
-  });
+  })
+  .add('BreadcrumbContainer', () => (
+    <BreadcrumbContainer>
+      {({ getContainerProps, getCurrentPageProps }) => (
+        <div {...getContainerProps({ className: 'c-breadcrumb' })}>
+          <a href="#foo" className="c-breadcrumb__item">
+            Home
+          </a>
+          <a {...getCurrentPageProps({ href: '#foo', className: 'c-breadcrumb__item is-current' })}>
+            Items
+          </a>
+        </div>
+      )}
+    </BreadcrumbContainer>
+  ));

--- a/packages/keyboardfocus/README.md
+++ b/packages/keyboardfocus/README.md
@@ -11,6 +11,8 @@ npm install @zendeskgarden/container-keyboardfocus
 
 ## Usage
 
+For live examples check out our [storybook](https://zendeskgarden.github.io/react-containers?selectedKind=KeyboardFocus%20Container).
+
 ### useKeyboardFocus
 
 The `useKeyboardFocus` hook supplies state and props that help you to distinguish

--- a/packages/keyboardfocus/package.json
+++ b/packages/keyboardfocus/package.json
@@ -35,5 +35,6 @@
   ],
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "zendeskgarden:src": "src/index.js"
 }

--- a/packages/schedule/README.md
+++ b/packages/schedule/README.md
@@ -11,6 +11,8 @@ npm install @zendeskgarden/container-schedule
 
 ## Usage
 
+For live examples check out our [storybook](https://zendeskgarden.github.io/react-containers?selectedKind=Schedule%20Container).
+
 ### As a Render Prop Component
 
 ```jsx static

--- a/packages/schedule/package.json
+++ b/packages/schedule/package.json
@@ -32,5 +32,6 @@
   ],
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "zendeskgarden:src": "src/index.js"
 }

--- a/packages/schedule/src/ScheduleContainer.spec.js
+++ b/packages/schedule/src/ScheduleContainer.spec.js
@@ -8,6 +8,8 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import createMockRaf from 'mock-raf';
+import { act } from 'react-dom/test-utils';
+
 import ScheduleContainer from './ScheduleContainer';
 
 jest.useFakeTimers();
@@ -38,20 +40,25 @@ describe('ScheduleContainer', () => {
 
   it('sets up requestAnimationFrame', () => {
     wrapper = mount(basicExample());
+
     jest.runOnlyPendingTimers();
     expect(requestAnimationFrame).toHaveBeenCalled();
   });
 
   it('updates elapsed render prop on each raf call', () => {
     wrapper = mount(basicExample());
+
     jest.runOnlyPendingTimers();
-    mockRaf.step({ count: 60 });
+    act(() => {
+      mockRaf.step({ count: 60 });
+    });
     wrapper.update();
     expect(parseFloat(wrapper.find('p').prop('children'))).not.toBe(0);
   });
 
   it('cancels requestAnimationFrame on duration end', () => {
     wrapper = mount(basicExample());
+
     jest.runOnlyPendingTimers(); // delayTimer
     jest.runOnlyPendingTimers(); // loopTimeout
     expect(cancelAnimationFrame).toHaveBeenCalled();
@@ -67,17 +74,20 @@ describe('ScheduleContainer', () => {
 
   it('passes correct ms delay to intitial setTimeout', () => {
     wrapper = mount(basicExample({ delayMS: 1000 }));
+
     expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 1000);
   });
 
   it('passes correct ms duration to setTimeout', () => {
     wrapper = mount(basicExample({ duration: 500 }));
+
     jest.runOnlyPendingTimers(); // trigger delayMS timeout
     expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 500);
   });
 
   it('stops animation after single iteration if loop false is passed', () => {
     wrapper = mount(basicExample({ loop: false }));
+
     jest.runOnlyPendingTimers(); // delayTimer
     jest.runOnlyPendingTimers(); // loopTimeout
     expect(setTimeout).toHaveBeenCalledTimes(2);
@@ -85,6 +95,7 @@ describe('ScheduleContainer', () => {
 
   it('animation loops once initial duration has completed', () => {
     wrapper = mount(basicExample()); // loop = true is the default
+
     jest.runOnlyPendingTimers(); // delayTimer
     jest.runOnlyPendingTimers(); // loopTimeout
     expect(setTimeout).toHaveBeenCalledTimes(3);

--- a/packages/schedule/stories.js
+++ b/packages/schedule/stories.js
@@ -14,21 +14,7 @@ import { ScheduleContainer, useSchedule } from './src';
 
 storiesOf('Schedule Container', module)
   .addDecorator(withKnobs)
-  .add('as render prop container', () => (
-    <ScheduleContainer
-      duration={number('duration', 1250)}
-      loop={boolean('loop', true)}
-      delayMS={number('delayMS', 750)}
-    >
-      {elapsed => (
-        <div>
-          Percentage: {(elapsed * 100).toFixed(0)}%<br />
-          Elapsed: {elapsed}
-        </div>
-      )}
-    </ScheduleContainer>
-  ))
-  .add('as a hook', () => {
+  .add('useSchedule', () => {
     const Animation = () => {
       const duration = number('duration', 1250);
       const loop = boolean('loop', true);
@@ -44,4 +30,18 @@ storiesOf('Schedule Container', module)
     };
 
     return <Animation />;
-  });
+  })
+  .add('ScheduleContainer', () => (
+    <ScheduleContainer
+      duration={number('duration', 1250)}
+      loop={boolean('loop', true)}
+      delayMS={number('delayMS', 750)}
+    >
+      {elapsed => (
+        <div>
+          Percentage: {(elapsed * 100).toFixed(0)}%<br />
+          Elapsed: {elapsed}
+        </div>
+      )}
+    </ScheduleContainer>
+  ));

--- a/packages/selection/README.md
+++ b/packages/selection/README.md
@@ -13,46 +13,11 @@ npm install @zendeskgarden/container-selection
 
 For live examples check out our [storybook](https://zendeskgarden.github.io/react-containers?selectedKind=Selection%20Containers).
 
-### SelectionContainer
-
-SelectionContainer is a render-prop around the `useSelection` hook which manages an items focus
-state including keyboard controls, aria attributes and RTL support. It uses the
-[roving tab index strategy](https://www.w3.org/TR/wai-aria-practices/#kbd_roving_tabindex).
-
-```jsx static
-import { SelectionContainer } from '@zendeskgarden/container-selection';
-
-const items = ['Item 1', 'Item 2', 'Item 3'];
-
-<SelectionContainer direction="vertical">
-  {({ selectedItem, focusedItem, getContainerProps, getItemProps }) => (
-    <ul {...getContainerProps()}>
-      {items.map(item => {
-        const ref = React.createRef();
-        const isSelected = item === selectedItem;
-        const isFocused = item === focusedItem;
-
-        return (
-          <li
-            {...getItemProps({
-              key: item,
-              item,
-              ref,
-              focusRef: ref
-            })}
-          >
-            {item}
-            {isSelected && <span> - Selected</span>}
-            {isFocused && <span> - Focused</span>}
-          </li>
-        );
-      })}
-    </ul>
-  )}
-</SelectionContainer>;
-```
-
 ### useSelection
+
+The `useSelection` hook which manages an items focus state including keyboard controls,
+aria attributes and RTL support. It uses the
+[roving tab index strategy](https://www.w3.org/TR/wai-aria-practices/#kbd_roving_tabindex).
 
 ```jsx static
 import { useSelection } from '@zendeskgarden/container-selection';
@@ -89,4 +54,39 @@ const Selection = ({ direction }) => {
     </ul>
   );
 };
+```
+
+### SelectionContainer
+
+```jsx static
+import { SelectionContainer } from '@zendeskgarden/container-selection';
+
+const items = ['Item 1', 'Item 2', 'Item 3'];
+
+<SelectionContainer direction="vertical">
+  {({ selectedItem, focusedItem, getContainerProps, getItemProps }) => (
+    <ul {...getContainerProps()}>
+      {items.map(item => {
+        const ref = React.createRef();
+        const isSelected = item === selectedItem;
+        const isFocused = item === focusedItem;
+
+        return (
+          <li
+            {...getItemProps({
+              key: item,
+              item,
+              ref,
+              focusRef: ref
+            })}
+          >
+            {item}
+            {isSelected && <span> - Selected</span>}
+            {isFocused && <span> - Focused</span>}
+          </li>
+        );
+      })}
+    </ul>
+  )}
+</SelectionContainer>;
 ```

--- a/packages/selection/src/useSelection.js
+++ b/packages/selection/src/useSelection.js
@@ -159,7 +159,7 @@ export function useSelection({
         refs[focusedIndex] && refs[focusedIndex].current.focus();
       }
     },
-    [controlledFocusedItem]
+    [controlledFocusedItem, items, refs]
   );
 
   const getContainerProps = ({ role = 'listbox', ...other } = {}) => ({

--- a/packages/selection/stories.js
+++ b/packages/selection/stories.js
@@ -16,41 +16,6 @@ import { DIRECTIONS } from './src/utils/DIRECTIONS';
 
 storiesOf('Selection Containers', module)
   .addDecorator(withKnobs)
-  .add('SelectionContainer', () => {
-    const items = ['Item 1', 'Item 2', 'Item 3'];
-
-    return (
-      <SelectionContainer
-        direction="vertical"
-        defaultFocusedIndex={number('defaultFocusedIndex', 0)}
-      >
-        {({ selectedItem, focusedItem, getContainerProps, getItemProps }) => (
-          <ul {...getContainerProps()}>
-            {items.map(item => {
-              const ref = React.createRef();
-              const isSelected = item === selectedItem;
-              const isFocused = item === focusedItem;
-
-              return (
-                <li
-                  {...getItemProps({
-                    key: item,
-                    item,
-                    ref,
-                    focusRef: ref
-                  })}
-                >
-                  {item}
-                  {isSelected && <span> - Selected</span>}
-                  {isFocused && <span> - Focused</span>}
-                </li>
-              );
-            })}
-          </ul>
-        )}
-      </SelectionContainer>
-    );
-  })
   .add('useSelection', () => {
     const items = ['One', 'Two', 'Three'];
     const isRtl = boolean('Enable RTL', false);
@@ -111,5 +76,40 @@ storiesOf('Selection Containers', module)
           DIRECTIONS.HORIZONTAL
         )}
       />
+    );
+  })
+  .add('SelectionContainer', () => {
+    const items = ['Item 1', 'Item 2', 'Item 3'];
+
+    return (
+      <SelectionContainer
+        direction="vertical"
+        defaultFocusedIndex={number('defaultFocusedIndex', 0)}
+      >
+        {({ selectedItem, focusedItem, getContainerProps, getItemProps }) => (
+          <ul {...getContainerProps()}>
+            {items.map(item => {
+              const ref = React.createRef();
+              const isSelected = item === selectedItem;
+              const isFocused = item === focusedItem;
+
+              return (
+                <li
+                  {...getItemProps({
+                    key: item,
+                    item,
+                    ref,
+                    focusRef: ref
+                  })}
+                >
+                  {item}
+                  {isSelected && <span> - Selected</span>}
+                  {isFocused && <span> - Focused</span>}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </SelectionContainer>
     );
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5156,6 +5156,11 @@ eslint-plugin-prettier@3.0.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-react-hooks@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.5.0.tgz#cdd958cfff55bd5fa4f84db90d1490fb5ca4ae2b"
+  integrity sha512-iwDuWR2ReRgvJsNm8fXPtTKdg78IVQF8I4+am3ntztPf/+nPnWZfArFu6aXpaC75/iCYRrkqI8nPCYkxJstmpA==
+
 eslint-plugin-react@7.11.1:
   version "7.11.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz#c01a7af6f17519457d6116aa94fc6d2ccad5443c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5156,7 +5156,7 @@ eslint-plugin-prettier@3.0.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-react-hooks@^1.5.0:
+eslint-plugin-react-hooks@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.5.0.tgz#cdd958cfff55bd5fa4f84db90d1490fb5ca4ae2b"
   integrity sha512-iwDuWR2ReRgvJsNm8fXPtTKdg78IVQF8I4+am3ntztPf/+nPnWZfArFu6aXpaC75/iCYRrkqI8nPCYkxJstmpA==


### PR DESCRIPTION
## Description

After adding several packages some of the patterns have diverged from each other so Ive brought them all back inline.

## Detail

- Updated readme to include all published packages so far
- Update template to better reflect starting point
- Made hooks come first and used consistent naming
- Re-added the `zendeskgarden:src` key to package.json as our `jest.resolver.js` file was using it
- Added eslint hooks package
- Add direct link to storybook examples in each package readme.
- Fixed jest warning logs about not using `act` test utility

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn storybook`)
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
