### PR TITLE
fix(focusvisible): allow server side rendering

### DIFF
--- a/packages/focusvisible/.size-snapshot.json
+++ b/packages/focusvisible/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 8854,
-    "minified": 3897,
-    "gzipped": 1431
+    "bundled": 8707,
+    "minified": 3903,
+    "gzipped": 1424
   },
   "dist/index.esm.js": {
-    "bundled": 8575,
-    "minified": 3667,
-    "gzipped": 1360,
+    "bundled": 8428,
+    "minified": 3673,
+    "gzipped": 1352,
     "treeshaked": {
       "rollup": {
-        "code": 3359,
+        "code": 3365,
         "import_statements": 72
       },
       "webpack": {
-        "code": 4438
+        "code": 4444
       }
     }
   }


### PR DESCRIPTION
## Description

The current `useFocusVisible` hook is unable to be used in server side rendering environments. The solution to this is to move the `document` usage from a default variable assignment within a `useEffect` hook.

I have tested this locally with our `ThemeProvider` usage to ensure this now works in SSR environments.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
