### PR TITLE
fix(keyboardfocus): allow keyboard focus after mouse event

### DIFF
--- a/packages/keyboardfocus/src/KeyboardFocusContainer.spec.js
+++ b/packages/keyboardfocus/src/KeyboardFocusContainer.spec.js
@@ -42,6 +42,19 @@ describe('KeyboardFocusContainer', () => {
         findTrigger(wrapper).simulate('focus');
         expect(findTrigger(wrapper)).toHaveProp('data-focused', true);
       });
+
+      it('should apply focused prop if focused by keyboard after mouse event', () => {
+        const wrapper = mount(basicExample);
+
+        findTrigger(wrapper).simulate('mousedown');
+        jest.runOnlyPendingTimers();
+        wrapper.update();
+
+        expect(findTrigger(wrapper)).toHaveProp('data-focused', false);
+
+        findTrigger(wrapper).simulate('focus');
+        expect(findTrigger(wrapper)).toHaveProp('data-focused', true);
+      });
     });
 
     describe('onMouseDown', () => {

--- a/packages/keyboardfocus/src/useKeyboardFocus.js
+++ b/packages/keyboardfocus/src/useKeyboardFocus.js
@@ -54,8 +54,6 @@ export function useKeyboardFocus() {
     };
   };
 
-  console.log(keyboardFocused);
-
   return {
     getFocusProps,
     keyboardFocused

--- a/packages/keyboardfocus/src/useKeyboardFocus.js
+++ b/packages/keyboardfocus/src/useKeyboardFocus.js
@@ -5,20 +5,35 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 
 import { composeEventHandlers } from '@zendeskgarden/container-selection';
 
 export function useKeyboardFocus() {
   const [keyboardFocused, setKeyboardFocused] = useState(false);
-  let keyboardFocusable = true;
+  const focusableTimeoutRef = useRef(undefined);
+  const isKeyboardFocusableRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(focusableTimeoutRef.current);
+    };
+  }, []);
 
   const onPointerDown = () => {
-    keyboardFocusable = false;
+    isKeyboardFocusableRef.current = false;
+
+    /**
+     * This is necessary to recognize focus events caused by keyboard vs mouseDown.
+     * Due to event ordering this is always called before onFocus.
+     */
+    focusableTimeoutRef.current = setTimeout(() => {
+      isKeyboardFocusableRef.current = true;
+    }, 0);
   };
 
   const onFocus = () => {
-    if (keyboardFocusable) {
+    if (isKeyboardFocusableRef.current) {
       setKeyboardFocused(true);
     }
   };
@@ -38,6 +53,8 @@ export function useKeyboardFocus() {
       ...props
     };
   };
+
+  console.log(keyboardFocused);
 
   return {
     getFocusProps,


### PR DESCRIPTION
## Description

While trying to use the `useKeyboardFocus` hook in our new `react-forms` package I noticed some focus states missing.

With the current implementation items do not display focus when keyboarded to after a `mouseDown` event.

![2019-04-30 14-17-40 2019-04-30 14_17_57](https://user-images.githubusercontent.com/4030377/56994008-c51ccc80-6b52-11e9-9390-ccedeaa067b6.gif)

## Detail

I've corrected this issue with the `setTimeout` implementation that was originally in `react-selection`.  Even though this is a little "hacky" the hooks implementation seems to handle it correctly with `useRef` usage and some timeout cleanup in `useEffect`.

Also, there were some `jest.runOnlyPendingTimer()` calls in the tests already so maybe this was originally part of the implementation?

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn storybook`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
