### PR TITLE
chore: remove deprecated `@zendeskgarden/react-testing` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@typescript-eslint/parser": "2.3.0",
     "@zendeskgarden/css-variables": "6.3.7",
     "@zendeskgarden/eslint-config": "9.0.0",
-    "@zendeskgarden/react-testing": "2.0.4",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.3",
     "babel-jest": "24.9.0",

--- a/packages/.template/src/index.spec.js
+++ b/packages/.template/src/index.spec.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { getExports } from '@zendeskgarden/react-testing';
+import { getExports } from 'garden-test-utils';
 import * as rootIndex from './';
 
 describe('Index', () => {

--- a/packages/accordion/src/index.spec.js
+++ b/packages/accordion/src/index.spec.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { getExports } from '@zendeskgarden/react-testing';
+import { getExports } from 'garden-test-utils';
 import * as rootIndex from './';
 
 describe('Index', () => {

--- a/packages/breadcrumb/src/index.spec.js
+++ b/packages/breadcrumb/src/index.spec.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { getExports } from '@zendeskgarden/react-testing';
+import { getExports } from 'garden-test-utils';
 import * as rootIndex from './';
 
 describe('Index', () => {

--- a/packages/buttongroup/src/index.spec.js
+++ b/packages/buttongroup/src/index.spec.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { getExports } from '@zendeskgarden/react-testing';
+import { getExports } from 'garden-test-utils';
 import * as rootIndex from './';
 
 describe('Index', () => {

--- a/packages/field/src/index.spec.js
+++ b/packages/field/src/index.spec.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { getExports } from '@zendeskgarden/react-testing';
+import { getExports } from 'garden-test-utils';
 import * as rootIndex from './';
 
 describe('Index', () => {

--- a/packages/focusjail/src/index.spec.js
+++ b/packages/focusjail/src/index.spec.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { getExports } from '@zendeskgarden/react-testing';
+import { getExports } from 'garden-test-utils';
 import * as rootIndex from './';
 
 describe('Index', () => {

--- a/packages/focusvisible/src/index.spec.js
+++ b/packages/focusvisible/src/index.spec.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { getExports } from '@zendeskgarden/react-testing';
+import { getExports } from 'garden-test-utils';
 import * as rootIndex from './';
 
 describe('Index', () => {

--- a/packages/keyboardfocus/src/index.spec.js
+++ b/packages/keyboardfocus/src/index.spec.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { getExports } from '@zendeskgarden/react-testing';
+import { getExports } from 'garden-test-utils';
 import * as rootIndex from './';
 
 describe('Index', () => {

--- a/packages/modal/src/index.spec.js
+++ b/packages/modal/src/index.spec.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { getExports } from '@zendeskgarden/react-testing';
+import { getExports } from 'garden-test-utils';
 import * as rootIndex from './';
 
 describe('Index', () => {

--- a/packages/pagination/src/index.spec.js
+++ b/packages/pagination/src/index.spec.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { getExports } from '@zendeskgarden/react-testing';
+import { getExports } from 'garden-test-utils';
 import * as rootIndex from './';
 
 describe('Index', () => {

--- a/packages/schedule/src/index.spec.js
+++ b/packages/schedule/src/index.spec.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { getExports } from '@zendeskgarden/react-testing';
+import { getExports } from 'garden-test-utils';
 import * as rootIndex from './';
 
 describe('Index', () => {

--- a/packages/selection/src/index.spec.js
+++ b/packages/selection/src/index.spec.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { getExports } from '@zendeskgarden/react-testing';
+import { getExports } from 'garden-test-utils';
 import * as rootIndex from './';
 
 describe('Index', () => {

--- a/packages/tabs/src/index.spec.js
+++ b/packages/tabs/src/index.spec.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { getExports } from '@zendeskgarden/react-testing';
+import { getExports } from 'garden-test-utils';
 import * as rootIndex from './';
 
 describe('Index', () => {

--- a/packages/tooltip/src/index.spec.js
+++ b/packages/tooltip/src/index.spec.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { getExports } from '@zendeskgarden/react-testing';
+import { getExports } from 'garden-test-utils';
 import * as rootIndex from './';
 
 describe('Index', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "moduleResolution": "node",
     "baseUrl": "./",
     "paths": {
-      "garden-test-utils": ["utils/test/garden-test-utils.tsx"]
+      "garden-test-utils": ["utils/test/utilities.ts"]
     },
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
@@ -17,7 +17,5 @@
   },
   "files": ["utils/build/declarations.d.ts", "utils/test/jest.d.ts"],
   "include": ["packages/*/src/**/*"],
-  "exclude": [
-    "node_modules", "**/node_modules", "**/dist"
-  ]
+  "exclude": ["node_modules", "**/node_modules", "**/dist"]
 }

--- a/utils/build/declarations.d.ts
+++ b/utils/build/declarations.d.ts
@@ -7,6 +7,3 @@
 
 /* Globals */
 declare const PACKAGE_VERSION: string;
-
-/* Testing mocks */
-declare module '@zendeskgarden/react-testing';

--- a/utils/test/jest.config.js
+++ b/utils/test/jest.config.js
@@ -24,6 +24,9 @@ module.exports = {
   },
   moduleFileExtensions: [...defaults.moduleFileExtensions],
   setupFilesAfterEnv: ['<rootDir>/utils/test/jest.setup.js'],
+  moduleNameMapper: {
+    'garden-test-utils': '<rootDir>/utils/test/utilities.ts'
+  },
   collectCoverageFrom: [
     '<rootDir>/packages/*/src/**/*.{js,jsx,ts,tsx}',
     '!<rootDir>/packages/*/src/index.js',

--- a/utils/test/utilities.ts
+++ b/utils/test/utilities.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import glob from 'glob';
+
+/**
+ * defaultFileMapper
+ * @param {*} files
+ */
+function defaultFileMapper(files: string[]) {
+  return files
+    .map(entry =>
+      entry
+        .replace(/\.js$/u, '')
+        .split('/')
+        .pop()
+    )
+    .sort();
+}
+
+/**
+ * getExports
+ * @param {*} options
+ */
+export function getExports({
+  globPath = '**/!(index|*.spec).js',
+  cwd,
+  options = {},
+  fileMapper = defaultFileMapper
+}: { globPath?: string; cwd?: string; options?: any; fileMapper?: any } = {}) {
+  return new Promise((resolve, reject) => {
+    glob(globPath, { ...options, cwd }, (error, files) => {
+      if (error) {
+        reject(error);
+      }
+
+      resolve(fileMapper(files));
+    });
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3372,13 +3372,6 @@
   resolved "https://registry.yarnpkg.com/@zendeskgarden/eslint-config/-/eslint-config-9.0.0.tgz#f506b86d2b53dc860a58a7f0d8b6303b2858cfbb"
   integrity sha512-8u3ZD/cvnkWKXHTTOuNI8RFSJMolAlfORJ5fxzCLXRWQc0pNKzEEUENnScNSsufXysOWQiiY6DY7d9jH/vgmRg==
 
-"@zendeskgarden/react-testing@2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-testing/-/react-testing-2.0.4.tgz#d97f6a893c28be93926ace5bc68c6b9eddda4011"
-  integrity sha512-qgYKhfWQK5kZg3l9/45v3Fd3dqpgjnUgCq/iJrp2Bao0GEFKNOo8CDi/7ZbdVg6OfEPiv8dH+W7WJw/SOProQQ==
-  dependencies:
-    glob "7.1.3"
-
 "@zkochan/cmd-shim@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz#2ab8ed81f5bb5452a85f25758eb9b8681982fd2e"
@@ -7567,18 +7560,6 @@ glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
-
-glob@7.1.3:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
-  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
 
 glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.2:
   version "7.1.4"


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

The `@zendeskgarden/react-testing` package was removed nearly 4 months ago. Furthermore, `react-containers` should never have a dependency on `react-components`.

## Detail

https://github.com/zendeskgarden/react-components/pull/342