### PR TITLE
fix(selection): correctly update state if focus is in controlled mode

### DIFF
--- a/packages/selection/src/SelectionContainer.spec.js
+++ b/packages/selection/src/SelectionContainer.spec.js
@@ -23,7 +23,9 @@ describe('SelectionContainer', () => {
     defaultFocusedIndex,
     defaultSelectedIndex,
     selectedAriaKey,
-    rtl
+    rtl,
+    onFocus,
+    onSelect
   } = {}) => (
     /* eslint-enable react/prop-types */
     <SelectionContainer
@@ -31,6 +33,8 @@ describe('SelectionContainer', () => {
       defaultFocusedIndex={defaultFocusedIndex}
       defaultSelectedIndex={defaultSelectedIndex}
       rtl={rtl}
+      onFocus={onFocus ? onFocus : undefined}
+      onSelect={onSelect ? onSelect : undefined}
     >
       {({ getContainerProps, getItemProps, focusedItem, selectedItem }) => (
         <div {...getContainerProps({ 'data-test-id': 'container' })}>
@@ -72,6 +76,32 @@ describe('SelectionContainer', () => {
       </SelectionContainer>
     );
   };
+
+  describe('controlled state', () => {
+    describe('onFocus', () => {
+      it('should call onFocus callback', () => {
+        const onFocusSpy = jest.fn();
+        const { getAllByTestId } = render(<BasicExample onFocus={onFocusSpy} />);
+        const [item] = getAllByTestId('item');
+
+        fireEvent.focus(item);
+
+        expect(onFocusSpy).toHaveBeenCalledWith(itemValues[0]);
+      });
+    });
+
+    describe('onSelect', () => {
+      it('should call onSelect callback', () => {
+        const onSelectSpy = jest.fn();
+        const { getAllByTestId } = render(<BasicExample onSelect={onSelectSpy} />);
+        const [item] = getAllByTestId('item');
+
+        fireEvent.click(item);
+
+        expect(onSelectSpy).toHaveBeenCalledWith(itemValues[0]);
+      });
+    });
+  });
 
   describe('getContainerProps', () => {
     it('applies accessibility role', () => {

--- a/packages/selection/src/useSelection.js
+++ b/packages/selection/src/useSelection.js
@@ -28,7 +28,7 @@ function stateReducer(state, action, { focusedItem, selectedItem, onFocus, onSel
       if (onFocus) {
         onFocus(action.payload);
 
-        return state;
+        return { ...state };
       }
 
       return { ...state, focusedItem: action.payload };
@@ -39,7 +39,7 @@ function stateReducer(state, action, { focusedItem, selectedItem, onFocus, onSel
       if (onFocus) {
         onFocus(newFocusedItem);
 
-        return state;
+        return { ...state };
       }
 
       return { ...state, focusedItem: newFocusedItem };
@@ -51,7 +51,7 @@ function stateReducer(state, action, { focusedItem, selectedItem, onFocus, onSel
       if (onFocus) {
         onFocus(newFocusedItem);
 
-        return state;
+        return { ...state };
       }
 
       return { ...state, focusedItem: newFocusedItem };
@@ -60,7 +60,7 @@ function stateReducer(state, action, { focusedItem, selectedItem, onFocus, onSel
       if (onFocus) {
         onFocus(action.items[0]);
 
-        return state;
+        return { ...state };
       }
 
       return { ...state, focusedItem: action.items[0] };
@@ -69,7 +69,7 @@ function stateReducer(state, action, { focusedItem, selectedItem, onFocus, onSel
       if (onFocus) {
         onFocus(action.items[action.items.length - 1]);
 
-        return state;
+        return { ...state };
       }
 
       return { ...state, focusedItem: action.items[action.items.length - 1] };
@@ -89,7 +89,7 @@ function stateReducer(state, action, { focusedItem, selectedItem, onFocus, onSel
       }
 
       if (isFocusControlled && isSelectControlled) {
-        return state;
+        return { ...state };
       }
 
       const updatedState = { ...state };


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

If you supplied `onFocus` and correctly managed the state externally the passed in `focusedItem` prop wouldn't actually update the internal reducer.

## Detail

This was the same issue as #22 with selecting an item and the state not updating correctly.

## Checklist

- [ ] :globe_with_meridians: ~Storybook demo is up-to-date (`yarn start`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
