### PR TITLE
fix: update config to handle stories.tsx

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -13,8 +13,8 @@ module.exports = ({ config }) => {
   config.resolve.extensions.push('.ts', '.tsx');
 
   config.module.rules.push({
-    test: /stories.js$/u,
-    loaders: [require.resolve('@storybook/addon-storysource/loader')],
+    test: /stories.tsx$/u,
+    loader: require.resolve('@storybook/source-loader'),
     enforce: 'pre'
   });
 
@@ -39,6 +39,10 @@ module.exports = ({ config }) => {
       {
         loader: 'ts-loader',
         options: {
+          // Temporarily ignore implicit any warnings caused by source-loader.
+          // Ignoring 7005 can be removed when the GitHub issue is resolved.
+          // See: https://github.com/storybookjs/storybook/issues/7829
+          ignoreDiagnostics: [7005],
           configFile: path.resolve(__dirname, 'tsconfig.storybook.json')
         }
       }


### PR DESCRIPTION
## Description

Story source code is not loading and users only see "Loading...".

## Detail

This problem occurred after each Storybook example was migrated to TypeScript. To address this problem I updated the `webpack.config.js` so that `stories.tsx` is picked up rather than `stories.js`.

## Screenshots

**Before**: "Loading..." persists and source code does not load.

<img width="1049" alt="Screen Shot 2019-12-03 at 3 19 37 AM" src="https://user-images.githubusercontent.com/1811365/70032657-e24bca80-157b-11ea-9c37-74682b4d0534.png">

**After**: Source code is loads ✅.

<img width="1048" alt="Screen Shot 2019-12-03 at 3 18 00 AM" src="https://user-images.githubusercontent.com/1811365/70032655-e1b33400-157b-11ea-9584-4c40675d331c.png">


## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
~- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
~- [ ] :guardsman: includes new unit tests~
~- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
