### PR TITLE
fix(selection): correctly use controlled state to avoid weird bugs

### DIFF
--- a/packages/selection/src/useSelection.js
+++ b/packages/selection/src/useSelection.js
@@ -195,8 +195,8 @@ export function useSelection({
       controlledFocusedItem === undefined ? isSelected : controlledFocusedItem === item;
     const tabIndex =
       isFocused ||
-      (state.selectedItem === undefined &&
-        state.focusedItem === undefined &&
+      (controlledSelectedItem === undefined &&
+        controlledFocusedItem === undefined &&
         items.indexOf(item) === defaultFocusedIndex)
         ? 0
         : -1;


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Regardless if the hook is controlled or not we use the `getControlledValue` util to grab the value either internally stored or passed in as arguments.

## Detail

This fixes a spot where we manage what should have the tabIndex applied it was still using internal state over controlled props which presented itself in `usePagination` .

See pagination PR #20

## Checklist

- [ ] :globe_with_meridians: ~Storybook demo is up-to-date (`yarn storybook`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
