### PR TITLE
fix(selection): Effect gets caught in infinite loop in test env

### DIFF
--- a/packages/selection/src/useSelection.js
+++ b/packages/selection/src/useSelection.js
@@ -158,9 +158,10 @@ export function useSelection({
     if (controlledFocusedItem !== undefined) {
       const focusedIndex = items.indexOf(controlledFocusedItem);
 
+      console.log('focus effect being called');
       refs[focusedIndex] && refs[focusedIndex].current.focus();
     }
-  }, [controlledFocusedItem, items, refs]);
+  }, [controlledFocusedItem]);
 
   useEffect(() => {
     if (selectedItem === undefined && defaultSelectedIndex !== undefined) {

--- a/packages/selection/src/useSelection.js
+++ b/packages/selection/src/useSelection.js
@@ -158,10 +158,9 @@ export function useSelection({
     if (controlledFocusedItem !== undefined) {
       const focusedIndex = items.indexOf(controlledFocusedItem);
 
-      console.log('focus effect being called');
       refs[focusedIndex] && refs[focusedIndex].current.focus();
     }
-  }, [controlledFocusedItem]);
+  }, [controlledFocusedItem]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (selectedItem === undefined && defaultSelectedIndex !== undefined) {


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

renovate recently did a non-major upgrade to our deps which moved react from 16.8 to 16.9, this caused the tests to hang and timeout in travis-ci

This is an attempt to fix that

## Detail

Turns out only in our test env once moving to react 16.9 [the effect](https://github.com/zendeskgarden/react-containers/blob/9d5c5190c435476db0bd39e6ea02ecb841a5fbaa/packages/selection/src/useSelection.js#L157-L163) that monitors the `focusedItem` would get caught in an infinite loop due to it having 2 dependencies that are arrays, `items` & `refs`. This only happens in our jsdom test env not in the actual browser. 

I don't think we need to have `items` & `refs` as deps of the effect as they don't really add anything other than appeasing our eslint exhaustive-deps rules.

But this could also be a weird bug with either react or jsdom and it not correctly shallow comparing the arrays i.e. jsdom might actually recreate the array and would make react think the effect array dep has changed.

I've yet to reduce this beyond our useSelection hook in [tests](https://codesandbox.io/s/react-testing-library-examples-9wz2n) (warning this will get into an infinite loop) codesandbox is actually using jsdom to run these tests hence why we see it in the browser.

#85 - See build

## Checklist

- [ ] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
