### PR TITLE
fix(focusjail): Handle conditional rendering and ref passing

### DIFF
--- a/packages/focusjail/README.md
+++ b/packages/focusjail/README.md
@@ -19,12 +19,15 @@ The `useFocusJail` hook allows you to trap focus to a container element. Useful
 for modals and widgets. Garden uses this in react-components for the modals package.
 
 ```jsx static
+import { useRef } from 'react';
 import { useFocusJail } from '@zendeskgarden/container-focusjail';
 
 const FocusJail = () => {
-  const { getContainerProps, containerRef } = useFocusJail({
+  const containerRef = useRef(null);
+  const { getContainerProps } = useFocusJail({
     focusOnMount: false,
-    environment: window.parent.document
+    environment: window.parent.document,
+    containerRef
   });
 
   return (
@@ -45,10 +48,17 @@ const FocusJail = () => {
 `FocusJailContainer` is a render-prop wrapper for the `useFocusJail` hook.
 
 ```jsx static
+import { createRef } from 'react';
 import { FocusJailContainer } from '@zendeskgarden/container-focusjail';
 
-<FocusJailContainer focusOnMount={false} environment={window.parent.document}>
-  {({ getContainerProps, containerRef }) => (
+const containerRef = createRef(null);
+
+<FocusJailContainer
+  containerRef={containerRef}
+  focusOnMount={false}
+  environment={window.parent.document}
+>
+  {({ getContainerProps }) => (
     <>
       <input />
       <div {...getContainerProps({ ref: containerRef, tabIndex: -1 })}>

--- a/packages/focusjail/src/FocusJailContainer.js
+++ b/packages/focusjail/src/FocusJailContainer.js
@@ -17,5 +17,6 @@ FocusJailContainer.propTypes = {
   children: PropTypes.func,
   render: PropTypes.func,
   focusOnMount: PropTypes.bool,
-  environment: PropTypes.object
+  environment: PropTypes.object,
+  containerRef: PropTypes.object.isRequired
 };

--- a/packages/focusjail/stories.js
+++ b/packages/focusjail/stories.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { useRef, createRef } from 'react';
 
 import { storiesOf } from '@storybook/react';
 import { withKnobs, boolean } from '@storybook/addon-knobs';
@@ -16,8 +16,10 @@ storiesOf('FocusJail Container', module)
   .addDecorator(withKnobs)
   .add('useFocusJail', () => {
     const FocusJail = () => {
-      const { getContainerProps, containerRef } = useFocusJail({
-        focusOnMount: boolean('focusOnMount', true)
+      const containerRef = useRef(null);
+      const { getContainerProps } = useFocusJail({
+        focusOnMount: boolean('focusOnMount', true),
+        containerRef
       });
 
       return (
@@ -34,17 +36,21 @@ storiesOf('FocusJail Container', module)
 
     return <FocusJail />;
   })
-  .add('FocusJailContainer', () => (
-    <FocusJailContainer focusOnMount={boolean('focusOnMount', true)}>
-      {({ getContainerProps, containerRef }) => (
-        <>
-          <input />
-          <div {...getContainerProps({ ref: containerRef, tabIndex: -1 })}>
-            <p>Focus is locked within the parent element</p>
+  .add('FocusJailContainer', () => {
+    const containerRef = createRef(null);
+
+    return (
+      <FocusJailContainer containerRef={containerRef} focusOnMount={boolean('focusOnMount', true)}>
+        {({ getContainerProps }) => (
+          <>
             <input />
-            <button>Focusable Items</button>
-          </div>
-        </>
-      )}
-    </FocusJailContainer>
-  ));
+            <div {...getContainerProps({ ref: containerRef, tabIndex: -1 })}>
+              <p>Focus is locked within the parent element</p>
+              <input />
+              <button>Focusable Items</button>
+            </div>
+          </>
+        )}
+      </FocusJailContainer>
+    );
+  });


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

This changes two things one of them breaking:
- If you tried to do conditional rendering with this e.g. `{condition && <Component />}` the ref created internally wouldn't update and would not be able to focus the container element where focus should be trapped.
- Instead of creating a ref internally to better keep it more flexible a ref should always be passed in by the consumer.

## Detail

This [issue](https://github.com/thebuilder/react-intersection-observer/issues/162) best describes the problem I was facing that I only came across as I started on the `useModal` hook.

Essentially the passed in ref is stored in state and when it changes we update the state which will re-render with the correct ref.

```js
const [ref, setRef] = useState(containerRef.current);

useEffect(() => {
  if(containerRef.current !== ref) {
    setRef(containerRef.current);
  }
});
```

### Previous usage
```jsx
const FocusJail = () => {
  const { getContainerProps, containerRef } = useFocusJail();

  return <div {...getContainerProps({ref: containerRef}) />;
}
```

### New usage
```jsx
const FocusJail = () => {
  const containerRef = useRef(null);
  const { getContainerProps } = useFocusJail({containerRef});

  return <div {...getContainerProps({ref: containerRef}) />;
}
```

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn storybook`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
