### PR TITLE
fix(pagination): accessibility semantics

### DIFF
--- a/packages/pagination/src/PaginationContainer.spec.tsx
+++ b/packages/pagination/src/PaginationContainer.spec.tsx
@@ -104,7 +104,7 @@ describe('PaginationContainer', () => {
       const { getByTestId } = render(<BasicExample />);
       const container = getByTestId('container');
 
-      expect(container).toHaveAttribute('role', 'listbox');
+      expect(container).toHaveAttribute('role', 'list');
     });
   });
 

--- a/packages/pagination/src/usePagination.ts
+++ b/packages/pagination/src/usePagination.ts
@@ -15,7 +15,8 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface IUsePaginationProps<Item> extends IUseSelectionProps<Item> {}
 
-export interface IGetPageProps<Item> extends IGetItemPropsOptions<Item> {
+export interface IGetPageProps<Item> extends Omit<IGetItemPropsOptions<Item>, 'role'> {
+  role?: string | null;
   page?: number;
   current?: any;
   ariaLabel?: any;
@@ -43,29 +44,34 @@ export function usePagination<Item = any>(
     getItemProps
   } = useSelection(options);
 
-  const getContainerProps = ({ ...props } = {} as any) => {
+  const getContainerProps = ({ role = 'list', ...other } = {} as any) => {
     return {
+      role,
       'data-garden-container-id': 'containers.pagination',
       'data-garden-container-version': PACKAGE_VERSION,
-      ...props
+      ...other
     };
   };
 
-  const getPreviousPageProps = ({ ariaLabel, ...props } = {} as any) => {
+  const getPreviousPageProps = ({ ariaLabel, role = 'listitem', ...props } = {} as any) => {
     return {
+      selectedAriaKey: null,
+      role,
       'aria-label': ariaLabel || 'Previous Page',
       ...props
     };
   };
 
-  const getNextPageProps = ({ ariaLabel, ...props } = {} as any) => {
+  const getNextPageProps = ({ ariaLabel, role = 'listitem', ...props } = {} as any) => {
     return {
+      selectedAriaKey: null,
+      role,
       'aria-label': ariaLabel || 'Next Page',
       ...props
     };
   };
 
-  const getPageProps = ({ ariaLabel, page, current, ...other } = {} as any) => {
+  const getPageProps = ({ ariaLabel, page, current, role = 'listitem', ...other } = {} as any) => {
     let ariaLabelText = `Page ${page}`;
 
     if (current && !ariaLabel) {
@@ -73,8 +79,9 @@ export function usePagination<Item = any>(
     }
 
     return {
+      selectedAriaKey: 'aria-current',
+      role,
       'aria-label': ariaLabel || ariaLabelText,
-      current,
       ...other
     };
   };

--- a/packages/pagination/stories.tsx
+++ b/packages/pagination/stories.tsx
@@ -21,7 +21,7 @@ storiesOf('Pagination Container', module)
       const previousPageRef = useRef(null);
       const nextPageRef = useRef(null);
       const pageRefs = pages.map(() => React.createRef());
-      const [controlledSelectedItem, setSelectedItem] = useState();
+      const [controlledSelectedItem, setSelectedItem] = useState(3);
 
       const {
         selectedItem,
@@ -33,15 +33,18 @@ storiesOf('Pagination Container', module)
       } = usePagination<number | string>({
         selectedItem: controlledSelectedItem,
         onSelect: newSelectedItem => {
-          let modifiedNewSelectedItem = newSelectedItem;
+          let modifiedNewSelectedItem = controlledSelectedItem;
 
-          if (newSelectedItem === 'prev' && controlledSelectedItem > 0) {
-            modifiedNewSelectedItem = controlledSelectedItem - 1;
-          } else if (
-            modifiedNewSelectedItem === 'next' &&
-            controlledSelectedItem < pages.length - 1
-          ) {
-            modifiedNewSelectedItem = controlledSelectedItem + 1;
+          if (newSelectedItem === 'prev') {
+            if (controlledSelectedItem > 0) {
+              modifiedNewSelectedItem = controlledSelectedItem - 1;
+            }
+          } else if (newSelectedItem === 'next') {
+            if (controlledSelectedItem < pages.length - 1) {
+              modifiedNewSelectedItem = controlledSelectedItem + 1;
+            }
+          } else {
+            modifiedNewSelectedItem = newSelectedItem as number;
           }
 
           if (modifiedNewSelectedItem !== controlledSelectedItem) {
@@ -51,17 +54,25 @@ storiesOf('Pagination Container', module)
       });
 
       return (
-        <nav>
+        <nav aria-label="Pagination (Hook)">
           <ul
             {...getContainerProps({
+              role: null,
               style: { display: 'flex' }
             })}
           >
             <li
               {...getPreviousPageProps({
+                role: null,
                 item: 'prev',
+                'aria-disabled': selectedItem === 0,
                 focusRef: previousPageRef,
-                key: 'previous-page'
+                key: 'previous-page',
+                style: {
+                  color: selectedItem === 0 ? 'gray' : undefined,
+                  cursor: 'pointer',
+                  userSelect: 'none'
+                }
               })}
             >
               Prev
@@ -70,14 +81,18 @@ storiesOf('Pagination Container', module)
               return (
                 <li
                   {...getPageProps({
+                    role: null,
                     page: index,
+                    current: index === selectedItem,
                     item: index,
                     focusRef: pageRefs[index],
                     key: `page-${index}`,
                     style: {
                       outline: index === focusedItem ? '3px solid red' : undefined,
                       background: index === selectedItem ? 'gray' : undefined,
-                      padding: '0 6px'
+                      padding: '0 6px',
+                      cursor: 'pointer',
+                      userSelect: 'none'
                     }
                   })}
                 >
@@ -87,9 +102,16 @@ storiesOf('Pagination Container', module)
             })}
             <li
               {...getNextPageProps({
+                role: null,
                 item: 'next',
+                'aria-disabled': selectedItem === pages.length - 1,
                 focusRef: nextPageRef,
-                key: 'next-page'
+                key: 'next-page',
+                style: {
+                  color: selectedItem === pages.length - 1 ? 'gray' : undefined,
+                  cursor: 'pointer',
+                  userSelect: 'none'
+                }
               })}
             >
               Next
@@ -103,7 +125,7 @@ storiesOf('Pagination Container', module)
   })
   .add('PaginationContainer', () => {
     const Pagination = () => {
-      const [controlledSelectedItem, setSelectedItem] = useState();
+      const [controlledSelectedItem, setSelectedItem] = useState(3);
       const previousPageRef = useRef(null);
       const nextPageRef = useRef(null);
       const pageRefs = pages.map(() => React.createRef());
@@ -112,15 +134,18 @@ storiesOf('Pagination Container', module)
         <PaginationContainer
           selectedItem={controlledSelectedItem}
           onSelect={newSelectedItem => {
-            let modifiedNewSelectedItem = newSelectedItem;
+            let modifiedNewSelectedItem = controlledSelectedItem;
 
-            if (newSelectedItem === 'prev' && controlledSelectedItem > 0) {
-              modifiedNewSelectedItem = controlledSelectedItem - 1;
-            } else if (
-              modifiedNewSelectedItem === 'next' &&
-              controlledSelectedItem < pages.length - 1
-            ) {
-              modifiedNewSelectedItem = controlledSelectedItem + 1;
+            if (newSelectedItem === 'prev') {
+              if (controlledSelectedItem > 0) {
+                modifiedNewSelectedItem = controlledSelectedItem - 1;
+              }
+            } else if (newSelectedItem === 'next') {
+              if (controlledSelectedItem < pages.length - 1) {
+                modifiedNewSelectedItem = controlledSelectedItem + 1;
+              }
+            } else {
+              modifiedNewSelectedItem = newSelectedItem;
             }
 
             if (modifiedNewSelectedItem !== controlledSelectedItem) {
@@ -137,23 +162,34 @@ storiesOf('Pagination Container', module)
             getPageProps
           }) => {
             return (
-              <nav {...getContainerProps({ role: null })}>
-                <ul style={{ display: 'flex' }}>
-                  <li
+              <nav aria-label="Pagination (Container)">
+                <div
+                  {...getContainerProps({
+                    style: { display: 'flex' }
+                  })}
+                >
+                  <div
                     {...getPreviousPageProps({
                       item: 'prev',
+                      'aria-disabled': selectedItem === 0,
                       focusRef: previousPageRef,
                       ref: previousPageRef,
-                      key: 'previous-page'
+                      key: 'previous-page',
+                      style: {
+                        color: selectedItem === 0 ? 'gray' : undefined,
+                        cursor: 'pointer',
+                        userSelect: 'none'
+                      }
                     })}
                   >
                     Prev
-                  </li>
+                  </div>
                   {pages.map((page, index) => {
                     return (
-                      <li
+                      <div
                         {...getPageProps({
                           page: index,
+                          current: index === selectedItem,
                           item: index,
                           focusRef: pageRefs[index],
                           ref: pageRefs[index],
@@ -161,25 +197,33 @@ storiesOf('Pagination Container', module)
                           style: {
                             outline: index === focusedItem ? '3px solid red' : undefined,
                             background: index === selectedItem ? 'gray' : undefined,
-                            padding: '0 6px'
+                            padding: '0 6px',
+                            cursor: 'pointer',
+                            userSelect: 'none'
                           }
                         })}
                       >
                         {index + 1}
-                      </li>
+                      </div>
                     );
                   })}
-                  <li
+                  <div
                     {...getNextPageProps({
                       item: 'next',
+                      'aria-disabled': selectedItem === pages.length - 1,
                       focusRef: nextPageRef,
                       ref: nextPageRef,
-                      key: 'next-page'
+                      key: 'next-page',
+                      style: {
+                        color: selectedItem === pages.length - 1 ? 'gray' : undefined,
+                        cursor: 'pointer',
+                        userSelect: 'none'
+                      }
                     })}
                   >
                     Next
-                  </li>
-                </ul>
+                  </div>
+                </div>
               </nav>
             );
           }}

--- a/packages/selection/src/useSelection.ts
+++ b/packages/selection/src/useSelection.ts
@@ -289,7 +289,7 @@ export function useSelection<Item = any>({
     return {
       role,
       tabIndex,
-      [selectedAriaKey]: isSelected,
+      [selectedAriaKey]: selectedAriaKey ? isSelected : undefined,
       [refKey]: focusRef,
       onFocus: composeEventHandlers(onFocusCallback, () => {
         dispatch({ type: 'FOCUS', payload: item, focusedItem, onFocus });


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

The a11y defaults from `useSelection` applied to pagination are incorrect. A pagination control is not a `listbox` with `option` elements. Rather it should be a `list` with `listitem` elements. The current page should be identified by `aria-current` rather than `aria-selected`.

The changes fix axe errors currently seen in the examples.

## Detail

- Pagination container updated to have a role of `list`
- All page items updated to have a role of `listitem`
- Current page identified by `aria-current` (next and previous items are excluded from applying the `ariaSelectedKey`)
- Storybook updated with improved examples:
  - `<nav>` labelled to fix axe errors
  - There is a current page selected by default
  - next/prev page navigation does not run off the ends of the list
  - `aria-disabled` applied to prev/next navigation on first/last page
  - Container (non-hook) example updated with non-semantic (`<div>`) html in order to demonstrate that the container applies expected a11y semantics against either semantic or non-semantic markup.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
