### PR TITLE
feat(useFocusJail): cache activeElement & restore focus

### DIFF
--- a/packages/focusjail/.size-snapshot.json
+++ b/packages/focusjail/.size-snapshot.json
@@ -1,17 +1,17 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 5024,
-    "minified": 2524,
-    "gzipped": 1129
+    "bundled": 5592,
+    "minified": 2711,
+    "gzipped": 1195
   },
   "dist/index.esm.js": {
-    "bundled": 4733,
-    "minified": 2281,
-    "gzipped": 1052,
+    "bundled": 5303,
+    "minified": 2469,
+    "gzipped": 1117,
     "treeshaked": {
       "rollup": {
-        "code": 270,
-        "import_statements": 219
+        "code": 282,
+        "import_statements": 231
       },
       "webpack": {
         "code": 1254


### PR DESCRIPTION
## Description

In the Modal Storybook example, [keyboard focus is not returned](https://www.w3.org/TR/wai-aria-practices/#dialog_modal#h-note-7) to the trigger element when a user closes a modal. This pull request proposes that the `useFocusJail` hook be updated so that when it unmounts, it is able to return keyboard focus to a trigger element if one was used to render it.

## Detail

Note this proposal does not completely abstract away keyboard focus management for end-users. In many cases, feature developers will still need to manage keyboard focus when a modal (which implements focus jail) is dismissed. 

## Demo

Here is a [demo](https://restore-focus.netlify.com/storybook/?path=/story/modal-container--usemodal) for `useModal` Storybook which leverages the updated `useFocusJail` hook.

## Screenshot

![2020-02-14 09 35 39](https://user-images.githubusercontent.com/1811365/74554059-80a9c400-4f0d-11ea-876e-a97cc2fcf8ae.gif)

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11

Closes #159 