### PR TITLE
fix(pagination): remove unnecessary attributes

### DIFF
--- a/packages/pagination/stories.js
+++ b/packages/pagination/stories.js
@@ -56,8 +56,6 @@ storiesOf('Pagination Container', module)
           <ul style={{ display: 'flex' }}>
             <li
               {...getPreviousPageProps({
-                current: selectedItem === 'prev',
-                focused: focusedItem === 'prev',
                 item: 'prev',
                 focusRef: previousPageRef,
                 key: 'previous-page'
@@ -69,8 +67,6 @@ storiesOf('Pagination Container', module)
               return (
                 <li
                   {...getPageProps({
-                    focused: index === focusedItem,
-                    current: index === selectedItem,
                     page: index,
                     item: index,
                     focusRef: pageRefs[index],
@@ -88,8 +84,6 @@ storiesOf('Pagination Container', module)
             })}
             <li
               {...getNextPageProps({
-                current: selectedItem === 'next',
-                focused: focusedItem === 'next',
                 item: 'next',
                 focusRef: nextPageRef,
                 key: 'next-page'
@@ -144,8 +138,6 @@ storiesOf('Pagination Container', module)
                 <ul style={{ display: 'flex' }}>
                   <li
                     {...getPreviousPageProps({
-                      current: selectedItem === 'prev',
-                      focused: focusedItem === 'prev',
                       item: 'prev',
                       focusRef: previousPageRef,
                       ref: previousPageRef,
@@ -158,8 +150,6 @@ storiesOf('Pagination Container', module)
                     return (
                       <li
                         {...getPageProps({
-                          focused: index === focusedItem,
-                          current: index === selectedItem,
                           page: index,
                           item: index,
                           focusRef: pageRefs[index],
@@ -178,8 +168,6 @@ storiesOf('Pagination Container', module)
                   })}
                   <li
                     {...getNextPageProps({
-                      current: selectedItem === 'next',
-                      focused: focusedItem === 'next',
                       item: 'next',
                       focusRef: nextPageRef,
                       ref: nextPageRef,


### PR DESCRIPTION
## Description

There are React warnings thrown in development mode in the `usePagination` and `paginationConatiner` Storybook example:

![Screen Shot 2019-10-18 at 12 03 38 PM](https://user-images.githubusercontent.com/1811365/67121469-70bce600-f1a0-11e9-9f6f-e9c2c1cf20d6.png)

## Detail

[The warnings](https://github.com/facebook/react/blob/master/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js#L186) say that the "current" and "focused" attributes must be non-boolean values. But these values are unnecessary and likely was copied over from `react-pagination`. **I went and removed the attributes and the warnings are now gone**.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11


