### PR TITLE
fix(build): apply babel to all bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@typescript-eslint/parser": "2.19.0",
     "@zendeskgarden/css-variables": "6.4.3",
     "@zendeskgarden/eslint-config": "11.0.1",
+    "acorn-jsx": "5.1.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.3",
     "babel-jest": "25.1.0",

--- a/packages/accordion/.size-snapshot.json
+++ b/packages/accordion/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 5816,
-    "minified": 2963,
-    "gzipped": 1378
+    "bundled": 9239,
+    "minified": 5029,
+    "gzipped": 1821
   },
   "dist/index.esm.js": {
-    "bundled": 5540,
-    "minified": 2734,
-    "gzipped": 1285,
+    "bundled": 8902,
+    "minified": 4738,
+    "gzipped": 1740,
     "treeshaked": {
       "rollup": {
-        "code": 143,
-        "import_statements": 98
+        "code": 4078,
+        "import_statements": 211
       },
       "webpack": {
-        "code": 1173
+        "code": 5224
       }
     }
   }

--- a/packages/breadcrumb/.size-snapshot.json
+++ b/packages/breadcrumb/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 1281,
-    "minified": 726,
-    "gzipped": 367
+    "bundled": 3832,
+    "minified": 2190,
+    "gzipped": 812
   },
   "dist/index.esm.js": {
-    "bundled": 1023,
-    "minified": 513,
-    "gzipped": 274,
+    "bundled": 3574,
+    "minified": 1977,
+    "gzipped": 738,
     "treeshaked": {
       "rollup": {
-        "code": 40,
+        "code": 1632,
         "import_statements": 26
       },
       "webpack": {
-        "code": 1036
+        "code": 2628
       }
     }
   }

--- a/packages/buttongroup/.size-snapshot.json
+++ b/packages/buttongroup/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 17012,
-    "minified": 8549,
-    "gzipped": 2796
+    "bundled": 4891,
+    "minified": 2717,
+    "gzipped": 955
   },
   "dist/index.esm.js": {
-    "bundled": 16751,
-    "minified": 8333,
-    "gzipped": 2727,
+    "bundled": 4607,
+    "minified": 2479,
+    "gzipped": 882,
     "treeshaked": {
       "rollup": {
-        "code": 6683,
-        "import_statements": 76
+        "code": 132,
+        "import_statements": 92
       },
       "webpack": {
-        "code": 8019
+        "code": 1146
       }
     }
   }

--- a/packages/field/.size-snapshot.json
+++ b/packages/field/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 1825,
-    "minified": 950,
-    "gzipped": 491
+    "bundled": 5979,
+    "minified": 3360,
+    "gzipped": 1259
   },
   "dist/index.esm.js": {
-    "bundled": 1569,
-    "minified": 741,
-    "gzipped": 391,
+    "bundled": 5723,
+    "minified": 3151,
+    "gzipped": 1180,
     "treeshaked": {
       "rollup": {
-        "code": 620,
+        "code": 2657,
         "import_statements": 98
       },
       "webpack": {
-        "code": 1684
+        "code": 3721
       }
     }
   }

--- a/packages/focusjail/.size-snapshot.json
+++ b/packages/focusjail/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 8226,
-    "minified": 4685,
-    "gzipped": 1967
+    "bundled": 7441,
+    "minified": 4091,
+    "gzipped": 1596
   },
   "dist/index.esm.js": {
-    "bundled": 7979,
-    "minified": 4481,
-    "gzipped": 1897,
+    "bundled": 7150,
+    "minified": 3848,
+    "gzipped": 1526,
     "treeshaked": {
       "rollup": {
-        "code": 1777,
-        "import_statements": 106
+        "code": 3235,
+        "import_statements": 219
       },
       "webpack": {
-        "code": 2748
+        "code": 4366
       }
     }
   }

--- a/packages/focusvisible/.size-snapshot.json
+++ b/packages/focusvisible/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 8205,
-    "minified": 3275,
-    "gzipped": 1167
+    "bundled": 10301,
+    "minified": 4764,
+    "gzipped": 1612
   },
   "dist/index.esm.js": {
-    "bundled": 7926,
-    "minified": 3041,
-    "gzipped": 1085,
+    "bundled": 10022,
+    "minified": 4534,
+    "gzipped": 1551,
     "treeshaked": {
       "rollup": {
-        "code": 113,
+        "code": 4126,
         "import_statements": 72
       },
       "webpack": {
-        "code": 1116
+        "code": 5205
       }
     }
   }

--- a/packages/keyboardfocus/.size-snapshot.json
+++ b/packages/keyboardfocus/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 2909,
-    "minified": 1484,
-    "gzipped": 688
+    "bundled": 6246,
+    "minified": 3488,
+    "gzipped": 1332
   },
   "dist/index.esm.js": {
-    "bundled": 2644,
-    "minified": 1263,
-    "gzipped": 602,
+    "bundled": 5889,
+    "minified": 3176,
+    "gzipped": 1252,
     "treeshaked": {
       "rollup": {
-        "code": 984,
-        "import_statements": 86
+        "code": 2621,
+        "import_statements": 160
       },
       "webpack": {
-        "code": 2034
+        "code": 3820
       }
     }
   }

