### PR TITLE
fix(selection): correct vertical ordering in RTL mode

### DIFF
--- a/packages/selection/src/SelectionContainer.spec.tsx
+++ b/packages/selection/src/SelectionContainer.spec.tsx
@@ -347,6 +347,16 @@ describe('SelectionContainer', () => {
             expect(item).toHaveAttribute('data-focused', 'true');
           });
 
+          it('decrements focusedIndex in RTL mode', () => {
+            const { getAllByTestId } = render(<BasicExample direction="vertical" rtl />);
+            const [item, secondItem] = getAllByTestId('item');
+
+            fireEvent.click(secondItem);
+            fireEvent.keyDown(secondItem, { keyCode: KEY_CODES.UP });
+
+            expect(item).toHaveAttribute('data-focused', 'true');
+          });
+
           it('decrements and wraps focusedIndex if currently less than or equal to 0', () => {
             const { getAllByTestId } = render(<BasicExample direction="vertical" />);
             const [item, , lastItem] = getAllByTestId('item');
@@ -361,6 +371,16 @@ describe('SelectionContainer', () => {
         describe('DOWN keyCode', () => {
           it('increments focusedIndex if currently less than items length', () => {
             const { getAllByTestId } = render(<BasicExample direction="vertical" />);
+            const [item, secondItem] = getAllByTestId('item');
+
+            fireEvent.click(item);
+            fireEvent.keyDown(item, { keyCode: KEY_CODES.DOWN });
+
+            expect(secondItem).toHaveAttribute('data-focused', 'true');
+          });
+
+          it('increments focusedIndex in RTL mode', () => {
+            const { getAllByTestId } = render(<BasicExample direction="vertical" rtl />);
             const [item, secondItem] = getAllByTestId('item');
 
             fireEvent.click(item);

--- a/packages/selection/src/useSelection.ts
+++ b/packages/selection/src/useSelection.ts
@@ -308,7 +308,7 @@ export function useSelection<Item = any>({
           (e.keyCode === KEY_CODES.UP && verticalDirection) ||
           (e.keyCode === KEY_CODES.LEFT && horizontalDirection)
         ) {
-          if (rtl) {
+          if (rtl && !verticalDirection) {
             dispatch({ type: 'INCREMENT', items, focusedItem, selectedItem, onFocus });
           } else {
             dispatch({ type: 'DECREMENT', items, focusedItem, selectedItem, onFocus });
@@ -319,7 +319,7 @@ export function useSelection<Item = any>({
           (e.keyCode === KEY_CODES.DOWN && verticalDirection) ||
           (e.keyCode === KEY_CODES.RIGHT && horizontalDirection)
         ) {
-          if (rtl) {
+          if (rtl && !verticalDirection) {
             dispatch({ type: 'DECREMENT', items, focusedItem, selectedItem, onFocus });
           } else {
             dispatch({ type: 'INCREMENT', items, focusedItem, selectedItem, onFocus });


### PR DESCRIPTION
## Description

While implementing some `useSelection` usages I found that the current hooks is unintentionally reversing focus order in `vertical` mode with `rtl` enabled.

The hook should not reverse order while in `rtl` mode.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
