### PR TITLE
fix: update render prop function return types

### DIFF
--- a/packages/accordion/src/AccordionContainer.ts
+++ b/packages/accordion/src/AccordionContainer.ts
@@ -10,14 +10,14 @@ import PropTypes from 'prop-types';
 import { useAccordion, IUseAccordionProps, IUseAccordionReturnValue } from './useAccordion';
 
 export interface IAccordionContainerProps extends IUseAccordionProps {
-  render?: (options: IUseAccordionReturnValue) => React.ReactElement;
-  children?: (options: IUseAccordionReturnValue) => React.ReactElement;
+  render?: (options: IUseAccordionReturnValue) => React.ReactNode;
+  children?: (options: IUseAccordionReturnValue) => React.ReactNode;
 }
 
 export const AccordionContainer: React.FunctionComponent<IAccordionContainerProps> = props => {
   const { children, render = children, ...options } = props;
 
-  return render!(useAccordion(options));
+  return render!(useAccordion(options)) as React.ReactElement;
 };
 
 AccordionContainer.propTypes = {

--- a/packages/breadcrumb/src/BreadcrumbContainer.ts
+++ b/packages/breadcrumb/src/BreadcrumbContainer.ts
@@ -10,15 +10,15 @@ import PropTypes from 'prop-types';
 import useBreadcrumb, { IUseBreadcrumbReturnValue } from './useBreadcrumb';
 
 export interface IBreadcrumbContainerProps {
-  render?: (options: IUseBreadcrumbReturnValue) => React.ReactElement;
-  children?: (options: IUseBreadcrumbReturnValue) => React.ReactElement;
+  render?: (options: IUseBreadcrumbReturnValue) => React.ReactNode;
+  children?: (options: IUseBreadcrumbReturnValue) => React.ReactNode;
 }
 
 const BreadcrumbContainer: React.FunctionComponent<IBreadcrumbContainerProps> = ({
   children,
   render = children
 }) => {
-  return render!(useBreadcrumb());
+  return render!(useBreadcrumb()) as React.ReactElement;
 };
 
 BreadcrumbContainer.propTypes = {

--- a/packages/buttongroup/src/ButtonGroupContainer.ts
+++ b/packages/buttongroup/src/ButtonGroupContainer.ts
@@ -10,8 +10,8 @@ import PropTypes from 'prop-types';
 import { useButtonGroup, IUseButtonGroupProps, UseButtonGroupReturnValue } from './useButtonGroup';
 
 export interface IButtonGroupContainerProps<Item> extends IUseButtonGroupProps<Item> {
-  render?: (options: UseButtonGroupReturnValue<Item>) => React.ReactElement;
-  children?: (options: UseButtonGroupReturnValue<Item>) => React.ReactElement;
+  render?: (options: UseButtonGroupReturnValue<Item>) => React.ReactNode;
+  children?: (options: UseButtonGroupReturnValue<Item>) => React.ReactNode;
 }
 
 export const ButtonGroupContainer: React.FunctionComponent<IButtonGroupContainerProps<any>> = ({
@@ -19,7 +19,7 @@ export const ButtonGroupContainer: React.FunctionComponent<IButtonGroupContainer
   render = children,
   ...options
 }) => {
-  return render!(useButtonGroup(options));
+  return render!(useButtonGroup(options)) as React.ReactElement;
 };
 
 ButtonGroupContainer.propTypes = {

--- a/packages/field/src/FieldContainer.ts
+++ b/packages/field/src/FieldContainer.ts
@@ -10,8 +10,8 @@ import PropTypes from 'prop-types';
 import { useField, IUseFieldPropGetters } from './useField';
 
 export interface IFieldContainerProps {
-  render?: (options: IUseFieldPropGetters) => React.ReactElement;
-  children?: (options: IUseFieldPropGetters) => React.ReactElement;
+  render?: (options: IUseFieldPropGetters) => React.ReactNode;
+  children?: (options: IUseFieldPropGetters) => React.ReactNode;
   id?: string;
 }
 
@@ -20,7 +20,7 @@ export const FieldContainer: React.FunctionComponent<IFieldContainerProps> = ({
   render = children,
   id
 }) => {
-  return render!(useField(id));
+  return render!(useField(id)) as React.ReactElement;
 };
 
 FieldContainer.propTypes = {

--- a/packages/focusjail/src/FocusJailContainer.ts
+++ b/packages/focusjail/src/FocusJailContainer.ts
@@ -10,8 +10,8 @@ import PropTypes from 'prop-types';
 import { useFocusJail, IUseFocusJailProps, IUseFocusJailReturnValue } from './useFocusJail';
 
 export interface IFocusJailContainerProps extends IUseFocusJailProps {
-  render?: (options: IUseFocusJailReturnValue) => React.ReactElement;
-  children?: (options: IUseFocusJailReturnValue) => React.ReactElement;
+  render?: (options: IUseFocusJailReturnValue) => React.ReactNode;
+  children?: (options: IUseFocusJailReturnValue) => React.ReactNode;
 }
 
 export const FocusJailContainer: React.FunctionComponent<IFocusJailContainerProps> = ({
@@ -19,7 +19,7 @@ export const FocusJailContainer: React.FunctionComponent<IFocusJailContainerProp
   render = children,
   ...options
 }) => {
-  return render!(useFocusJail(options));
+  return render!(useFocusJail(options)) as React.ReactElement;
 };
 
 FocusJailContainer.propTypes = {

--- a/packages/selection/src/SelectionContainer.ts
+++ b/packages/selection/src/SelectionContainer.ts
@@ -11,8 +11,8 @@ import PropTypes from 'prop-types';
 import { useSelection, IUseSelectionProps, UseSelectionReturnValue } from './useSelection';
 
 export interface ISelectionContainerProps<Item> extends IUseSelectionProps<Item> {
-  render?: (options: UseSelectionReturnValue<Item>) => any;
-  children?: (options: UseSelectionReturnValue<Item>) => any;
+  render?: (options: UseSelectionReturnValue<Item>) => React.ReactNode;
+  children?: (options: UseSelectionReturnValue<Item>) => React.ReactNode;
 }
 
 export const SelectionContainer: React.FunctionComponent<ISelectionContainerProps<any>> = ({
@@ -20,7 +20,7 @@ export const SelectionContainer: React.FunctionComponent<ISelectionContainerProp
   render = children,
   ...options
 }) => {
-  return render!(useSelection(options));
+  return render!(useSelection(options)) as React.ReactElement;
 };
 
 SelectionContainer.propTypes = {

--- a/packages/tabs/src/TabsContainer.ts
+++ b/packages/tabs/src/TabsContainer.ts
@@ -10,8 +10,8 @@ import PropTypes from 'prop-types';
 import { useTabs, IUseTabsProps, IUseTabsReturnValue } from './useTabs';
 
 export interface ITabsContainerProps extends IUseTabsProps<any> {
-  render?: (options: IUseTabsReturnValue<any>) => React.ReactElement;
-  children?: (options: IUseTabsReturnValue<any>) => React.ReactElement;
+  render?: (options: IUseTabsReturnValue<any>) => React.ReactNode;
+  children?: (options: IUseTabsReturnValue<any>) => React.ReactNode;
 }
 
 export const TabsContainer: React.FunctionComponent<ITabsContainerProps> = ({
@@ -19,7 +19,7 @@ export const TabsContainer: React.FunctionComponent<ITabsContainerProps> = ({
   render = children,
   ...options
 }) => {
-  return render!(useTabs(options));
+  return render!(useTabs(options)) as React.ReactElement;
 };
 
 TabsContainer.propTypes = {


### PR DESCRIPTION
## Description

The proper type annotation for render prop return value to be a type of [`React.ReactNode`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L196). This is because the author of a render prop function can choose to return `null`, or a [`boolean`](https://github.com/zendeskgarden/react-containers/blob/master/packages/modal/stories.js#L100).

Also, the container function component return value should be typecasted as [`React.ReactElement`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L103).

That would mean the code would look like this:

```jsx
export interface IModalContainerProps extends IUseModalProps {
  render?: (options: IUseModalReturnValue) => React.ReactNode; 
  children?: (options: IUseModalReturnValue) => React.ReactNode;
}

export const ModalContainer: React.FunctionComponent<IModalContainerProps> = ({
  children,
  render = children,
  ...options
}) => {
  return render!(useModal(options)) as React.ReactElement; 
};
```

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