--- a/packages/modal/.size-snapshot.json
+++ b/packages/modal/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 15213,
-    "minified": 8743,
-    "gzipped": 3051
+    "bundled": 7957,
+    "minified": 4607,
+    "gzipped": 1575
   },
   "dist/index.esm.js": {
-    "bundled": 14962,
-    "minified": 8536,
-    "gzipped": 2989,
+    "bundled": 7596,
+    "minified": 4294,
+    "gzipped": 1492,
     "treeshaked": {
       "rollup": {
-        "code": 1876,
-        "import_statements": 145
+        "code": 3594,
+        "import_statements": 253
       },
       "webpack": {
-        "code": 2873
+        "code": 1342
       }
     }
   }

--- a/packages/pagination/.size-snapshot.json
+++ b/packages/pagination/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 17956,
-    "minified": 8952,
-    "gzipped": 2904
+    "bundled": 6336,
+    "minified": 3453,
+    "gzipped": 1080
   },
   "dist/index.esm.js": {
-    "bundled": 17697,
-    "minified": 8738,
-    "gzipped": 2836,
+    "bundled": 6054,
+    "minified": 3217,
+    "gzipped": 1006,
     "treeshaked": {
       "rollup": {
-        "code": 7094,
-        "import_statements": 76
+        "code": 132,
+        "import_statements": 92
       },
       "webpack": {
-        "code": 8430
+        "code": 1146
       }
     }
   }

--- a/packages/schedule/.size-snapshot.json
+++ b/packages/schedule/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 2074,
-    "minified": 1002,
-    "gzipped": 508
+    "bundled": 4480,
+    "minified": 2362,
+    "gzipped": 1052
   },
   "dist/index.esm.js": {
-    "bundled": 1823,
-    "minified": 796,
-    "gzipped": 414,
+    "bundled": 4229,
+    "minified": 2156,
+    "gzipped": 972,
     "treeshaked": {
       "rollup": {
-        "code": 630,
+        "code": 1740,
         "import_statements": 80
       },
       "webpack": {
-        "code": 1685
+        "code": 2795
       }
     }
   }

--- a/packages/selection/.size-snapshot.json
+++ b/packages/selection/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 11033,
-    "minified": 5036,
-    "gzipped": 1822
+    "bundled": 14970,
+    "minified": 7464,
+    "gzipped": 2339
   },
   "dist/index.esm.js": {
-    "bundled": 10776,
-    "minified": 4824,
-    "gzipped": 1732,
+    "bundled": 14424,
+    "minified": 6962,
+    "gzipped": 2261,
     "treeshaked": {
       "rollup": {
-        "code": 4058,
-        "import_statements": 76
+        "code": 5983,
+        "import_statements": 189
       },
       "webpack": {
-        "code": 5398
+        "code": 7326
       }
     }
   }

--- a/packages/tabs/.size-snapshot.json
+++ b/packages/tabs/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 18209,
-    "minified": 9172,
-    "gzipped": 3057
+    "bundled": 7490,
+    "minified": 4384,
+    "gzipped": 1565
   },
   "dist/index.esm.js": {
-    "bundled": 17960,
-    "minified": 8968,
-    "gzipped": 2986,
+    "bundled": 7212,
+    "minified": 4154,
+    "gzipped": 1489,
     "treeshaked": {
       "rollup": {
-        "code": 273,
-        "import_statements": 129
+        "code": 3514,
+        "import_statements": 164
       },
       "webpack": {
-        "code": 1290
+        "code": 1250
       }
     }
   }

--- a/packages/tooltip/.size-snapshot.json
+++ b/packages/tooltip/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 4513,
-    "minified": 2336,
-    "gzipped": 1104
+    "bundled": 8440,
+    "minified": 4709,
+    "gzipped": 1615
   },
   "dist/index.esm.js": {
-    "bundled": 4248,
-    "minified": 2116,
-    "gzipped": 1011,
+    "bundled": 8037,
+    "minified": 4351,
+    "gzipped": 1527,
     "treeshaked": {
       "rollup": {
-        "code": 1512,
-        "import_statements": 125
+        "code": 3681,
+        "import_statements": 214
       },
       "webpack": {
-        "code": 2619
+        "code": 4990
       }
     }
   }

--- a/packages/utilities/.size-snapshot.json
+++ b/packages/utilities/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 1890,
-    "minified": 1068,
-    "gzipped": 606
+    "bundled": 2478,
+    "minified": 1518,
+    "gzipped": 733
   },
   "dist/index.esm.js": {
-    "bundled": 1673,
-    "minified": 867,
-    "gzipped": 536,
+    "bundled": 2261,
+    "minified": 1317,
+    "gzipped": 664,
     "treeshaked": {
       "rollup": {
         "code": 14,

--- a/utils/scripts/build.sh
+++ b/utils/scripts/build.sh
@@ -2,4 +2,4 @@
 set -x
 set -e
 
-rollup -c ../../utils/build/rollup.config.js
+NODE_ENV=production rollup -c ../../utils/build/rollup.config.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -4146,7 +4146,7 @@ acorn-globals@^4.3.2:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
 
-acorn-jsx@^5.1.0:
+acorn-jsx@5.1.0, acorn-jsx@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.1.0.tgz#294adb71b57398b0680015f0a38c563ee1db5384"
   integrity sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==


### PR DESCRIPTION
## Description

During the rollup migration babel wasn't recognizing `ts` and `tsx` files. This fix ensures babel is ran on all files.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
