### PR TITLE
fix(selection|buttongroup|pagination): Pass focusRef through as ref

### DIFF
--- a/packages/buttongroup/src/ButtonGroupContainer.spec.js
+++ b/packages/buttongroup/src/ButtonGroupContainer.spec.js
@@ -25,7 +25,6 @@ describe('ButtonGroupContainer', () => {
                 key: button,
                 item: button,
                 focusRef: buttonRefs[index],
-                ref: buttonRefs[index],
                 'data-test-id': 'button',
                 'data-selected': button === selectedKey,
                 'data-focused': button === focusedKey

--- a/packages/buttongroup/src/useButtonGroup.js
+++ b/packages/buttongroup/src/useButtonGroup.js
@@ -35,6 +35,6 @@ export function useButtonGroup(options) {
     selectedItem,
     focusedItem,
     getGroupProps: props => getContainerProps(getGroupProps(props)),
-    getButtonProps: props => getItemProps(getButtonProps(props))
+    getButtonProps: props => getItemProps(getButtonProps(props), 'getButtonProps')
   };
 }

--- a/packages/buttongroup/stories.js
+++ b/packages/buttongroup/stories.js
@@ -33,7 +33,6 @@ storiesOf('ButtonGroup Container', module)
                 key: button,
                 item: button,
                 focusRef: buttonRefs[index],
-                ref: buttonRefs[index],
                 style: {
                   boxShadow: button === focusedItem && 'inset 0 0 0 3px rgba(31,115,183, 0.35)',
                   outline: 'none',
@@ -62,7 +61,6 @@ storiesOf('ButtonGroup Container', module)
                 key: button,
                 item: button,
                 focusRef: buttonRefs[index],
-                ref: buttonRefs[index],
                 style: {
                   boxShadow: button === focusedItem && 'inset 0 0 0 3px rgba(31,115,183, 0.35)',
                   outline: 'none',

--- a/packages/pagination/src/PaginationContainer.spec.js
+++ b/packages/pagination/src/PaginationContainer.spec.js
@@ -37,7 +37,6 @@ describe('PaginationContainer', () => {
                 key: 'previous',
                 item: 'prev',
                 focusRef: previousPageRef,
-                ref: previousPageRef,
                 'data-focused': focusedItem === 'previous',
                 'data-selected': selectedItem === 'previous'
               })}
@@ -48,7 +47,6 @@ describe('PaginationContainer', () => {
                   key: page,
                   item: page,
                   focusRef: pageRefs[page - 1],
-                  ref: pageRefs[page - 1],
                   page,
                   current: page === selectedItem ? 'current' : undefined,
                   'data-test-id': 'page',
@@ -65,7 +63,6 @@ describe('PaginationContainer', () => {
                 key: 'next',
                 item: 'next',
                 focusRef: nextPageRef,
-                ref: nextPageRef,
                 'data-focused': focusedItem === 'next',
                 'data-selected': selectedItem === 'next'
               })}
@@ -154,13 +151,13 @@ describe('PaginationContainer', () => {
 
       it('if item prop is not provided', () => {
         expect(component({ focusRef: ref })).toThrow(
-          'Accessibility Error: You must provide an "item" option to "getItemProps()"'
+          'Accessibility Error: You must provide an "item" option to "getPreviousPageProps()"'
         );
       });
 
       it('if focusRef prop is not provided', () => {
         expect(component({ item: 1 })).toThrow(
-          'Accessibility Error: You must provide a "focusRef" option to "getItemProps()"'
+          'Accessibility Error: You must provide a "focusRef" option to "getPreviousPageProps()"'
         );
       });
     });
@@ -199,13 +196,13 @@ describe('PaginationContainer', () => {
 
       it('if item prop is not provided', () => {
         expect(component({ focusRef: ref })).toThrow(
-          'Accessibility Error: You must provide an "item" option to "getItemProps()"'
+          'Accessibility Error: You must provide an "item" option to "getNextPageProps()"'
         );
       });
 
       it('if focusRef prop is not provided', () => {
         expect(component({ item: 1 })).toThrow(
-          'Accessibility Error: You must provide a "focusRef" option to "getItemProps()"'
+          'Accessibility Error: You must provide a "focusRef" option to "getNextPageProps()"'
         );
       });
     });
@@ -244,13 +241,13 @@ describe('PaginationContainer', () => {
 
       it('if item prop is not provided', () => {
         expect(component({ focusRef: ref })).toThrow(
-          'Accessibility Error: You must provide an "item" option to "getItemProps()"'
+          'Accessibility Error: You must provide an "item" option to "getPageProps()"'
         );
       });
 
       it('if focusRef prop is not provided', () => {
         expect(component({ item: 1 })).toThrow(
-          'Accessibility Error: You must provide a "focusRef" option to "getItemProps()"'
+          'Accessibility Error: You must provide a "focusRef" option to "getPageProps()"'
         );
       });
     });

--- a/packages/pagination/src/usePagination.js
+++ b/packages/pagination/src/usePagination.js
@@ -55,8 +55,9 @@ export function usePagination(options) {
     selectedItem,
     focusedItem,
     getContainerProps: props => getControlledContainerProps(getContainerProps(props)),
-    getPageProps: props => getItemProps(getPageProps(props)),
-    getPreviousPageProps: props => getItemProps(getPreviousPageProps(props)),
-    getNextPageProps: props => getItemProps(getNextPageProps(props))
+    getPageProps: props => getItemProps(getPageProps(props), 'getPageProps'),
+    getPreviousPageProps: props =>
+      getItemProps(getPreviousPageProps(props), 'getPreviousPageProps'),
+    getNextPageProps: props => getItemProps(getNextPageProps(props), 'getNextPageProps')
   };
 }

--- a/packages/pagination/stories.js
+++ b/packages/pagination/stories.js
@@ -60,7 +60,6 @@ storiesOf('Pagination Container', module)
                 focused: focusedItem === 'prev',
                 item: 'prev',
                 focusRef: previousPageRef,
-                ref: previousPageRef,
                 key: 'previous-page'
               })}
             >
