### PR TITLE
docs(breadcrumbs): Remove garden styling from example

### DIFF
--- a/packages/breadcrumb/package.json
+++ b/packages/breadcrumb/package.json
@@ -21,7 +21,6 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },
-  "devDependencies": {},
   "keywords": [
     "a11y",
     "accessible",

--- a/packages/breadcrumb/package.json
+++ b/packages/breadcrumb/package.json
@@ -21,9 +21,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },
-  "devDependencies": {
-    "@zendeskgarden/css-breadcrumbs": "^0.2.2"
-  },
+  "devDependencies": {},
   "keywords": [
     "a11y",
     "accessible",

--- a/packages/breadcrumb/stories.js
+++ b/packages/breadcrumb/stories.js
@@ -12,8 +12,6 @@ import { withKnobs } from '@storybook/addon-knobs';
 
 import { BreadcrumbContainer, useBreadcrumb } from './src';
 
-import '@zendeskgarden/css-breadcrumbs';
-
 storiesOf('Breadcrumb Container', module)
   .addDecorator(withKnobs)
   .add('useBreadcrumb', () => {
@@ -21,13 +19,10 @@ storiesOf('Breadcrumb Container', module)
       const { getContainerProps, getCurrentPageProps } = useBreadcrumb();
 
       return (
-        <div {...getContainerProps({ className: 'c-breadcrumb' })}>
-          <a href="#foo" className="c-breadcrumb__item">
-            Home
-          </a>
-          <a {...getCurrentPageProps({ href: '#', className: 'c-breadcrumb__item is-current' })}>
-            Items
-          </a>
+        <div {...getContainerProps()}>
+          <a href="#foo">Home</a>
+          <span aria-hidden="true">&gt;</span>
+          <a {...getCurrentPageProps({ href: '#' })}>Items</a>
         </div>
       );
     };
@@ -37,13 +32,10 @@ storiesOf('Breadcrumb Container', module)
   .add('BreadcrumbContainer', () => (
     <BreadcrumbContainer>
       {({ getContainerProps, getCurrentPageProps }) => (
-        <div {...getContainerProps({ className: 'c-breadcrumb' })}>
-          <a href="#foo" className="c-breadcrumb__item">
-            Home
-          </a>
-          <a {...getCurrentPageProps({ href: '#foo', className: 'c-breadcrumb__item is-current' })}>
-            Items
-          </a>
+        <div {...getContainerProps()}>
+          <a href="#foo">Home</a>
+          <span aria-hidden="true">&gt;</span>
+          <a {...getCurrentPageProps({ href: '#foo' })}>Items</a>
         </div>
       )}
     </BreadcrumbContainer>


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Remove styling from breadcrumbs example

## Detail

Hooks are bare bones they shouldn't look like our high fidelity garden react components. 

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
