### PR TITLE
chore: Add data-garden-container-* attributes

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -5,12 +5,20 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+const webpack = require('webpack');
+
 module.exports = ({ config }) => {
   config.module.rules.push({
     test: /stories.js$/u,
     loaders: [require.resolve('@storybook/addon-storysource/loader')],
     enforce: 'pre'
   });
+
+  config.plugins.push(
+    new webpack.DefinePlugin({
+      PACKAGE_VERSION: JSON.stringify('storybook')
+    })
+  );
 
   return config;
 };

--- a/packages/accordion/src/useAccordion.js
+++ b/packages/accordion/src/useAccordion.js
@@ -8,19 +8,6 @@
 import { useState } from 'react';
 import { composeEventHandlers, generateId, KEY_CODES } from '@zendeskgarden/container-utilities';
 
-const HOOK_ID = 'accordion';
-let PKG_VERSION;
-
-if (process.env.NODE_ENV === 'development') {
-  // In the prod build this is handled in the webpack build
-  // storybook doesn't run each packages build so we need to get the
-  // version here
-  // eslint-disable-next-line global-require
-  const packageManifest = require('../package.json');
-
-  PKG_VERSION = packageManifest.version;
-}
-
 export function useAccordion({
   idPrefix,
   expandedSections = [],
@@ -69,8 +56,8 @@ export function useAccordion({
     return {
       role,
       'aria-level': ariaLevel,
-      'data-garden-container-id': HOOK_ID,
-      'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
+      'data-garden-container-id': 'accordion',
+      'data-garden-container-version': PACKAGE_VERSION,
       ...props
     };
   };

--- a/packages/accordion/src/useAccordion.js
+++ b/packages/accordion/src/useAccordion.js
@@ -8,6 +8,19 @@
 import { useState } from 'react';
 import { composeEventHandlers, generateId, KEY_CODES } from '@zendeskgarden/container-utilities';
 
+const HOOK_ID = 'accordion';
+let PKG_VERSION;
+
+if (process.env.NODE_ENV === 'development') {
+  // In the prod build this is handled in the webpack build
+  // storybook doesn't run each packages build so we need to get the
+  // version here
+  // eslint-disable-next-line global-require
+  const packageManifest = require('../package.json');
+
+  PKG_VERSION = packageManifest.version;
+}
+
 export function useAccordion({
   idPrefix,
   expandedSections = [],
@@ -56,6 +69,8 @@ export function useAccordion({
     return {
       role,
       'aria-level': ariaLevel,
+      'data-garden-container-id': HOOK_ID,
+      'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
       ...props
     };
   };

--- a/packages/breadcrumb/src/useBreadcrumb.js
+++ b/packages/breadcrumb/src/useBreadcrumb.js
@@ -5,11 +5,26 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+const HOOK_ID = 'breadcrumb';
+let PKG_VERSION;
+
+if (process.env.NODE_ENV === 'development') {
+  // In the prod build this is handled in the webpack build
+  // storybook doesn't run each packages build so we need to get the
+  // version here
+  // eslint-disable-next-line global-require
+  const packageManifest = require('../package.json');
+
+  PKG_VERSION = packageManifest.version;
+}
+
 export default function useBreadcrumb() {
   const getContainerProps = ({ role = 'navigation', ...other } = {}) => {
     return {
       role,
       'aria-label': 'Breadcrumb navigation',
+      'data-garden-container-id': HOOK_ID,
+      'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
       ...other
     };
   };

--- a/packages/breadcrumb/src/useBreadcrumb.js
+++ b/packages/breadcrumb/src/useBreadcrumb.js
@@ -5,26 +5,13 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-const HOOK_ID = 'breadcrumb';
-let PKG_VERSION;
-
-if (process.env.NODE_ENV === 'development') {
-  // In the prod build this is handled in the webpack build
-  // storybook doesn't run each packages build so we need to get the
-  // version here
-  // eslint-disable-next-line global-require
-  const packageManifest = require('../package.json');
-
-  PKG_VERSION = packageManifest.version;
-}
-
 export default function useBreadcrumb() {
   const getContainerProps = ({ role = 'navigation', ...other } = {}) => {
     return {
       role,
       'aria-label': 'Breadcrumb navigation',
-      'data-garden-container-id': HOOK_ID,
-      'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
+      'data-garden-container-id': 'breadcrumb',
+      'data-garden-container-version': PACKAGE_VERSION,
       ...other
     };
   };

--- a/packages/buttongroup/src/useButtonGroup.js
+++ b/packages/buttongroup/src/useButtonGroup.js
@@ -7,27 +7,14 @@
 
 import { useSelection } from '@zendeskgarden/container-selection';
 
-const HOOK_ID = 'buttongroup';
-let PKG_VERSION;
-
-if (process.env.NODE_ENV === 'development') {
-  // In the prod build this is handled in the webpack build
-  // storybook doesn't run each packages build so we need to get the
-  // version here
-  // eslint-disable-next-line global-require
-  const packageManifest = require('../package.json');
-
-  PKG_VERSION = packageManifest.version;
-}
-
 export function useButtonGroup(options) {
   const { selectedItem, focusedItem, getContainerProps, getItemProps } = useSelection(options);
 
   const getGroupProps = ({ role = 'group', ...other } = {}) => {
     return {
       role,
-      'data-garden-container-id': HOOK_ID,
-      'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
+      'data-garden-container-id': 'buttongroup',
+      'data-garden-container-version': PACKAGE_VERSION,
       ...other
     };
   };

--- a/packages/buttongroup/src/useButtonGroup.js
+++ b/packages/buttongroup/src/useButtonGroup.js
@@ -7,12 +7,27 @@
 
 import { useSelection } from '@zendeskgarden/container-selection';
 
+const HOOK_ID = 'buttongroup';
+let PKG_VERSION;
+
+if (process.env.NODE_ENV === 'development') {
+  // In the prod build this is handled in the webpack build
+  // storybook doesn't run each packages build so we need to get the
+  // version here
+  // eslint-disable-next-line global-require
+  const packageManifest = require('../package.json');
+
+  PKG_VERSION = packageManifest.version;
+}
+
 export function useButtonGroup(options) {
   const { selectedItem, focusedItem, getContainerProps, getItemProps } = useSelection(options);
 
   const getGroupProps = ({ role = 'group', ...other } = {}) => {
     return {
       role,
+      'data-garden-container-id': HOOK_ID,
+      'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
       ...other
     };
   };

--- a/packages/field/src/useField.js
+++ b/packages/field/src/useField.js
@@ -8,6 +8,19 @@
 import { useState } from 'react';
 import { generateId } from '@zendeskgarden/container-utilities';
 
+const HOOK_ID = 'field';
+let PKG_VERSION;
+
+if (process.env.NODE_ENV === 'development') {
+  // In the prod build this is handled in the webpack build
+  // storybook doesn't run each packages build so we need to get the
+  // version here
+  // eslint-disable-next-line global-require
+  const packageManifest = require('../package.json');
+
+  PKG_VERSION = packageManifest.version;
+}
+
 export function useField(idPrefix) {
   const [prefix] = useState(idPrefix || generateId('garden-field-container'));
   const inputId = `${prefix}--input`;
@@ -18,6 +31,8 @@ export function useField(idPrefix) {
     return {
       id,
       htmlFor,
+      'data-garden-container-id': HOOK_ID,
+      'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
       ...other
     };
   };

--- a/packages/field/src/useField.js
+++ b/packages/field/src/useField.js
@@ -8,19 +8,6 @@
 import { useState } from 'react';
 import { generateId } from '@zendeskgarden/container-utilities';
 
-const HOOK_ID = 'field';
-let PKG_VERSION;
-
-if (process.env.NODE_ENV === 'development') {
-  // In the prod build this is handled in the webpack build
-  // storybook doesn't run each packages build so we need to get the
-  // version here
-  // eslint-disable-next-line global-require
-  const packageManifest = require('../package.json');
-
-  PKG_VERSION = packageManifest.version;
-}
-
 export function useField(idPrefix) {
   const [prefix] = useState(idPrefix || generateId('garden-field-container'));
   const inputId = `${prefix}--input`;
@@ -31,8 +18,8 @@ export function useField(idPrefix) {
     return {
       id,
       htmlFor,
-      'data-garden-container-id': HOOK_ID,
-      'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
+      'data-garden-container-id': 'field',
+      'data-garden-container-version': PACKAGE_VERSION,
       ...other
     };
   };

--- a/packages/focusjail/src/useFocusJail.js
+++ b/packages/focusjail/src/useFocusJail.js
@@ -10,6 +10,19 @@ import { composeEventHandlers, KEY_CODES } from '@zendeskgarden/container-utilit
 import tabbable from 'tabbable';
 import activeElement from 'dom-helpers/activeElement';
 
+const HOOK_ID = 'focusjail';
+let PKG_VERSION;
+
+if (process.env.NODE_ENV === 'development') {
+  // In the prod build this is handled in the webpack build
+  // storybook doesn't run each packages build so we need to get the
+  // version here
+  // eslint-disable-next-line global-require
+  const packageManifest = require('../package.json');
+
+  PKG_VERSION = packageManifest.version;
+}
+
 export function useFocusJail({ focusOnMount = true, environment, focusElem, containerRef } = {}) {
   // To support conditional rendering we need to store the ref in state and
   // trigger a re-render if the ref updates once rendered since react will
@@ -67,7 +80,6 @@ export function useFocusJail({ focusOnMount = true, environment, focusElem, cont
         if (event.keyCode !== KEY_CODES.TAB) {
           return;
         }
-
         validateContainerRef();
 
         const tabbableNodes = getTabbableNodes();
@@ -85,6 +97,8 @@ export function useFocusJail({ focusOnMount = true, environment, focusElem, cont
           event.preventDefault();
         }
       }),
+      'data-garden-container-id': HOOK_ID,
+      'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
       ...other
     };
   };

--- a/packages/focusjail/src/useFocusJail.js
+++ b/packages/focusjail/src/useFocusJail.js
@@ -10,19 +10,6 @@ import { composeEventHandlers, KEY_CODES } from '@zendeskgarden/container-utilit
 import tabbable from 'tabbable';
 import activeElement from 'dom-helpers/activeElement';
 
-const HOOK_ID = 'focusjail';
-let PKG_VERSION;
-
-if (process.env.NODE_ENV === 'development') {
-  // In the prod build this is handled in the webpack build
-  // storybook doesn't run each packages build so we need to get the
-  // version here
-  // eslint-disable-next-line global-require
-  const packageManifest = require('../package.json');
-
-  PKG_VERSION = packageManifest.version;
-}
-
 export function useFocusJail({ focusOnMount = true, environment, focusElem, containerRef } = {}) {
   // To support conditional rendering we need to store the ref in state and
   // trigger a re-render if the ref updates once rendered since react will
@@ -97,8 +84,8 @@ export function useFocusJail({ focusOnMount = true, environment, focusElem, cont
           event.preventDefault();
         }
       }),
-      'data-garden-container-id': HOOK_ID,
-      'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
+      'data-garden-container-id': 'focusjail',
+      'data-garden-container-version': PACKAGE_VERSION,
       ...other
     };
   };

--- a/packages/keyboardfocus/src/useKeyboardFocus.js
+++ b/packages/keyboardfocus/src/useKeyboardFocus.js
@@ -9,19 +9,6 @@ import { useState, useRef, useEffect } from 'react';
 
 import { composeEventHandlers } from '@zendeskgarden/container-utilities';
 
-const HOOK_ID = 'keyboardfocus';
-let PKG_VERSION;
-
-if (process.env.NODE_ENV === 'development') {
-  // In the prod build this is handled in the webpack build
-  // storybook doesn't run each packages build so we need to get the
-  // version here
-  // eslint-disable-next-line global-require
-  const packageManifest = require('../package.json');
-
-  PKG_VERSION = packageManifest.version;
-}
-
 export function useKeyboardFocus() {
   const [keyboardFocused, setKeyboardFocused] = useState(false);
   const focusableTimeoutRef = useRef(undefined);
@@ -63,8 +50,8 @@ export function useKeyboardFocus() {
       onMouseDown: composeEventHandlers(props.onMouseDown, onPointerDown),
       onPointerDown: composeEventHandlers(props.onPointerDown, onPointerDown),
       onTouchStart: composeEventHandlers(props.onTouchStart, onPointerDown),
-      'data-garden-container-id': HOOK_ID,
-      'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
+      'data-garden-container-id': 'keyboardfocus',
+      'data-garden-container-version': PACKAGE_VERSION,
       ...props
     };
   };

--- a/packages/keyboardfocus/src/useKeyboardFocus.js
+++ b/packages/keyboardfocus/src/useKeyboardFocus.js
@@ -9,6 +9,19 @@ import { useState, useRef, useEffect } from 'react';
 
 import { composeEventHandlers } from '@zendeskgarden/container-utilities';
 
+const HOOK_ID = 'keyboardfocus';
+let PKG_VERSION;
+
+if (process.env.NODE_ENV === 'development') {
+  // In the prod build this is handled in the webpack build
+  // storybook doesn't run each packages build so we need to get the
+  // version here
+  // eslint-disable-next-line global-require
+  const packageManifest = require('../package.json');
+
+  PKG_VERSION = packageManifest.version;
+}
+
 export function useKeyboardFocus() {
   const [keyboardFocused, setKeyboardFocused] = useState(false);
   const focusableTimeoutRef = useRef(undefined);
@@ -50,6 +63,8 @@ export function useKeyboardFocus() {
       onMouseDown: composeEventHandlers(props.onMouseDown, onPointerDown),
       onPointerDown: composeEventHandlers(props.onPointerDown, onPointerDown),
       onTouchStart: composeEventHandlers(props.onTouchStart, onPointerDown),
+      'data-garden-container-id': HOOK_ID,
+      'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
       ...props
     };
   };

--- a/packages/modal/src/useModal.js
+++ b/packages/modal/src/useModal.js
@@ -9,6 +9,19 @@ import { useState } from 'react';
 import { composeEventHandlers, generateId, KEY_CODES } from '@zendeskgarden/container-utilities';
 import { useFocusJail } from '@zendeskgarden/container-focusjail';
 
+const HOOK_ID = 'modal';
+let PKG_VERSION;
+
+if (process.env.NODE_ENV === 'development') {
+  // In the prod build this is handled in the webpack build
+  // storybook doesn't run each packages build so we need to get the
+  // version here
+  // eslint-disable-next-line global-require
+  const packageManifest = require('../package.json');
+
+  PKG_VERSION = packageManifest.version;
+}
+
 export function useModal({ onClose, modalRef, id: _id } = {}) {
   const [idPrefix] = useState(_id || generateId('garden-modal-container'));
   const titleId = `${idPrefix}--title`;
@@ -23,6 +36,8 @@ export function useModal({ onClose, modalRef, id: _id } = {}) {
       onClick: composeEventHandlers(onClick, event => {
         closeModal(event);
       }),
+      'data-garden-container-id': HOOK_ID,
+      'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
       ...other
     };
   };

--- a/packages/modal/src/useModal.js
+++ b/packages/modal/src/useModal.js
@@ -9,19 +9,6 @@ import { useState } from 'react';
 import { composeEventHandlers, generateId, KEY_CODES } from '@zendeskgarden/container-utilities';
 import { useFocusJail } from '@zendeskgarden/container-focusjail';
 
-const HOOK_ID = 'modal';
-let PKG_VERSION;
-
-if (process.env.NODE_ENV === 'development') {
-  // In the prod build this is handled in the webpack build
-  // storybook doesn't run each packages build so we need to get the
-  // version here
-  // eslint-disable-next-line global-require
-  const packageManifest = require('../package.json');
-
-  PKG_VERSION = packageManifest.version;
-}
-
 export function useModal({ onClose, modalRef, id: _id } = {}) {
   const [idPrefix] = useState(_id || generateId('garden-modal-container'));
   const titleId = `${idPrefix}--title`;
@@ -36,8 +23,8 @@ export function useModal({ onClose, modalRef, id: _id } = {}) {
       onClick: composeEventHandlers(onClick, event => {
         closeModal(event);
       }),
-      'data-garden-container-id': HOOK_ID,
-      'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
+      'data-garden-container-id': 'modal',
+      'data-garden-container-version': PACKAGE_VERSION,
       ...other
     };
   };

--- a/packages/pagination/src/usePagination.js
+++ b/packages/pagination/src/usePagination.js
@@ -7,6 +7,19 @@
 
 import { useSelection } from '@zendeskgarden/container-selection';
 
+const HOOK_ID = 'pagination';
+let PKG_VERSION;
+
+if (process.env.NODE_ENV === 'development') {
+  // In the prod build this is handled in the webpack build
+  // storybook doesn't run each packages build so we need to get the
+  // version here
+  // eslint-disable-next-line global-require
+  const packageManifest = require('../package.json');
+
+  PKG_VERSION = packageManifest.version;
+}
+
 export function usePagination(options) {
   const {
     selectedItem,
@@ -19,6 +32,8 @@ export function usePagination(options) {
     return {
       role,
       'aria-label': ariaLabel || 'Pagination navigation',
+      'data-garden-container-id': HOOK_ID,
+      'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
       ...props
     };
   };

--- a/packages/pagination/src/usePagination.js
+++ b/packages/pagination/src/usePagination.js
@@ -7,19 +7,6 @@
 
 import { useSelection } from '@zendeskgarden/container-selection';
 
-const HOOK_ID = 'pagination';
-let PKG_VERSION;
-
-if (process.env.NODE_ENV === 'development') {
-  // In the prod build this is handled in the webpack build
-  // storybook doesn't run each packages build so we need to get the
-  // version here
-  // eslint-disable-next-line global-require
-  const packageManifest = require('../package.json');
-
-  PKG_VERSION = packageManifest.version;
-}
-
 export function usePagination(options) {
   const {
     selectedItem,
@@ -32,8 +19,8 @@ export function usePagination(options) {
     return {
       role,
       'aria-label': ariaLabel || 'Pagination navigation',
-      'data-garden-container-id': HOOK_ID,
-      'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
+      'data-garden-container-id': 'pagination',
+      'data-garden-container-version': PACKAGE_VERSION,
       ...props
     };
   };

--- a/packages/selection/src/useSelection.js
+++ b/packages/selection/src/useSelection.js
@@ -15,6 +15,19 @@ import {
 import { DIRECTIONS } from './utils/DIRECTIONS';
 import { ACTIONS } from './utils/ACTIONS';
 
+const HOOK_ID = 'selection';
+let PKG_VERSION;
+
+if (process.env.NODE_ENV === 'development') {
+  // In the prod build this is handled in the webpack build
+  // storybook doesn't run each packages build so we need to get the
+  // version here
+  // eslint-disable-next-line global-require
+  const packageManifest = require('../package.json');
+
+  PKG_VERSION = packageManifest.version;
+}
+
 function stateReducer(state, action, { focusedItem, selectedItem, onFocus, onSelect }) {
   const controlledFocusedItem = getControlledValue(focusedItem, state.focusedItem);
   const controlledSelectedItem = getControlledValue(selectedItem, state.selectedItem);
@@ -175,6 +188,8 @@ export function useSelection({
   const getContainerProps = ({ role = 'listbox', ...other } = {}) => ({
     role,
     'aria-orientation': direction === DIRECTIONS.BOTH ? undefined : direction,
+    'data-garden-container-id': HOOK_ID,
+    'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
     ...other
   });
 

--- a/packages/selection/src/useSelection.js
+++ b/packages/selection/src/useSelection.js
@@ -15,19 +15,6 @@ import {
 import { DIRECTIONS } from './utils/DIRECTIONS';
 import { ACTIONS } from './utils/ACTIONS';
 
-const HOOK_ID = 'selection';
-let PKG_VERSION;
-
-if (process.env.NODE_ENV === 'development') {
-  // In the prod build this is handled in the webpack build
-  // storybook doesn't run each packages build so we need to get the
-  // version here
-  // eslint-disable-next-line global-require
-  const packageManifest = require('../package.json');
-
-  PKG_VERSION = packageManifest.version;
-}
-
 function stateReducer(state, action, { focusedItem, selectedItem, onFocus, onSelect }) {
   const controlledFocusedItem = getControlledValue(focusedItem, state.focusedItem);
   const controlledSelectedItem = getControlledValue(selectedItem, state.selectedItem);
@@ -188,8 +175,8 @@ export function useSelection({
   const getContainerProps = ({ role = 'listbox', ...other } = {}) => ({
     role,
     'aria-orientation': direction === DIRECTIONS.BOTH ? undefined : direction,
-    'data-garden-container-id': HOOK_ID,
-    'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
+    'data-garden-container-id': 'selection',
+    'data-garden-container-version': PACKAGE_VERSION,
     ...other
   });
 

--- a/packages/tabs/src/useTabs.js
+++ b/packages/tabs/src/useTabs.js
@@ -17,19 +17,6 @@ function requiredArguments(arg, argStr, methodName) {
   }
 }
 
-const HOOK_ID = 'tabs';
-let PKG_VERSION;
-
-if (process.env.NODE_ENV === 'development') {
-  // In the prod build this is handled in the webpack build
-  // storybook doesn't run each packages build so we need to get the
-  // version here
-  // eslint-disable-next-line global-require
-  const packageManifest = require('../package.json');
-
-  PKG_VERSION = packageManifest.version;
-}
-
 export function useTabs({ vertical, idPrefix, ...options } = {}) {
   const { selectedItem, focusedItem, getContainerProps, getItemProps } = useSelection({
     direction: vertical ? 'vertical' : 'horizontal',
@@ -43,8 +30,8 @@ export function useTabs({ vertical, idPrefix, ...options } = {}) {
   const getTabListProps = ({ role = 'tablist', ...other } = {}) => {
     return {
       role,
-      'data-garden-container-id': HOOK_ID,
-      'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
+      'data-garden-container-id': 'tabs',
+      'data-garden-container-version': PACKAGE_VERSION,
       ...other
     };
   };

--- a/packages/tabs/src/useTabs.js
+++ b/packages/tabs/src/useTabs.js
@@ -17,6 +17,19 @@ function requiredArguments(arg, argStr, methodName) {
   }
 }
 
+const HOOK_ID = 'tabs';
+let PKG_VERSION;
+
+if (process.env.NODE_ENV === 'development') {
+  // In the prod build this is handled in the webpack build
+  // storybook doesn't run each packages build so we need to get the
+  // version here
+  // eslint-disable-next-line global-require
+  const packageManifest = require('../package.json');
+
+  PKG_VERSION = packageManifest.version;
+}
+
 export function useTabs({ vertical, idPrefix, ...options } = {}) {
   const { selectedItem, focusedItem, getContainerProps, getItemProps } = useSelection({
     direction: vertical ? 'vertical' : 'horizontal',
@@ -30,6 +43,8 @@ export function useTabs({ vertical, idPrefix, ...options } = {}) {
   const getTabListProps = ({ role = 'tablist', ...other } = {}) => {
     return {
       role,
+      'data-garden-container-id': HOOK_ID,
+      'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
       ...other
     };
   };

--- a/packages/tooltip/src/useTooltip.js
+++ b/packages/tooltip/src/useTooltip.js
@@ -8,6 +8,19 @@
 import { useState, useEffect } from 'react';
 import { composeEventHandlers, generateId, KEY_CODES } from '@zendeskgarden/container-utilities';
 
+const HOOK_ID = 'tooltip';
+let PKG_VERSION;
+
+if (process.env.NODE_ENV === 'development') {
+  // In the prod build this is handled in the webpack build
+  // storybook doesn't run each packages build so we need to get the
+  // version here
+  // eslint-disable-next-line global-require
+  const packageManifest = require('../package.json');
+
+  PKG_VERSION = packageManifest.version;
+}
+
 export function useTooltip({ tooltipRef, delayMilliseconds = 500, id, isVisible } = {}) {
   const [visibility, setVisibility] = useState(isVisible);
   const [_id] = useState(id || generateId('garden-tooltip-container'));
@@ -65,6 +78,8 @@ export function useTooltip({ tooltipRef, delayMilliseconds = 500, id, isVisible 
         }
       }),
       'aria-describedby': _id,
+      'data-garden-container-id': HOOK_ID,
+      'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
       ...other
     };
   };

--- a/packages/tooltip/src/useTooltip.js
+++ b/packages/tooltip/src/useTooltip.js
@@ -8,19 +8,6 @@
 import { useState, useEffect } from 'react';
 import { composeEventHandlers, generateId, KEY_CODES } from '@zendeskgarden/container-utilities';
 
-const HOOK_ID = 'tooltip';
-let PKG_VERSION;
-
-if (process.env.NODE_ENV === 'development') {
-  // In the prod build this is handled in the webpack build
-  // storybook doesn't run each packages build so we need to get the
-  // version here
-  // eslint-disable-next-line global-require
-  const packageManifest = require('../package.json');
-
-  PKG_VERSION = packageManifest.version;
-}
-
 export function useTooltip({ tooltipRef, delayMilliseconds = 500, id, isVisible } = {}) {
   const [visibility, setVisibility] = useState(isVisible);
   const [_id] = useState(id || generateId('garden-tooltip-container'));
@@ -78,8 +65,8 @@ export function useTooltip({ tooltipRef, delayMilliseconds = 500, id, isVisible 
         }
       }),
       'aria-describedby': _id,
-      'data-garden-container-id': HOOK_ID,
-      'data-garden-container-version': PKG_VERSION || PACKAGE_VERSION,
+      'data-garden-container-id': 'tooltip',
+      'data-garden-container-version': PACKAGE_VERSION,
       ...other
     };
   };

--- a/utils/build/webpack.commonjs.js
+++ b/utils/build/webpack.commonjs.js
@@ -23,7 +23,7 @@ const options = {
   devtool: 'source-map',
   plugins: [
     /**
-     * Allows the `data-garden-version` attribute to be applied to all
+     * Allows the `data-garden-container-version` attribute to be applied to all
      * views without importing entire package.json into the bundle
      */
     new webpack.DefinePlugin({


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Adds some data-attributes `data-garden-container-id` and `data-garden-container-version` to each hook except for container-schedule since it doesn't render any UI or return any prop getters.

## Detail

I have added some code that is stripped in prod builds so the ids and version show up in dev builds when testing.

## Checklist

- [ ] :globe_with_meridians: ~Storybook demo is up-to-date (`yarn start`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
