### PR TITLE
feat(accordion): allow useAccordion hook to become controlled

### DIFF
--- a/packages/accordion/src/AccordionContainer.spec.js
+++ b/packages/accordion/src/AccordionContainer.spec.js
@@ -32,12 +32,18 @@ describe('AccordionContainer', () => {
   const sections = Array(3).fill();
   const CONTAINER_ID_PREFIX = 'test';
 
-  const BasicExample = ({ expandedSections = [], expandable = true, collapsible = true } = {}) => (
+  const BasicExample = ({
+    expandedSections = [],
+    expandable = true,
+    collapsible = true,
+    onChange
+  } = {}) => (
     <AccordionContainer
       idPrefix={CONTAINER_ID_PREFIX}
       expandedSections={expandedSections}
       expandable={expandable}
       collapsible={collapsible}
+      onChange={onChange}
     >
       {({ getHeaderProps, getTriggerProps, getPanelProps }) => (
         <>
@@ -85,6 +91,17 @@ describe('AccordionContainer', () => {
       )}
     </AccordionContainer>
   );
+
+  it('calls onChange with correct sections on section selection', () => {
+    const onChangeSpy = jest.fn();
+
+    const { getAllByTestId } = render(<BasicExample onChange={onChangeSpy} />);
+    const triggers = getAllByTestId('trigger');
+
+    fireEvent.click(triggers[2]);
+
+    expect(onChangeSpy).toHaveBeenCalledWith([2]);
+  });
 
   describe('getHeaderProps', () => {
     it('applies the correct accessibility role', () => {

--- a/packages/accordion/stories.js
+++ b/packages/accordion/stories.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { createRef } from 'react';
+import React, { createRef, useState } from 'react';
 
 import { storiesOf } from '@storybook/react';
 import { boolean, number, withKnobs } from '@storybook/addon-knobs';
@@ -21,6 +21,7 @@ storiesOf('Accordion Container', module)
       .map(() => createRef());
 
     const Accordion = ({ expandable = true, collapsible = true } = {}) => {
+      const [controlledExpandedSections, setControlledExpandedSections] = useState([0]);
       const {
         getHeaderProps,
         getTriggerProps,
@@ -28,9 +29,10 @@ storiesOf('Accordion Container', module)
         expandedSections,
         disabledSections
       } = useAccordion({
-        expandedSections: [0],
+        expandedSections: controlledExpandedSections,
         expandable,
-        collapsible
+        collapsible,
+        onChange: setControlledExpandedSections
       });
 
       return (


### PR DESCRIPTION
## Description

While deprecating the `AccordionContainer` in `react-chrome` I found that the current `useAccordion` hook cannot be controlled. This PR adds an `onChange` callback which allows the component to be controlled.

## Detail

The previous `useAccordion` hook used the `expandedSections` prop as a "default". To avoid a breaking change I have made it so the hook only becomes controlled if `expandedSections` AND `onChange` are provided.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
