### PR TITLE
fix(selection): remove aria orientation

### DIFF
--- a/packages/pagination/src/PaginationContainer.spec.tsx
+++ b/packages/pagination/src/PaginationContainer.spec.tsx
@@ -7,7 +7,7 @@
 
 import React, { useRef } from 'react';
 import { render, fireEvent } from '@testing-library/react';
-import { IGetContainerProps, IGetPageProps } from './usePagination';
+import { IGetPageProps } from './usePagination';
 import { PaginationContainer } from './PaginationContainer';
 
 describe('PaginationContainer', () => {
@@ -71,16 +71,6 @@ describe('PaginationContainer', () => {
     );
   };
 
-  const containerProps = (props: IGetContainerProps) => {
-    return render(
-      <PaginationContainer>
-        {({ getContainerProps }) => (
-          <div {...getContainerProps({ 'data-test-id': 'container', ...props })} />
-        )}
-      </PaginationContainer>
-    );
-  };
-
   const pageProps = (props: IGetPageProps<any>) => {
     return render(
       <PaginationContainer>
@@ -114,15 +104,7 @@ describe('PaginationContainer', () => {
       const { getByTestId } = render(<BasicExample />);
       const container = getByTestId('container');
 
-      expect(container).toHaveAttribute('role', 'navigation');
-      expect(container).toHaveAttribute('aria-label', 'Pagination navigation');
-    });
-
-    it('applies custom aria-label attribute', () => {
-      const ariaLabel = 'Test aria label';
-      const { getByTestId } = containerProps({ ariaLabel });
-
-      expect(getByTestId('container')).toHaveAttribute('aria-label', ariaLabel);
+      expect(container).toHaveAttribute('role', 'listbox');
     });
   });
 

--- a/packages/pagination/src/usePagination.ts
+++ b/packages/pagination/src/usePagination.ts
@@ -43,10 +43,8 @@ export function usePagination<Item = any>(
     getItemProps
   } = useSelection(options);
 
-  const getContainerProps = ({ role = 'navigation', ariaLabel, ...props } = {} as any) => {
+  const getContainerProps = ({ ...props } = {} as any) => {
     return {
-      role,
-      'aria-label': ariaLabel || 'Pagination navigation',
       'data-garden-container-id': 'containers.pagination',
       'data-garden-container-version': PACKAGE_VERSION,
       ...props

--- a/packages/pagination/stories.tsx
+++ b/packages/pagination/stories.tsx
@@ -50,10 +50,13 @@ storiesOf('Pagination Container', module)
         }
       });
 
-      // role="null" is applied due to implied role="navigation" semantics of <nav />
       return (
-        <nav {...getContainerProps({ role: null })}>
-          <ul style={{ display: 'flex' }}>
+        <nav>
+          <ul
+            {...getContainerProps({
+              style: { display: 'flex' }
+            })}
+          >
             <li
               {...getPreviousPageProps({
                 item: 'prev',

--- a/packages/selection/src/SelectionContainer.spec.tsx
+++ b/packages/selection/src/SelectionContainer.spec.tsx
@@ -102,15 +102,6 @@ describe('SelectionContainer', () => {
       const container = getByTestId('container');
 
       expect(container).toHaveAttribute('role', 'listbox');
-      expect(container).toHaveAttribute('aria-orientation', 'horizontal');
-    });
-
-    describe('while using vertical direction', () => {
-      it('applies accessibility role', () => {
-        const { getByTestId } = render(<BasicExample direction="vertical" />);
-
-        expect(getByTestId('container')).toHaveAttribute('aria-orientation', 'vertical');
-      });
     });
 
     it('first item in container defaults as the only initial focusable item', () => {

--- a/packages/selection/src/useSelection.ts
+++ b/packages/selection/src/useSelection.ts
@@ -239,7 +239,6 @@ export function useSelection<Item = any>({
   const getContainerProps = ({ role = 'listbox', ...other }: React.HTMLProps<any> = {}) =>
     ({
       role,
-      'aria-orientation': direction === 'both' ? undefined : direction,
       'data-garden-container-id': 'containers.selection',
       'data-garden-container-version': PACKAGE_VERSION,
       ...other

--- a/packages/tabs/src/TabsContainer.spec.tsx
+++ b/packages/tabs/src/TabsContainer.spec.tsx
@@ -73,6 +73,7 @@ describe('TabsContainer', () => {
       const { getByTestId } = render(<BasicExample />);
 
       expect(getByTestId('tab-list')).toHaveAttribute('role', 'tablist');
+      expect(getByTestId('tab-list')).toHaveAttribute('aria-orientation', 'horizontal');
     });
 
     describe('Tab', () => {

--- a/packages/tabs/src/useTabs.ts
+++ b/packages/tabs/src/useTabs.ts
@@ -59,6 +59,7 @@ export function useTabs<Item = any>({
   const getTabListProps = ({ role = 'tablist', ...other }: React.HTMLProps<any> = {}) => {
     return {
       role,
+      'aria-orientation': vertical ? 'vertical' : 'horizontal',
       'data-garden-container-id': 'containers.tabs',
       'data-garden-container-version': PACKAGE_VERSION,
       ...other


### PR DESCRIPTION
## Description

It was discovered that there were accessibility issues with some Storybook examples caused by improper application of aria attributes and roles. The `aria-orientation` property from `useSelection` was improperly applied to `buttongroup` and `pagination` examples. Some aria attributes were improperly used in the `pagination` Storybook..

## Solution

The `aria-orientation` property has been removed from the `useSelection` hook which prevents `aria-orientation` being applied by default. Consumers that require this property can pass it to the prop getter or apply it to an element manually. For example, it is manually applied in the `useTabs` hook in this PR.

Lastly, the `pagination` Storybook was updated so that `getContainerProps` return value is spread onto the `ul` rather than the `nav`. This applies the `role="listbox"` onto the `ul`.

These changes fixes #128. 

## Verification 

Ensure there are no regressions in behavior and run accessibility auditing tools on the following Storybook examples:`selection`, `pagination`, `buttongroup`, and `tabs`.

## Screenshots

Screenshots of the improved Chrome Lighthouse scores (`buttongroup` & `pagination`):

**BEFORE**
<img width="1680" alt="Screen Shot 2019-11-05 at 11 52 13 PM" src="https://user-images.githubusercontent.com/1811365/68278974-518ad900-0027-11ea-929f-d5ce7a6b2265.png">

**AFTER**
<img width="1680" alt="Screen Shot 2019-11-05 at 11 47 15 PM" src="https://user-images.githubusercontent.com/1811365/68278780-ed681500-0026-11ea-9cba-7269342ec42d.png">

**SAME**
⭐️  `tabs` and `selection` examples retain a Chrome Lighthouse score of 100.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11

Thanks, @austin94 for sharing your thoughts on an alternative solution that lead to this PR 🙏.
