### PR TITLE
fix(selection): check if keyboard select is in controlled mode

### DIFF
--- a/packages/selection/src/useSelection.js
+++ b/packages/selection/src/useSelection.js
@@ -103,13 +103,20 @@ function stateReducer(state, action, { focusedItem, selectedItem, onFocus, onSel
       return updatedState;
     }
     case ACTIONS.KEYBOARD_SELECT: {
+      let isSelectControlled = false;
+
       if (onSelect) {
         onSelect(action.payload);
-
-        return state;
+        isSelectControlled = true;
       }
 
-      return { ...state, selectedItem: action.payload };
+      const updatedState = { ...state };
+
+      if (!isSelectControlled) {
+        updatedState.selectedItem = action.payload;
+      }
+
+      return updatedState;
     }
     case ACTIONS.EXIT_WIDGET: {
       if (onFocus) {

--- a/packages/selection/src/useSelection.js
+++ b/packages/selection/src/useSelection.js
@@ -103,20 +103,13 @@ function stateReducer(state, action, { focusedItem, selectedItem, onFocus, onSel
       return updatedState;
     }
     case ACTIONS.KEYBOARD_SELECT: {
-      let isSelectControlled = false;
-
       if (onSelect) {
         onSelect(action.payload);
-        isSelectControlled = true;
+
+        return { ...state };
       }
 
-      const updatedState = { ...state };
-
-      if (!isSelectControlled) {
-        updatedState.selectedItem = action.payload;
-      }
-
-      return updatedState;
+      return { ...state, selectedItem: action.payload };
     }
     case ACTIONS.EXIT_WIDGET: {
       if (onFocus) {


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

If `onFocus` or `onSelect` are used with the hook the internal state isn't updated correctly as it returns the current state un-modified.

## Detail

See [codesandbox](https://codesandbox.io/s/38557pq5l1) with container-selection package and it using the `onFocus` argument in the `useSelection` hook. It doesn't actually allow you to increment or decrement the focus state.

This manifested in the `PaginationContainer` example #20 

## Checklist

- [ ] :globe_with_meridians: ~Storybook demo is up-to-date (`yarn storybook`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
