### PR TITLE
feat(schedule): Add state to determine when delay timeout is complete

### DIFF
--- a/packages/schedule/src/useSchedule.js
+++ b/packages/schedule/src/useSchedule.js
@@ -9,6 +9,7 @@ import { useState, useLayoutEffect } from 'react';
 
 export default function useSchedule({ duration = 1250, delayMS = 750, loop = true } = {}) {
   const [elapsed, setTime] = useState(0);
+  const [delayComplete, setDelayComplete] = useState(false);
 
   useLayoutEffect(() => {
     let raf;
@@ -34,6 +35,7 @@ export default function useSchedule({ duration = 1250, delayMS = 750, loop = tru
 
       // Start the loop
       start = Date.now();
+      setDelayComplete(true);
       tick();
     };
 
@@ -46,5 +48,9 @@ export default function useSchedule({ duration = 1250, delayMS = 750, loop = tru
     };
   }, [duration, delayMS, loop]);
 
-  return Math.min(1, elapsed / duration);
+  return {
+    elapsed: Math.min(1, elapsed / duration),
+    delayMS,
+    delayComplete
+  };
 }

--- a/packages/schedule/stories.js
+++ b/packages/schedule/stories.js
@@ -19,7 +19,11 @@ storiesOf('Schedule Container', module)
       const duration = number('duration', 1250);
       const loop = boolean('loop', true);
       const delayMS = number('delayMS', 750);
-      const elapsed = useSchedule({ duration, loop, delayMS });
+      const { elapsed, delayComplete } = useSchedule({ duration, loop, delayMS });
+
+      if (!delayComplete && delayMS !== 0) {
+        return <div>Delay...</div>;
+      }
 
       return (
         <div>
@@ -37,11 +41,17 @@ storiesOf('Schedule Container', module)
       loop={boolean('loop', true)}
       delayMS={number('delayMS', 750)}
     >
-      {elapsed => (
-        <div>
-          Percentage: {(elapsed * 100).toFixed(0)}%<br />
-          Elapsed: {elapsed}
-        </div>
-      )}
+      {({ elapsed, delayMS, delayComplete }) => {
+        if (!delayComplete && delayMS !== 0) {
+          return <div>Delay...</div>;
+        }
+
+        return (
+          <div>
+            Percentage: {(elapsed * 100).toFixed(0)}%<br />
+            Elapsed: {elapsed}
+          </div>
+        );
+      }}
     </ScheduleContainer>
   ));


### PR DESCRIPTION
- [x] **BREAKING CHANGE?**

## Description

In order to support the use case where you want to render something differently based on the delayTimeout we need to expose the state in the hook so a consumer can do that.

## Detail

This is a breaking change because the hook now returns an object with multiple properties rather than the elapsed time.

### Old
```js
const elapsed = useSchedule();
```

### New
```js
const { elapsed, delayMS, delayComplete } = useSchedule();
```

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
