### PR TITLE
fix(schedule): update timeout type

### DIFF
--- a/packages/schedule/src/useSchedule.ts
+++ b/packages/schedule/src/useSchedule.ts
@@ -30,7 +30,7 @@ export const useSchedule = ({
   useLayoutEffect(() => {
     let raf: number;
     let start: number;
-    let loopTimeout: NodeJS.Timeout;
+    let loopTimeout: ReturnType<typeof setTimeout>;
 
     const tick = () => {
       // eslint-disable-next-line @typescript-eslint/no-use-before-define


### PR DESCRIPTION
## Description

During the `schedule` package TypeScript refactor, a `NodeJS.Timer` type slipped into `useSchedule.ts`.  **The type for a Timeout is not consistent between the browser and node declarations** and I mistakenly used `NodeJS.Timer`.  Since the hooks are client-side code, `NodeJS` types should be avoided. 

The type is now inferred from the `setTimeout` type.

## Detail

I went with alternative 1 based on this [S.O.](https://stackoverflow.com/questions/51040703/what-return-type-should-be-used-for-settimeout-in-typescript) answer, but there are different alternatives: 

```jsx
// alternative #1
let loopTimeout: ReturnType<typeof setTimeout>;
loopTimeout = setTimeout(() => {}, 0)

// alternative #2
let loopTimeout: number
loopTimeout = window.setTimeout(() => {}, 0)

// alternative #3
let loopTimeout: number
loopTimeout = Number(setTimeout(() => {}, 0))
```

There are other places in the codebase that require a choice of one of the above alternatives. For example, [here](https://github.com/zendeskgarden/react-containers/blob/master/packages/tooltip/src/useTooltip.ts#L46) and [here](https://github.com/zendeskgarden/react-containers/blob/master/packages/keyboardfocus/src/useKeyboardFocus.ts#L39).

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
