### PR TITLE
fix(tooltip): don't pass in a ref as it's not actually needed

### DIFF
--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -16,14 +16,10 @@ For live examples check out our [storybook](https://zendeskgarden.github.io/reac
 ### useTooltip
 
 ```jsx static
-import { useRef } from 'react';
 import { useTooltip } from '@zendeskgarden/container-tooltip';
 
 const Tooltip = () => {
-  const tooltipRef = useRef(null);
-
   const { isVisible, getTooltipProps, getTriggerProps } = useTooltip({
-    tooltipRef,
     isVisible: false,
     delayMilliseconds: 500
   });
@@ -38,8 +34,8 @@ const Tooltip = () => {
 
   return (
     <>
-      <div {...getTooltipProps({ ref: tooltipRef, style: styles })}>Tooltip</div>
-      <button {...getTriggerProps({ ref: triggerRef })}>Trigger</button>
+      <div {...getTooltipProps({ style: styles })}>Tooltip</div>
+      <button {...getTriggerProps()}>Trigger</button>
     </>
   );
 };
@@ -48,14 +44,11 @@ const Tooltip = () => {
 ### TooltipContainer
 
 ```jsx static
-import { useRef } from 'react';
 import { TooltipContainer } from '@zendeskgarden/container-tooltip';
 
 const Tooltip = () => {
-  const tooltipRef = useRef(null);
-
   return (
-    <TooltipContainer tooltipRef={tooltipRef} isVisible={false} delayMilliseconds={500}>
+    <TooltipContainer isVisible={false} delayMilliseconds={500}>
       {({ isVisible, getTooltipProps, getTriggerProps }) => {
         const styles = {
           visibility: isVisible ? 'visible' : 'hidden',
@@ -69,7 +62,6 @@ const Tooltip = () => {
           <>
             <div
               {...getTooltipProps({
-                ref: tooltipRef,
                 style: styles
               })}
             >

--- a/packages/tooltip/src/TooltipContainer.js
+++ b/packages/tooltip/src/TooltipContainer.js
@@ -16,7 +16,6 @@ export function TooltipContainer({ children, render = children, ...options }) {
 TooltipContainer.propTypes = {
   children: PropTypes.func,
   render: PropTypes.func,
-  tooltipRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }).isRequired,
   delayMilliseconds: PropTypes.number,
   isVisible: PropTypes.bool
 };

--- a/packages/tooltip/src/TooltipContainer.spec.js
+++ b/packages/tooltip/src/TooltipContainer.spec.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useRef } from 'react';
+import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 
@@ -17,17 +17,14 @@ describe('TooltipContainer', () => {
   const TOOLTIP_ID = 'test';
 
   const BasicExample = props => {
-    const tooltipRef = useRef(null);
-
     return (
-      <TooltipContainer tooltipRef={tooltipRef} id={TOOLTIP_ID} {...props}>
+      <TooltipContainer id={TOOLTIP_ID} {...props}>
         {({ getTooltipProps, getTriggerProps }) => (
           <>
             <div {...getTriggerProps({ 'data-test-id': 'trigger' })}>trigger</div>
             <div
               {...getTooltipProps({
-                'data-test-id': 'tooltip',
-                ref: tooltipRef
+                'data-test-id': 'tooltip'
               })}
             >
               tooltip


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Passing in the tooltip ref was completely pointless and made it hard to work with.

## Detail

I believe I was trying to work around the bug fixed here rather than actually needing the ref to the tooltip for any useful reason.

Even though this removes a prop it's not actually a breaking change since you can still pass the ref and it'll work fine, it just doesn't use the ref passed.

I think this react [PR merged](https://github.com/facebook/react/pull/15650) in the latest react (beta/alpha?) might fix the underlying issue and not require the `isMount` tracking.

https://github.com/facebook/react/pull/15650

## Checklist

- [ ] :globe_with_meridians: ~Storybook demo is up-to-date (`yarn start`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
