### PR TITLE
fix: lint-staged upgrade broke due to config changes

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,19 +1,16 @@
 {
-  "linters": {
-    "*.js": [
-      "eslint",
-      "prettier --write",
-      "git add"
-    ],
-    "*.md": [
-      "markdownlint",
-      "prettier --write",
-      "git add"
-    ],
-    "**/package.json": [
-      "prettier-package-json --write",
-      "git add"
-    ]
-  },
-  "ignore": ["**/CHANGELOG.md"]
+  "*.js": [
+    "eslint",
+    "prettier --write",
+    "git add"
+  ],
+  "!(*CHANGELOG).md": [
+    "markdownlint",
+    "prettier --write",
+    "git add"
+  ],
+  "**/package.json": [
+    "prettier-package-json --write",
+    "git add"
+  ]
 }


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Recently pushed a major version upgrade of lint-staged which came with some breaking config changes.

## Detail

Updated config to match new changes.

## Checklist

- [ ] :globe_with_meridians: ~Storybook demo is up-to-date (`yarn start`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
