### PR TITLE
feat(modal): allow optional restore focus

### DIFF
--- a/packages/modal/.size-snapshot.json
+++ b/packages/modal/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 5486,
-    "minified": 2848,
-    "gzipped": 1072
+    "bundled": 5558,
+    "minified": 2880,
+    "gzipped": 1087
   },
   "dist/index.esm.js": {
-    "bundled": 5125,
-    "minified": 2535,
-    "gzipped": 979,
+    "bundled": 5197,
+    "minified": 2567,
+    "gzipped": 993,
     "treeshaked": {
       "rollup": {
         "code": 313,

--- a/packages/modal/src/useModal.ts
+++ b/packages/modal/src/useModal.ts
@@ -15,6 +15,7 @@ export interface IUseModalProps {
   modalRef: React.RefObject<HTMLElement>;
   id?: string;
   focusOnMount?: boolean;
+  restoreFocus?: boolean;
   environment?: Document;
 }
 
@@ -28,7 +29,14 @@ export interface IUseModalReturnValue {
 }
 
 export function useModal(
-  { onClose, modalRef, id: _id, focusOnMount, environment }: IUseModalProps = {} as any
+  {
+    onClose,
+    modalRef,
+    id: _id,
+    focusOnMount,
+    restoreFocus,
+    environment
+  }: IUseModalProps = {} as any
 ): IUseModalReturnValue {
   const seed = useUIDSeed();
   const [idPrefix] = useState(_id || seed(`modal_${PACKAGE_VERSION}`));
@@ -97,7 +105,12 @@ export function useModal(
     };
   };
 
-  const { getContainerProps } = useFocusJail({ containerRef: modalRef, focusOnMount, environment });
+  const { getContainerProps } = useFocusJail({
+    containerRef: modalRef,
+    focusOnMount,
+    restoreFocus,
+    environment
+  });
 
   return {
     getBackdropProps,

--- a/packages/modal/stories.tsx
+++ b/packages/modal/stories.tsx
@@ -8,7 +8,7 @@
 import React, { useState, useRef } from 'react';
 
 import { storiesOf } from '@storybook/react';
-import { withKnobs } from '@storybook/addon-knobs';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
 
 import { ModalContainer, useModal } from './src';
 
@@ -17,6 +17,7 @@ storiesOf('Modal Container', module)
   .add('useModal', () => {
     const Modal = () => {
       const [isModalVisible, setModalVisibility] = useState(false);
+      const restoreFocus = boolean('restoreFocus', true);
       const modalRef = useRef(null);
       const {
         getBackdropProps,
@@ -24,7 +25,7 @@ storiesOf('Modal Container', module)
         getTitleProps,
         getContentProps,
         getCloseProps
-      } = useModal({ onClose: () => setModalVisibility(false), modalRef });
+      } = useModal({ onClose: () => setModalVisibility(false), modalRef, restoreFocus });
 
       return (
         <>


### PR DESCRIPTION
## Description

This PR adds a `restoreFocus` argument to the `useModal` hook to allow consumers to have the option of restoring focus. Once this PR is merged, the [`Modal` component](https://github.com/zendeskgarden/react-components/blob/master/packages/modals/src/elements/Modal.tsx#L100) will be updated accordingly.

## Demo

The demo for this PR can be found here: https://restore-focus-option.netlify.com/storybook/?path=/story/modal-container--usemodal

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
