### PR TITLE
Support passing in focusOnMount and environment for the useModal hook

### DIFF
--- a/packages/modal/src/ModalContainer.js
+++ b/packages/modal/src/ModalContainer.js
@@ -18,5 +18,7 @@ ModalContainer.propTypes = {
   render: PropTypes.func,
   onClose: PropTypes.func,
   modalRef: PropTypes.object.isRequired,
-  id: PropTypes.string
+  id: PropTypes.string,
+  focusOnMount: PropTypes.bool,
+  environment: PropTypes.object
 };

--- a/packages/modal/src/useModal.js
+++ b/packages/modal/src/useModal.js
@@ -9,7 +9,7 @@ import { useState } from 'react';
 import { composeEventHandlers, generateId, KEY_CODES } from '@zendeskgarden/container-utilities';
 import { useFocusJail } from '@zendeskgarden/container-focusjail';
 
-export function useModal({ onClose, modalRef, id: _id } = {}) {
+export function useModal({ onClose, modalRef, id: _id, focusOnMount, environment } = {}) {
   const [idPrefix] = useState(_id || generateId('garden-modal-container'));
   const titleId = `${idPrefix}--title`;
   const contentId = `${idPrefix}--content`;
@@ -76,7 +76,7 @@ export function useModal({ onClose, modalRef, id: _id } = {}) {
     };
   };
 
-  const { getContainerProps } = useFocusJail({ containerRef: modalRef });
+  const { getContainerProps } = useFocusJail({ containerRef: modalRef, focusOnMount, environment });
 
   return {
     getBackdropProps,


### PR DESCRIPTION
## Description
This PR adds the options `focusOnMount` and `environment` to the `useModal`.

## Detail
The `useModal` hook uses the `useFocusJail` hook to handle the focus for the modal. This hook by default focuses the element on mount and also defaults to using the global `document`.

When using the `useModal` hook, you may want to handle focus yourself, e.g. focusing on an input inside of the modal on mount, and you may also be rendering the modal inside of an iframe, so the global `document` isn't the correct context you are rendering into.

## Checklist

- [ ] :globe_with_meridians: ~Storybook demo is up-to-date (`yarn start`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
