### PR TITLE
chore(field|selection): remove utility re-exports

### DIFF
--- a/packages/field/src/index.js
+++ b/packages/field/src/index.js
@@ -10,6 +10,3 @@ export { useField } from './useField';
 
 /* Render-props */
 export { FieldContainer } from './FieldContainer';
-
-/* Utils */
-export { generateId, setIdCounter } from '@zendeskgarden/container-utilities';

--- a/packages/field/src/index.spec.js
+++ b/packages/field/src/index.spec.js
@@ -7,24 +7,10 @@
 
 import { getExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
-import { generateId, setIdCounter } from '@zendeskgarden/container-utilities';
 
 describe('Index', () => {
   it('exports all components and utilities', async () => {
-    const exports = await getExports({
-      cwd: __dirname,
-      fileMapper: files => {
-        return files
-          .map(entry =>
-            entry
-              .replace(/\.js$/u, '')
-              .split('/')
-              .pop()
-          )
-          .concat(Object.keys({ generateId, setIdCounter }))
-          .sort();
-      }
-    });
+    const exports = await getExports({ cwd: __dirname });
 
     expect(Object.keys(rootIndex).sort()).toEqual(exports);
   });

--- a/packages/selection/src/index.js
+++ b/packages/selection/src/index.js
@@ -10,6 +10,3 @@ export { useSelection } from './useSelection';
 
 /* Render-props */
 export { SelectionContainer } from './SelectionContainer';
-
-/* Utils */
-export { composeEventHandlers, KEY_CODES } from '@zendeskgarden/container-utilities';

--- a/packages/selection/src/index.spec.js
+++ b/packages/selection/src/index.spec.js
@@ -7,7 +7,6 @@
 
 import { getExports } from '@zendeskgarden/react-testing';
 import * as rootIndex from './';
-import { composeEventHandlers, KEY_CODES } from '@zendeskgarden/container-utilities';
 
 describe('Index', () => {
   it('exports all components and utilities', async () => {
@@ -22,7 +21,6 @@ describe('Index', () => {
               .pop()
           )
           .filter(file => !/ACTIONS|DIRECTIONS/u.test(file))
-          .concat(Object.keys({ composeEventHandlers, KEY_CODES }))
           .sort();
       }
     });


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

This is a breaking change for `field` and `selection` components that removes temporary re-exports of `@zendeskgarden/container-utilities` modules made in #30.

## Checklist

- [ ] :globe_with_meridians: ~Storybook demo is up-to-date (`yarn start`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
