### PR TITLE
chore(focusvisible): move callbacks into useEffect

### DIFF
--- a/packages/focusvisible/src/useFocusVisible.js
+++ b/packages/focusvisible/src/useFocusVisible.js
@@ -10,7 +10,7 @@
  * `:focus-visible` polyfill.
  */
 
-import { useRef, useCallback, useEffect } from 'react';
+import { useRef, useEffect } from 'react';
 
 const INPUT_TYPES_WHITE_LIST = {
   text: true,
@@ -43,12 +43,12 @@ export function useFocusVisible({
   const hadFocusVisibleRecently = useRef(false);
   const hadFocusVisibleRecentlyTimeout = useRef(null);
 
-  /**
-   * Helper function for legacy browsers and iframes which sometimes focus
-   * elements like document, body, and non-interactive SVG.
-   */
-  const isValidFocusTarget = useCallback(
-    el => {
+  useEffect(() => {
+    /**
+     * Helper function for legacy browsers and iframes which sometimes focus
+     * elements like document, body, and non-interactive SVG.
+     */
+    const isValidFocusTarget = el => {
       if (
         el &&
         el !== scope.current &&
@@ -61,86 +61,74 @@ export function useFocusVisible({
       }
 
       return false;
-    },
-    [scope]
-  );
+    };
 
-  /**
-   * Computes whether the given element should automatically trigger the
-   * `garden-focus-visible` class being added, i.e. whether it should always match
-   * `:focus-visible` when focused.
-   */
-  const focusTriggersKeyboardModality = useCallback(el => {
-    const type = el.type;
-    const tagName = el.tagName;
+    /**
+     * Computes whether the given element should automatically trigger the
+     * `garden-focus-visible` class being added, i.e. whether it should always match
+     * `:focus-visible` when focused.
+     */
+    const focusTriggersKeyboardModality = el => {
+      const type = el.type;
+      const tagName = el.tagName;
 
-    if (tagName === 'INPUT' && INPUT_TYPES_WHITE_LIST[type] && !el.readOnly) {
-      return true;
-    }
+      if (tagName === 'INPUT' && INPUT_TYPES_WHITE_LIST[type] && !el.readOnly) {
+        return true;
+      }
 
-    if (tagName === 'TEXTAREA' && !el.readOnly) {
-      return true;
-    }
+      if (tagName === 'TEXTAREA' && !el.readOnly) {
+        return true;
+      }
 
-    /** Unable to test in JSDom environment */
-    /* istanbul ignore if */
-    if (el.isContentEditable) {
-      return true;
-    }
+      /** Unable to test in JSDom environment */
+      /* istanbul ignore if */
+      if (el.isContentEditable) {
+        return true;
+      }
 
-    return false;
-  }, []);
+      return false;
+    };
 
-  /**
-   * Whether the given element is currently :focus-visible
-   */
-  const isFocused = useCallback(
-    el => {
+    /**
+     * Whether the given element is currently :focus-visible
+     */
+    const isFocused = el => {
       if (el && (el.classList.contains(className) || el.hasAttribute(dataAttribute))) {
         return true;
       }
 
       return false;
-    },
-    [className, dataAttribute]
-  );
+    };
 
-  /**
-   * Add the `:focus-visible` class to the given element if it was not added by
-   * the consumer.
-   */
-  const addFocusVisibleClass = useCallback(
-    el => {
+    /**
+     * Add the `:focus-visible` class to the given element if it was not added by
+     * the consumer.
+     */
+    const addFocusVisibleClass = el => {
       if (isFocused(el)) {
         return;
       }
 
       el.classList.add(className);
       el.setAttribute(dataAttribute, true);
-    },
-    [className, dataAttribute, isFocused]
-  );
+    };
 
-  /**
-   * Remove the `:focus-visible` class from the given element.
-   */
-  const removeFocusVisibleClass = useCallback(
-    el => {
+    /**
+     * Remove the `:focus-visible` class from the given element.
+     */
+    const removeFocusVisibleClass = el => {
       el.classList.remove(className);
       el.removeAttribute(dataAttribute);
-    },
-    [className, dataAttribute]
-  );
+    };
 
-  /**
-   * If the most recent user interaction was via the keyboard;
-   * and the key press did not include a meta, alt/option, or control key;
-   * then the modality is keyboard. Otherwise, the modality is not keyboard.
-   * Apply `:focus-visible` to any current active element and keep track
-   * of our keyboard modality state with `hadKeyboardEvent`.
-   */
-  const onKeyDown = useCallback(
-    e => {
+    /**
+     * If the most recent user interaction was via the keyboard;
+     * and the key press did not include a meta, alt/option, or control key;
+     * then the modality is keyboard. Otherwise, the modality is not keyboard.
+     * Apply `:focus-visible` to any current active element and keep track
+     * of our keyboard modality state with `hadKeyboardEvent`.
+     */
+    const onKeyDown = e => {
       if (e.metaKey || e.altKey || e.ctrlKey) {
         return;
       }
@@ -150,30 +138,27 @@ export function useFocusVisible({
       }
 
       hadKeyboardEvent.current = true;
-    },
-    [isValidFocusTarget, relativeDocument.activeElement, addFocusVisibleClass]
-  );
+    };
 
-  /**
-   * If at any point a user clicks with a pointing device, ensure that we change
-   * the modality away from keyboard.
-   * This avoids the situation where a user presses a key on an already focused
-   * element, and then clicks on a different element, focusing it with a
-   * pointing device, while we still think we're in keyboard modality.
-   */
-  const onPointerDown = useCallback(() => {
-    hadKeyboardEvent.current = false;
-  }, []);
+    /**
+     * If at any point a user clicks with a pointing device, ensure that we change
+     * the modality away from keyboard.
+     * This avoids the situation where a user presses a key on an already focused
+     * element, and then clicks on a different element, focusing it with a
+     * pointing device, while we still think we're in keyboard modality.
+     */
+    const onPointerDown = () => {
+      hadKeyboardEvent.current = false;
+    };
 
-  /**
-   * On `focus`, add the `:focus-visible` styling to the target if:
-   * - the target received focus as a result of keyboard navigation, or
-   * - the event target is an element that will likely require interaction
-   *   via the keyboard (e.g. a text box)
-   * @param {Event} e
-   */
-  const onFocus = useCallback(
-    e => {
+    /**
+     * On `focus`, add the `:focus-visible` styling to the target if:
+     * - the target received focus as a result of keyboard navigation, or
+     * - the event target is an element that will likely require interaction
+     *   via the keyboard (e.g. a text box)
+     * @param {Event} e
+     */
+    const onFocus = e => {
       // Prevent IE from focusing the document or HTML element.
       if (!isValidFocusTarget(e.target)) {
         return;
@@ -182,15 +167,12 @@ export function useFocusVisible({
       if (hadKeyboardEvent.current || focusTriggersKeyboardModality(e.target)) {
         addFocusVisibleClass(e.target);
       }
-    },
-    [addFocusVisibleClass, focusTriggersKeyboardModality, isValidFocusTarget]
-  );
+    };
 
-  /**
-   * On `blur`, remove the `:focus-visible` styling from the target.
-   */
-  const onBlur = useCallback(
-    e => {
+    /**
+     * On `blur`, remove the `:focus-visible` styling from the target.
+     */
+    const onBlur = e => {
       if (!isValidFocusTarget(e.target)) {
         return;
       }
@@ -211,19 +193,16 @@ export function useFocusVisible({
 
         removeFocusVisibleClass(e.target);
       }
-    },
-    [isFocused, isValidFocusTarget, removeFocusVisibleClass]
-  );
+    };
 
-  /**
-   * When the polfyill first loads, assume the user is in keyboard modality.
-   * If any event is received from a pointing device (e.g. mouse, pointer,
-   * touch), turn off keyboard modality.
-   *
-   * This accounts for situations where focus enters the page from the URL bar.
-   */
-  const onInitialPointerMove = useCallback(
-    e => {
+    /**
+     * When the polfyill first loads, assume the user is in keyboard modality.
+     * If any event is received from a pointing device (e.g. mouse, pointer,
+     * touch), turn off keyboard modality.
+     *
+     * This accounts for situations where focus enters the page from the URL bar.
+     */
+    const onInitialPointerMove = e => {
       if (e.target.nodeName && e.target.nodeName.toLowerCase() === 'html') {
         return;
       }
@@ -231,56 +210,52 @@ export function useFocusVisible({
       hadKeyboardEvent.current = false;
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
       removeInitialPointerMoveListeners();
-    },
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    [removeInitialPointerMoveListeners]
-  );
+    };
 
-  /**
-   * Add a group of listeners to detect usage of any pointing devices.
-   * These listeners will be added when the polyfill first loads, and anytime
-   * the window is blurred, so that they are active when the window regains
-   * focus.
-   */
-  const addInitialPointerMoveListeners = useCallback(() => {
-    relativeDocument.addEventListener('mousemove', onInitialPointerMove);
-    relativeDocument.addEventListener('mousedown', onInitialPointerMove);
-    relativeDocument.addEventListener('mouseup', onInitialPointerMove);
-    relativeDocument.addEventListener('pointermove', onInitialPointerMove);
-    relativeDocument.addEventListener('pointerdown', onInitialPointerMove);
-    relativeDocument.addEventListener('pointerup', onInitialPointerMove);
-    relativeDocument.addEventListener('touchmove', onInitialPointerMove);
-    relativeDocument.addEventListener('touchstart', onInitialPointerMove);
-    relativeDocument.addEventListener('touchend', onInitialPointerMove);
-  }, [onInitialPointerMove, relativeDocument]);
+    /**
+     * Add a group of listeners to detect usage of any pointing devices.
+     * These listeners will be added when the polyfill first loads, and anytime
+     * the window is blurred, so that they are active when the window regains
+     * focus.
+     */
+    const addInitialPointerMoveListeners = () => {
+      relativeDocument.addEventListener('mousemove', onInitialPointerMove);
+      relativeDocument.addEventListener('mousedown', onInitialPointerMove);
+      relativeDocument.addEventListener('mouseup', onInitialPointerMove);
+      relativeDocument.addEventListener('pointermove', onInitialPointerMove);
+      relativeDocument.addEventListener('pointerdown', onInitialPointerMove);
+      relativeDocument.addEventListener('pointerup', onInitialPointerMove);
+      relativeDocument.addEventListener('touchmove', onInitialPointerMove);
+      relativeDocument.addEventListener('touchstart', onInitialPointerMove);
+      relativeDocument.addEventListener('touchend', onInitialPointerMove);
+    };
 
-  const removeInitialPointerMoveListeners = useCallback(() => {
-    relativeDocument.removeEventListener('mousemove', onInitialPointerMove);
-    relativeDocument.removeEventListener('mousedown', onInitialPointerMove);
-    relativeDocument.removeEventListener('mouseup', onInitialPointerMove);
-    relativeDocument.removeEventListener('pointermove', onInitialPointerMove);
-    relativeDocument.removeEventListener('pointerdown', onInitialPointerMove);
-    relativeDocument.removeEventListener('pointerup', onInitialPointerMove);
-    relativeDocument.removeEventListener('touchmove', onInitialPointerMove);
-    relativeDocument.removeEventListener('touchstart', onInitialPointerMove);
-    relativeDocument.removeEventListener('touchend', onInitialPointerMove);
-  }, [onInitialPointerMove, relativeDocument]);
+    const removeInitialPointerMoveListeners = () => {
+      relativeDocument.removeEventListener('mousemove', onInitialPointerMove);
+      relativeDocument.removeEventListener('mousedown', onInitialPointerMove);
+      relativeDocument.removeEventListener('mouseup', onInitialPointerMove);
+      relativeDocument.removeEventListener('pointermove', onInitialPointerMove);
+      relativeDocument.removeEventListener('pointerdown', onInitialPointerMove);
+      relativeDocument.removeEventListener('pointerup', onInitialPointerMove);
+      relativeDocument.removeEventListener('touchmove', onInitialPointerMove);
+      relativeDocument.removeEventListener('touchstart', onInitialPointerMove);
+      relativeDocument.removeEventListener('touchend', onInitialPointerMove);
+    };
 
-  /**
-   * If the user changes tabs, keep track of whether or not the previously
-   * focused element had :focus-visible.
-   */
-  /* istanbul ignore next */
-  const onVisibilityChange = useCallback(() => {
-    /* Unable to mock visibilityState in JSDom environment */
-    if (relativeDocument.visibilityState === 'hidden') {
-      if (hadFocusVisibleRecently.current) {
-        hadKeyboardEvent.current = true;
+    /**
+     * If the user changes tabs, keep track of whether or not the previously
+     * focused element had :focus-visible.
+     */
+    /* istanbul ignore next */
+    const onVisibilityChange = () => {
+      /* Unable to mock visibilityState in JSDom environment */
+      if (relativeDocument.visibilityState === 'hidden') {
+        if (hadFocusVisibleRecently.current) {
+          hadKeyboardEvent.current = true;
+        }
       }
-    }
-  }, [relativeDocument]);
+    };
 
-  useEffect(() => {
     const currentScope = scope.current;
 
     if (!relativeDocument || !currentScope) {
@@ -325,15 +300,5 @@ export function useFocusVisible({
 
       clearTimeout(hadFocusVisibleRecentlyTimeout.current);
     };
-  }, [
-    addInitialPointerMoveListeners,
-    onBlur,
-    onFocus,
-    onKeyDown,
-    onPointerDown,
-    onVisibilityChange,
-    relativeDocument,
-    removeInitialPointerMoveListeners,
-    scope
-  ]);
+  }, [relativeDocument, scope, className, dataAttribute]);
 }


### PR DESCRIPTION
## Description

When migrating this package to TypeScript, I noticed that it was challenging because the document listeners are memoized using `useCallback` when it probably doesn't need to be. Though this isn't a bug, I was finding the code easier to think about without memoization. 

In addition, `removeInitialPointerMoveListeners` is used in a `useCallback` dependency array before it is defined. See [here](https://github.com/zendeskgarden/react-containers/blob/master/packages/focusvisible/src/useFocusVisible.js#L236). This causes TypeScript to complain. This can be resolved with some finagling, but I decided it would be best to propose a refactor which removes the dependency arrays entirely.

Since memoization isn't needed, I removed the calls to `useCallback`, then moved the listeners into the `useEffect`. This side effect only runs when `relativeDocument`, `scope`, `className`, `dataAttribute` changes.

## Detail

The `useFocusVisible` hook behavior remains the same. The performance should remain the same. All tests remain passing ✅.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
