### PR TITLE
fix(selection): Add aria-orientation when direction is changed

### DIFF
--- a/packages/selection/src/SelectionContainer.spec.js
+++ b/packages/selection/src/SelectionContainer.spec.js
@@ -67,6 +67,19 @@ describe('SelectionContainer', () => {
       const container = findContainer(wrapper);
 
       expect(container).toHaveProp('role', 'listbox');
+      expect(container).toHaveProp('aria-orientation', 'horizontal');
+    });
+
+    describe('while using vertical direction', () => {
+      beforeEach(() => {
+        wrapper = mount(<BasicExample direction="vertical" />);
+      });
+
+      it('applies accessibility role', () => {
+        const container = findContainer(wrapper);
+
+        expect(container).toHaveProp('aria-orientation', 'vertical');
+      });
     });
 
     it('first item in container defaults as the only initial focusable item', () => {

--- a/packages/selection/src/useSelection.js
+++ b/packages/selection/src/useSelection.js
@@ -163,6 +163,7 @@ export function useSelection({
 
   const getContainerProps = ({ role = 'listbox', ...other } = {}) => ({
     role,
+    'aria-orientation': direction === DIRECTIONS.BOTH ? undefined : direction,
     ...other
   });
 


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

As defined in the [authoring practices](https://www.w3.org/TR/wai-aria-practices-1.1/#listbox_roles_states_props) a `listbox` should have `aria-orientation` applied based on the keyboard control directions.

## Detail

Tabs is the main use-case where you can have horizontal or vertical tabs once this is published I'll update #31 to have it.

This defaults to `horizontal` and will remove the attribute if the `both` direction is applied. Should we support `both` direction?

## Checklist

- [ ] :globe_with_meridians: ~Storybook demo is up-to-date (`yarn start`)~
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