@@ -75,7 +74,6 @@ storiesOf('Pagination Container', module)
                     page: index,
                     item: index,
                     focusRef: pageRefs[index],
-                    ref: pageRefs[index],
                     key: `page-${index}`,
                     style: {
                       outline: index === focusedItem && '3px solid red',
@@ -94,7 +92,6 @@ storiesOf('Pagination Container', module)
                 focused: focusedItem === 'next',
                 item: 'next',
                 focusRef: nextPageRef,
-                ref: nextPageRef,
                 key: 'next-page'
               })}
             >

--- a/packages/selection/src/SelectionContainer.spec.js
+++ b/packages/selection/src/SelectionContainer.spec.js
@@ -34,7 +34,6 @@ describe('SelectionContainer', () => {
                     key: item,
                     item,
                     focusRef: ref,
-                    ref,
                     selectedAriaKey,
                     'data-test-id': 'item',
                     'data-focused': isFocused,

--- a/packages/selection/src/useSelection.js
+++ b/packages/selection/src/useSelection.js
@@ -166,23 +166,28 @@ export function useSelection({
     ...other
   });
 
-  const getItemProps = ({
-    selectedAriaKey = 'aria-selected',
-    role = 'option',
-    onFocus: onFocusCallback,
-    onKeyDown,
-    onClick,
-    item,
-    focusRef,
-    ...other
-  } = {}) => {
+  const getItemProps = (
+    {
+      selectedAriaKey = 'aria-selected',
+      role = 'option',
+      onFocus: onFocusCallback,
+      onKeyDown,
+      onClick,
+      item,
+      focusRef,
+      ...other
+    } = {},
+    propGetterName = 'getItemProps'
+  ) => {
     if (item === undefined) {
-      throw new Error('Accessibility Error: You must provide an "item" option to "getItemProps()"');
+      throw new Error(
+        `Accessibility Error: You must provide an "item" option to "${propGetterName}()"`
+      );
     }
 
     if (focusRef === undefined) {
       throw new Error(
-        'Accessibility Error: You must provide a "focusRef" option to "getItemProps()"'
+        `Accessibility Error: You must provide a "focusRef" option to "${propGetterName}()"`
       );
     }
 
@@ -207,6 +212,7 @@ export function useSelection({
       role,
       tabIndex,
       [selectedAriaKey]: isSelected,
+      ref: focusRef,
       onFocus: composeEventHandlers(onFocusCallback, () => {
         dispatch({ type: ACTIONS.FOCUS, payload: item, items });
       }),

--- a/packages/selection/src/useSelection.js
+++ b/packages/selection/src/useSelection.js
@@ -175,6 +175,7 @@ export function useSelection({
       onClick,
       item,
       focusRef,
+      refKey = 'ref',
       ...other
     } = {},
     propGetterName = 'getItemProps'
@@ -212,7 +213,7 @@ export function useSelection({
       role,
       tabIndex,
       [selectedAriaKey]: isSelected,
-      ref: focusRef,
+      [refKey]: focusRef,
       onFocus: composeEventHandlers(onFocusCallback, () => {
         dispatch({ type: ACTIONS.FOCUS, payload: item, items });
       }),

--- a/packages/selection/stories.js
+++ b/packages/selection/stories.js
@@ -44,7 +44,6 @@ storiesOf('Selection Containers', module)
                 {...getItemProps({
                   key: item,
                   item,
-                  ref: itemRef,
                   focusRef: itemRef
                 })}
                 style={{
@@ -98,7 +97,6 @@ storiesOf('Selection Containers', module)
                   {...getItemProps({
                     key: item,
                     item,
-                    ref,
                     focusRef: ref
                   })}
                 >


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

`useSelection` required a `focusRef` prop for the `getItemProps` prop getter but didn't pass it along as the elements actual `ref` requiring you to do `focusRef` and `ref` to make it work.

## Detail

A simple change to apply `focusRef` as the `ref` when the `getItemProps` is spread onto an element.

I also improved the errors we throw if you miss applying `item` or `focusRef` it'll now correctly display the right prop getter name.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn storybook`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
