### PR TITLE
fix(utils): add typing to getControlledValue

### DIFF
--- a/packages/accordion/src/useAccordion.ts
+++ b/packages/accordion/src/useAccordion.ts
@@ -61,7 +61,7 @@ export function useAccordion({
   const PANEL_ID = `${prefix}--panel`;
   const [expandedState, setExpandedState] = useState<number[]>(expandedSections || []);
 
-  const controlledExpandedState = getControlledValue(onChange && expandedSections, expandedState);
+  const controlledExpandedState = getControlledValue(onChange && expandedSections, expandedState)!;
 
   const [disabledState, setDisabledState] = useState(collapsible ? [] : controlledExpandedState);
 

--- a/packages/utilities/src/utils/getControlledValue.ts
+++ b/packages/utilities/src/utils/getControlledValue.ts
@@ -8,7 +8,7 @@
 /**
  * Utility to determine controlled vs uncontrolled values
  */
-export function getControlledValue(...values: any[]) {
+export function getControlledValue<T>(...values: T[]): T | undefined {
   for (const value of values) {
     if (value !== undefined) {
       return value;


### PR DESCRIPTION
## Description

This PR updates `getControlledValue` to take a generic and gives consumers TypeScript support.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
