### PR TITLE
fix(field): update field interface

### DIFF
--- a/packages/field/src/useField.ts
+++ b/packages/field/src/useField.ts
@@ -9,12 +9,12 @@ import { useState } from 'react';
 import { generateId } from '@zendeskgarden/container-utilities';
 
 export interface IUseFieldPropGetters {
-  getHintProps: <T>(options?: T & React.HTMLProps<any>) => React.HTMLProps<any>;
-  getLabelProps: <T>(options?: T & React.HTMLProps<any>) => React.HTMLProps<any>;
+  getHintProps: <T>(options?: T) => T & React.HTMLProps<any>;
+  getLabelProps: <T>(options?: T) => T & React.HTMLProps<any>;
   getInputProps: <T>(
-    options?: T & React.HTMLProps<any>,
+    options?: T,
     isDescribedOptions?: { isDescribed: boolean }
-  ) => any;
+  ) => T & React.HTMLProps<any>;
 }
 
 export function useField(idPrefix?: string): IUseFieldPropGetters {
@@ -30,7 +30,7 @@ export function useField(idPrefix?: string): IUseFieldPropGetters {
       'data-garden-container-id': 'field',
       'data-garden-container-version': PACKAGE_VERSION,
       ...other
-    };
+    } as any;
   };
 
   const getInputProps = ({ id = inputId, ...other } = {}, { isDescribed = false } = {}) => {
@@ -39,14 +39,14 @@ export function useField(idPrefix?: string): IUseFieldPropGetters {
       'aria-labelledby': labelId,
       'aria-describedby': isDescribed ? hintId : null,
       ...other
-    };
+    } as any;
   };
 
   const getHintProps = ({ id = hintId, ...other } = {}) => {
     return {
       id,
       ...other
-    };
+    } as any;
   };
 
   return {

--- a/packages/field/stories.tsx
+++ b/packages/field/stories.tsx
@@ -11,7 +11,7 @@ import { storiesOf } from '@storybook/react';
 import { withKnobs, text } from '@storybook/addon-knobs';
 
 import { FieldContainer, useField } from './src';
-import { generateId } from '@zendeskgarden/container-utilities/src';
+import { generateId } from '@zendeskgarden/container-utilities';
 
 storiesOf('Field Container', module)
   .addDecorator(withKnobs)


### PR DESCRIPTION
## Description

Update interfaces for `useField` to allow for custom props being provided. This PR aims to address @austin94's code review comments left [here](https://github.com/zendeskgarden/react-containers/pull/110#pullrequestreview-298415244). 

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :memo: Tested in Chrome, Firefox, and Safari
