### PR TITLE
feat(useAccordion): update accordion hook 

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -7,5 +7,6 @@
 
 import '@storybook/addons';
 import '@storybook/addon-knobs/register';
+import '@storybook/addon-actions/register';
 import '@storybook/addon-storysource/register';
 import '@storybook/addon-a11y/register';

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@rollup/plugin-node-resolve": "7.1.1",
     "@rollup/plugin-replace": "2.3.1",
     "@storybook/addon-a11y": "5.3.14",
+    "@storybook/addon-actions": "5.3.17",
     "@storybook/addon-centered": "5.3.14",
     "@storybook/addon-knobs": "5.3.14",
     "@storybook/addon-storysource": "5.3.14",

--- a/packages/accordion/.size-snapshot.json
+++ b/packages/accordion/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 7204,
-    "minified": 3479,
-    "gzipped": 1389
+    "bundled": 7462,
+    "minified": 3513,
+    "gzipped": 1405
   },
   "dist/index.esm.js": {
-    "bundled": 6873,
-    "minified": 3194,
-    "gzipped": 1300,
+    "bundled": 7131,
+    "minified": 3228,
+    "gzipped": 1317,
     "treeshaked": {
       "rollup": {
-        "code": 2774,
+        "code": 2808,
         "import_statements": 211
       },
       "webpack": {
-        "code": 3941
+        "code": 3975
       }
     }
   }

--- a/packages/accordion/.size-snapshot.json
+++ b/packages/accordion/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 7226,
-    "minified": 3487,
-    "gzipped": 1391
+    "bundled": 7204,
+    "minified": 3479,
+    "gzipped": 1389
   },
   "dist/index.esm.js": {
-    "bundled": 6895,
-    "minified": 3202,
-    "gzipped": 1304,
+    "bundled": 6873,
+    "minified": 3194,
+    "gzipped": 1300,
     "treeshaked": {
       "rollup": {
-        "code": 2782,
+        "code": 2774,
         "import_statements": 211
       },
       "webpack": {
-        "code": 3949
+        "code": 3941
       }
     }
   }

--- a/packages/accordion/.size-snapshot.json
+++ b/packages/accordion/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 6615,
-    "minified": 3252,
-    "gzipped": 1335
+    "bundled": 7151,
+    "minified": 3451,
+    "gzipped": 1371
   },
   "dist/index.esm.js": {
-    "bundled": 6278,
-    "minified": 2961,
-    "gzipped": 1244,
+    "bundled": 6820,
+    "minified": 3166,
+    "gzipped": 1283,
     "treeshaked": {
       "rollup": {
-        "code": 2580,
+        "code": 2746,
         "import_statements": 211
       },
       "webpack": {
-        "code": 3754
+        "code": 3913
       }
     }
   }

--- a/packages/accordion/.size-snapshot.json
+++ b/packages/accordion/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 7151,
-    "minified": 3451,
-    "gzipped": 1371
+    "bundled": 7226,
+    "minified": 3487,
+    "gzipped": 1391
   },
   "dist/index.esm.js": {
-    "bundled": 6820,
-    "minified": 3166,
-    "gzipped": 1283,
+    "bundled": 6895,
+    "minified": 3202,
+    "gzipped": 1304,
     "treeshaked": {
       "rollup": {
-        "code": 2746,
+        "code": 2782,
         "import_statements": 211
       },
       "webpack": {
-        "code": 3913
+        "code": 3949
       }
     }
   }

--- a/packages/accordion/src/AccordionContainer.spec.tsx
+++ b/packages/accordion/src/AccordionContainer.spec.tsx
@@ -18,15 +18,15 @@ describe('AccordionContainer', () => {
   const BasicExample = ({
     expandedSections,
     onChange,
-    isExpandable,
-    isCollapsible,
+    expandable,
+    collapsible,
     defaultExpandedSections
   }: IUseAccordionProps = {}) => (
     <AccordionContainer
       idPrefix={CONTAINER_ID_PREFIX}
       expandedSections={expandedSections}
-      isExpandable={isExpandable}
-      isCollapsible={isCollapsible}
+      expandable={expandable}
+      collapsible={collapsible}
       onChange={onChange}
       defaultExpandedSections={defaultExpandedSections}
     >
@@ -364,7 +364,7 @@ describe('AccordionContainer', () => {
 
   describe('is not expandable (but is collapsible)', () => {
     it('renders with one section expanded', () => {
-      const { getAllByTestId } = render(<BasicExample isCollapsible />);
+      const { getAllByTestId } = render(<BasicExample collapsible />);
 
       const triggers = getAllByTestId('trigger');
       const panels = getAllByTestId('panel');
@@ -379,7 +379,7 @@ describe('AccordionContainer', () => {
     });
 
     it('only expands one section at a time', () => {
-      const { getAllByTestId } = render(<BasicExample isCollapsible />);
+      const { getAllByTestId } = render(<BasicExample collapsible />);
 
       const triggers = getAllByTestId('trigger');
       const panels = getAllByTestId('panel');
@@ -395,7 +395,7 @@ describe('AccordionContainer', () => {
     });
 
     it('can collapse the expanded section', () => {
-      const { getAllByTestId } = render(<BasicExample isCollapsible />);
+      const { getAllByTestId } = render(<BasicExample collapsible />);
 
       const triggers = getAllByTestId('trigger');
       const panels = getAllByTestId('panel');
@@ -456,7 +456,7 @@ describe('AccordionContainer', () => {
     });
 
     it('expands panels, at least one panel must be expanded at all times', () => {
-      const { getAllByTestId } = render(<BasicExample isExpandable />);
+      const { getAllByTestId } = render(<BasicExample expandable />);
 
       const triggers = getAllByTestId('trigger');
       const panels = getAllByTestId('panel');
@@ -531,7 +531,7 @@ describe('AccordionContainer', () => {
   describe('is expandable and collapsible', () => {
     it('can expand and collapse all panels', () => {
       const { getAllByText } = render(
-        <BasicExample defaultExpandedSections={[]} isCollapsible isExpandable />
+        <BasicExample defaultExpandedSections={[]} collapsible expandable />
       );
 
       const triggers = getAllByText('Trigger');

--- a/packages/accordion/src/AccordionContainer.spec.tsx
+++ b/packages/accordion/src/AccordionContainer.spec.tsx
@@ -473,9 +473,15 @@ describe('AccordionContainer', () => {
 
       fireEvent.click(triggers[1]);
 
-      expect(triggers[1]).toHaveAttribute('aria-disabled', 'true');
+      expect(triggers[1]).toHaveAttribute('aria-disabled', 'false');
       expect(triggers[1]).toHaveAttribute('aria-expanded', 'true');
       expect(panels[1]).toHaveAttribute('aria-hidden', 'false');
+
+      fireEvent.click(triggers[2]);
+
+      expect(triggers[2]).toHaveAttribute('aria-disabled', 'false');
+      expect(triggers[2]).toHaveAttribute('aria-expanded', 'true');
+      expect(panels[2]).toHaveAttribute('aria-hidden', 'false');
     });
   });
 

--- a/packages/accordion/src/AccordionContainer.spec.tsx
+++ b/packages/accordion/src/AccordionContainer.spec.tsx
@@ -9,40 +9,9 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { KEY_CODES } from '@zendeskgarden/container-utilities';
 import { AccordionContainer } from './AccordionContainer';
-import { IUseAccordionReturnValue, IUseAccordionProps } from './useAccordion';
+import { IUseAccordionProps } from './useAccordion';
 
 describe('AccordionContainer', () => {
-  it('renders with expected return value', () => {
-    const { getByText } = render(
-      <AccordionContainer>
-        {({ expandedSections, getPanelProps }: IUseAccordionReturnValue) => {
-          const index = 0;
-
-          return (
-            <>
-              <h1>
-                <button>Trigger</button>
-              </h1>
-              <section
-                data-test-id="test"
-                {...getPanelProps({
-                  index,
-                  role: null,
-                  hidden: (expandedSections as number[]).includes(index) === false
-                })}
-              >
-                Panel Content
-              </section>
-            </>
-          );
-        }}
-      </AccordionContainer>
-    );
-    const test = getByText('Panel Content');
-
-    expect(test).not.toHaveAttribute('hidden');
-  });
-
   const sections = Array(3).fill(undefined);
   const CONTAINER_ID_PREFIX = 'test';
 
@@ -67,9 +36,9 @@ describe('AccordionContainer', () => {
             return (
               <div key={index}>
                 <div {...getHeaderProps({ ariaLevel: 1, 'data-test-id': 'header' })}>
-                  <button {...getTriggerProps({ index, 'data-test-id': 'trigger' })}>
+                  <div {...getTriggerProps({ index, role: 'button', 'data-test-id': 'trigger' })}>
                     Trigger
-                  </button>
+                  </div>
                 </div>
                 <div {...getPanelProps({ index, 'data-test-id': 'panel' })}>Panel</div>
               </div>

--- a/packages/accordion/src/AccordionContainer.ts
+++ b/packages/accordion/src/AccordionContainer.ts
@@ -23,8 +23,9 @@ export const AccordionContainer: React.FunctionComponent<IAccordionContainerProp
 AccordionContainer.propTypes = {
   children: PropTypes.func,
   render: PropTypes.func,
-  expandedSections: PropTypes.array,
-  expandable: PropTypes.bool,
-  collapsible: PropTypes.bool,
+  expandedSections: PropTypes.oneOfType([PropTypes.array, PropTypes.number]),
+  defaultExpandedSections: PropTypes.oneOfType([PropTypes.array, PropTypes.number]),
+  isExpandable: PropTypes.bool,
+  isCollapsible: PropTypes.bool,
   idPrefix: PropTypes.string
 };

--- a/packages/accordion/src/AccordionContainer.ts
+++ b/packages/accordion/src/AccordionContainer.ts
@@ -25,7 +25,7 @@ AccordionContainer.propTypes = {
   render: PropTypes.func,
   expandedSections: PropTypes.oneOfType([PropTypes.array, PropTypes.number]),
   defaultExpandedSections: PropTypes.oneOfType([PropTypes.array, PropTypes.number]),
-  isExpandable: PropTypes.bool,
-  isCollapsible: PropTypes.bool,
+  expandable: PropTypes.bool,
+  collapsible: PropTypes.bool,
   idPrefix: PropTypes.string
 };

--- a/packages/accordion/src/useAccordion.ts
+++ b/packages/accordion/src/useAccordion.ts
@@ -18,8 +18,8 @@ export interface IUseAccordionProps {
   expandedSections?: number | number[];
   defaultExpandedSections?: number | number[];
   onChange?: (index: number) => any;
-  isCollapsible?: boolean;
-  isExpandable?: boolean;
+  collapsible?: boolean;
+  expandable?: boolean;
 }
 
 interface IHeaderProps extends HTMLProps<any> {
@@ -52,8 +52,8 @@ export function useAccordion({
   expandedSections,
   defaultExpandedSections = 0,
   onChange,
-  isCollapsible,
-  isExpandable
+  collapsible,
+  expandable
 }: IUseAccordionProps = {}): IUseAccordionReturnValue {
   const isControlled = expandedSections !== null && expandedSections !== undefined;
   const seed = useUIDSeed();
@@ -77,19 +77,19 @@ export function useAccordion({
       return undefined;
     }
 
-    if (isExpandable && isCollapsible) {
+    if (expandable && collapsible) {
       if (expandedState.includes(index)) {
         setExpandedState(expandedState.filter((n: number) => n !== index));
       } else {
         setExpandedState([...expandedState, index]);
       }
-    } else if (isExpandable) {
+    } else if (expandable) {
       if (!expandedState.includes(index)) {
         setExpandedState([...expandedState, index]);
       } else if (expandedState.length > 1) {
         setExpandedState(expandedState.filter((n: number) => n !== index));
       }
-    } else if (isCollapsible) {
+    } else if (collapsible) {
       if (expandedState[0] === index) {
         setExpandedState([]);
       } else {
@@ -141,7 +141,7 @@ export function useAccordion({
       tabIndex,
       disabled,
       'aria-controls': `${PANEL_ID}:${index}`,
-      'aria-disabled': isCollapsible ? 'false' : isExpanded,
+      'aria-disabled': collapsible ? 'false' : isExpanded,
       'aria-expanded': isExpanded,
       onClick: composeEventHandlers(props.onClick, () => {
         if (disabled !== false) {

--- a/packages/accordion/src/useAccordion.ts
+++ b/packages/accordion/src/useAccordion.ts
@@ -135,13 +135,27 @@ export function useAccordion({
       ? controlledExpandedSections.includes(index)
       : controlledExpandedSections === index;
 
+    let ariaDisabled;
+
+    if (collapsible) {
+      ariaDisabled = 'false';
+    } else if (isExpanded) {
+      if (expandedState.length > 1) {
+        ariaDisabled = 'false';
+      } else {
+        ariaDisabled = 'true';
+      }
+    } else {
+      ariaDisabled = isExpanded;
+    }
+
     return {
       id: `${TRIGGER_ID}:${index}`,
       role,
       tabIndex,
       disabled,
       'aria-controls': `${PANEL_ID}:${index}`,
-      'aria-disabled': collapsible ? 'false' : isExpanded,
+      'aria-disabled': ariaDisabled,
       'aria-expanded': isExpanded,
       onClick: composeEventHandlers(props.onClick, () => {
         if (disabled !== false) {

--- a/packages/accordion/src/useAccordion.ts
+++ b/packages/accordion/src/useAccordion.ts
@@ -55,8 +55,7 @@ export function useAccordion({
   isCollapsible,
   isExpandable
 }: IUseAccordionProps = {}): IUseAccordionReturnValue {
-  // eslint-disable-next-line
-  const isControlled = expandedSections != null;
+  const isControlled = expandedSections !== null && expandedSections !== undefined;
   const seed = useUIDSeed();
   const [prefix] = useState<string>(idPrefix || seed(`accordion_${PACKAGE_VERSION}`));
   const TRIGGER_ID = `${prefix}--trigger`;
@@ -67,7 +66,7 @@ export function useAccordion({
     Array.isArray(defaultExpandedSections) ? defaultExpandedSections : [defaultExpandedSections]
   );
 
-  const internalExpandedSections = getControlledValue(expandedSections, expandedState);
+  const controlledExpandedSections = getControlledValue(expandedSections, expandedState)!;
 
   const toggle = (index: number) => {
     if (onChange) {
@@ -79,19 +78,19 @@ export function useAccordion({
     }
 
     if (isExpandable && isCollapsible) {
-      if (internalExpandedSections.includes(index)) {
-        setExpandedState(internalExpandedSections.filter((n: number) => n !== index));
+      if (expandedState.includes(index)) {
+        setExpandedState(expandedState.filter((n: number) => n !== index));
       } else {
-        setExpandedState([...internalExpandedSections, index]);
+        setExpandedState([...expandedState, index]);
       }
     } else if (isExpandable) {
-      if (!internalExpandedSections.includes(index)) {
-        setExpandedState([...internalExpandedSections, index]);
-      } else if (internalExpandedSections.length > 1) {
-        setExpandedState(internalExpandedSections.filter((n: number) => n !== index));
+      if (!expandedState.includes(index)) {
+        setExpandedState([...expandedState, index]);
+      } else if (expandedState.length > 1) {
+        setExpandedState(expandedState.filter((n: number) => n !== index));
       }
     } else if (isCollapsible) {
-      if (internalExpandedSections[0] === index) {
+      if (expandedState[0] === index) {
         setExpandedState([]);
       } else {
         setExpandedState([index]);
@@ -122,6 +121,7 @@ export function useAccordion({
   const getTriggerProps = ({
     index,
     role = 'button',
+    disabled,
     tabIndex = 0,
     ...props
   }: ITriggerProps = {}) => {
@@ -131,18 +131,23 @@ export function useAccordion({
       );
     }
 
-    const isExpanded = Array.isArray(internalExpandedSections)
-      ? internalExpandedSections.includes(index)
-      : internalExpandedSections === index;
+    const isExpanded = Array.isArray(controlledExpandedSections)
+      ? controlledExpandedSections.includes(index)
+      : controlledExpandedSections === index;
 
     return {
       id: `${TRIGGER_ID}:${index}`,
       role,
       tabIndex,
+      disabled,
       'aria-controls': `${PANEL_ID}:${index}`,
       'aria-disabled': isCollapsible ? 'false' : isExpanded,
       'aria-expanded': isExpanded,
-      onClick: composeEventHandlers(props.onClick, () => toggle(index)),
+      onClick: composeEventHandlers(props.onClick, () => {
+        if (disabled !== false) {
+          toggle(index);
+        }
+      }),
       onKeyDown: composeEventHandlers(props.onKeyDown, (event: KeyboardEvent) => {
         if (event.keyCode === KEY_CODES.SPACE || event.keyCode === KEY_CODES.ENTER) {
           toggle(index);
@@ -160,9 +165,9 @@ export function useAccordion({
       );
     }
 
-    const ariaHidden = Array.isArray(internalExpandedSections)
-      ? !internalExpandedSections.includes(index)
-      : internalExpandedSections !== index;
+    const ariaHidden = Array.isArray(controlledExpandedSections)
+      ? !controlledExpandedSections.includes(index)
+      : controlledExpandedSections !== index;
 
     return {
       id: `${PANEL_ID}:${index}`,
@@ -177,6 +182,6 @@ export function useAccordion({
     getHeaderProps,
     getTriggerProps,
     getPanelProps,
-    expandedSections: internalExpandedSections
+    expandedSections: controlledExpandedSections
   };
 }

--- a/packages/accordion/stories.tsx
+++ b/packages/accordion/stories.tsx
@@ -9,37 +9,38 @@ import React, { createRef, useState } from 'react';
 
 import { storiesOf } from '@storybook/react';
 import { boolean, number, withKnobs } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 
-import { AccordionContainer, useAccordion, IUseAccordionReturnValue } from './src';
+import {
+  AccordionContainer,
+  useAccordion,
+  IUseAccordionReturnValue,
+  IUseAccordionProps
+} from './src';
 
 storiesOf('Accordion Container', module)
   .addDecorator(withKnobs)
-  .add('useAccordion', () => {
+  .add('useAccordion (uncontrolled)', () => {
     const size = number('Sections', 5, { range: true, min: 1, max: 9 });
+    const defaultExpandedSections = number('defaultExpandedSections', 0, { min: 0, max: size - 1 });
     const sections = Array(size)
       .fill(undefined)
       .map(() => createRef());
 
-    const Accordion = ({ expandable = true, collapsible = true } = {}) => {
-      const [controlledExpandedSections, setControlledExpandedSections] = useState([0]);
-      const {
-        getHeaderProps,
-        getTriggerProps,
-        getPanelProps,
-        expandedSections,
-        disabledSections
-      } = useAccordion({
-        expandedSections: controlledExpandedSections,
-        expandable,
-        collapsible,
-        onChange: setControlledExpandedSections
+    const Accordion = ({ isCollapsible = false, isExpandable = false } = {}) => {
+      const { expandedSections, getHeaderProps, getTriggerProps, getPanelProps } = useAccordion({
+        defaultExpandedSections,
+        isCollapsible,
+        isExpandable,
+        onChange: action(`Selected panel`)
       });
 
       return (
         <div style={{ width: 300 }}>
           {sections.map((section, index) => {
-            const disabled = disabledSections.indexOf(index) !== -1;
-            const hidden = expandedSections.indexOf(index) === -1;
+            const hidden = Array.isArray(expandedSections)
+              ? expandedSections.indexOf(index) === -1
+              : index !== expandedSections;
 
             return (
               <div key={index}>
@@ -49,7 +50,6 @@ storiesOf('Accordion Container', module)
                       index,
                       role: null,
                       tabIndex: null,
-                      disabled,
                       style: { width: '100%', textAlign: 'inherit' }
                     })}
                   >
@@ -76,72 +76,213 @@ storiesOf('Accordion Container', module)
 
     return (
       <Accordion
-        expandable={boolean('Expandable', true)}
-        collapsible={boolean('Collapsible', true)}
+        isExpandable={boolean('isExpandable', false)}
+        isCollapsible={boolean('isCollapsible', false)}
       />
     );
   })
-  .add('AccordionContainer', () => {
-    const size = number('Sections', 5, { range: true, min: 1, max: 9 });
+  .add('useAccordion (controlled)', () => {
+    const size = number('Sections', 3, { range: true, min: 1, max: 9 });
+    const controlledIndex = number('index', 0, { range: false, min: 0, max: size - 1 });
     const sections = Array(size)
       .fill(undefined)
-      .map(() => createRef());
+      .map((value, index) => index);
 
-    const Accordion = ({ expandable = true, collapsible = true } = {}) => (
-      <AccordionContainer expandedSections={[0]} expandable={expandable} collapsible={collapsible}>
-        {({
-          getHeaderProps,
-          getTriggerProps,
-          getPanelProps,
-          expandedSections,
-          disabledSections
-        }: IUseAccordionReturnValue) => (
-          <div style={{ width: 300 }}>
+    const Accordion = () => {
+      const [expandedSections, setExpandedSections] = useState<number | number[]>(controlledIndex);
+      const { getHeaderProps, getTriggerProps, getPanelProps } = useAccordion({
+        expandedSections,
+        onChange: setExpandedSections
+      });
+
+      return (
+        <>
+          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+            {sections.length >= 2 && (
+              <button onClick={() => setExpandedSections(1)}>Open Trigger 2</button>
+            )}
+            <button onClick={() => setExpandedSections(sections)}>Expand All</button>
+            <button onClick={() => setExpandedSections([])}>Collapse All</button>
+          </div>
+
+          <div style={{ width: 300, marginTop: '20px' }}>
             {sections.map((section, index) => {
-              const disabled = disabledSections.indexOf(index) !== -1;
-              const hidden = expandedSections.indexOf(index) === -1;
+              const hidden = Array.isArray(expandedSections)
+                ? !expandedSections.includes(index)
+                : index !== expandedSections;
 
               return (
                 <div key={index}>
-                  <div {...getHeaderProps({ ariaLevel: 2 })}>
-                    <div
+                  <h2 {...getHeaderProps({ role: null, ariaLevel: null })}>
+                    <button
                       {...getTriggerProps({
                         index,
-                        disabled,
-                        style: {
-                          WebkitAppearance: 'button',
-                          border: '1px solid',
-                          opacity: disabled ? 0.4 : 1,
-                          padding: 1,
-                          cursor: 'pointer'
-                        }
+                        role: null,
+                        tabIndex: null,
+                        style: { width: '100%', textAlign: 'inherit' }
                       })}
                     >
                       {`Trigger ${index + 1}`}
-                    </div>
-                  </div>
-                  <p
+                    </button>
+                  </h2>
+                  <section
                     {...getPanelProps({
                       index,
+                      role: null,
                       hidden
                     })}
                   >
                     {`[Panel ${index + 1}] `}
                     Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion
                     daikon amaranth tatsoi tomatillo melon azuki bean garlic.
-                  </p>
+                  </section>
                 </div>
               );
             })}
           </div>
-        )}
+        </>
+      );
+    };
+
+    return <Accordion />;
+  })
+  .add('AccordionContainer (controlled)', () => {
+    const size = number('Sections', 3, { range: true, min: 1, max: 9 });
+    const controlledIndex = number('index', 0, { range: false, min: 0, max: size - 1 });
+    const sections = Array(size)
+      .fill(undefined)
+      .map((value, index) => index);
+
+    const Accordion = () => {
+      const [expandedSections, setExpandedSections] = useState<number | number[]>(controlledIndex);
+
+      return (
+        <AccordionContainer
+          expandedSections={expandedSections}
+          onChange={index => setExpandedSections(index)}
+        >
+          {({ getHeaderProps, getTriggerProps, getPanelProps }: IUseAccordionReturnValue) => {
+            return (
+              <>
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                  {sections.length >= 2 && (
+                    <button onClick={() => setExpandedSections(1)}>Open Trigger 2</button>
+                  )}
+                  <button onClick={() => setExpandedSections([0, 1, 2])}>Expand All</button>
+                  <button onClick={() => setExpandedSections([])}>Collapse All</button>
+                </div>
+
+                <div style={{ width: 300, marginTop: '20px' }}>
+                  {sections.map((section, index) => {
+                    const hidden = Array.isArray(expandedSections)
+                      ? !expandedSections.includes(index)
+                      : index !== expandedSections;
+
+                    return (
+                      <div key={index}>
+                        <div {...getHeaderProps({ ariaLevel: 2 })}>
+                          <div
+                            {...getTriggerProps({
+                              index,
+                              style: {
+                                WebkitAppearance: 'button',
+                                border: '1px solid',
+                                padding: 1,
+                                cursor: 'pointer'
+                              }
+                            })}
+                          >
+                            {`Trigger ${index + 1}`}
+                          </div>
+                        </div>
+                        <p
+                          {...getPanelProps({
+                            index,
+                            hidden
+                          })}
+                        >
+                          {`[Panel ${index + 1}] `}
+                          Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh
+                          onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+                        </p>
+                      </div>
+                    );
+                  })}
+                </div>
+              </>
+            );
+          }}
+        </AccordionContainer>
+      );
+    };
+
+    return <Accordion />;
+  })
+  .add('AccordionContainer (uncontrolled)', () => {
+    const size = number('Sections', 5, { range: true, min: 1, max: 9 });
+    const sections = Array(size)
+      .fill(undefined)
+      .map(() => createRef());
+
+    const Accordion = ({ isExpandable, isCollapsible }: IUseAccordionProps) => (
+      <AccordionContainer
+        onChange={action(`Selected panel`)}
+        isExpandable={isExpandable}
+        isCollapsible={isCollapsible}
+      >
+        {({
+          getHeaderProps,
+          getTriggerProps,
+          getPanelProps,
+          expandedSections
+        }: IUseAccordionReturnValue) => {
+          return (
+            <div style={{ width: 300 }}>
+              {sections.map((section, index) => {
+                const hidden = Array.isArray(expandedSections)
+                  ? expandedSections.indexOf(index) === -1
+                  : index !== expandedSections;
+
+                return (
+                  <div key={index}>
+                    <div {...getHeaderProps({ ariaLevel: 2 })}>
+                      <div
+                        {...getTriggerProps({
+                          index,
+                          style: {
+                            WebkitAppearance: 'button',
+                            border: '1px solid',
+                            padding: 1,
+                            cursor: 'pointer'
+                          }
+                        })}
+                      >
+                        {`Trigger ${index + 1}`}
+                      </div>
+                    </div>
+                    <p
+                      {...getPanelProps({
+                        index,
+                        hidden
+                      })}
+                    >
+                      {`[Panel ${index + 1}] `}
+                      Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion
+                      daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+          );
+        }}
       </AccordionContainer>
     );
 
     return (
       <Accordion
-        expandable={boolean('Expandable', true)}
-        collapsible={boolean('Collapsible', true)}
+        isExpandable={boolean('isExpandable', false)}
+        isCollapsible={boolean('isCollapsible', false)}
       />
     );
   });

--- a/packages/accordion/stories.tsx
+++ b/packages/accordion/stories.tsx
@@ -27,11 +27,11 @@ storiesOf('Accordion Container', module)
       .fill(undefined)
       .map(() => createRef());
 
-    const Accordion = ({ isCollapsible = false, isExpandable = false } = {}) => {
+    const Accordion = ({ collapsible = false, expandable = false } = {}) => {
       const { expandedSections, getHeaderProps, getTriggerProps, getPanelProps } = useAccordion({
         defaultExpandedSections,
-        isCollapsible,
-        isExpandable,
+        collapsible,
+        expandable,
         onChange: action('Selected panel')
       });
 
@@ -76,8 +76,8 @@ storiesOf('Accordion Container', module)
 
     return (
       <Accordion
-        isExpandable={boolean('isExpandable', false)}
-        isCollapsible={boolean('isCollapsible', false)}
+        expandable={boolean('expandable', true)}
+        collapsible={boolean('collapsible', true)}
       />
     );
   })
@@ -114,31 +114,29 @@ storiesOf('Accordion Container', module)
 
               return (
                 <div key={index}>
-                  <div {...getHeaderProps({ ariaLevel: 2 })}>
-                    <div
+                  <h2 {...getHeaderProps({ role: null, ariaLevel: null })}>
+                    <button
                       {...getTriggerProps({
                         index,
-                        style: {
-                          WebkitAppearance: 'button',
-                          border: '1px solid',
-                          padding: 1,
-                          cursor: 'pointer'
-                        }
+                        role: null,
+                        tabIndex: null,
+                        style: { width: '100%', textAlign: 'inherit' }
                       })}
                     >
                       {`Trigger ${index + 1}`}
-                    </div>
-                  </div>
-                  <p
+                    </button>
+                  </h2>
+                  <section
                     {...getPanelProps({
                       index,
+                      role: null,
                       hidden
                     })}
                   >
                     {`[Panel ${index + 1}]`}
                     Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion
                     daikon amaranth tatsoi tomatillo melon azuki bean garlic.
-                  </p>
+                  </section>
                 </div>
               );
             })}
@@ -155,11 +153,11 @@ storiesOf('Accordion Container', module)
       .fill(undefined)
       .map(() => createRef());
 
-    const Accordion = ({ isExpandable, isCollapsible }: IUseAccordionProps) => (
+    const Accordion = ({ expandable, collapsible }: IUseAccordionProps) => (
       <AccordionContainer
         onChange={action('Selected panel')}
-        isExpandable={isExpandable}
-        isCollapsible={isCollapsible}
+        expandable={expandable}
+        collapsible={collapsible}
       >
         {({
           getHeaderProps,
@@ -175,30 +173,32 @@ storiesOf('Accordion Container', module)
                   : index !== expandedSections;
 
                 return (
-                  <div key={index}>
-                    <h2 {...getHeaderProps({ role: null, ariaLevel: null })}>
-                      <button
+                  <div>
+                    <div {...getHeaderProps({ ariaLevel: 2 })}>
+                      <div
                         {...getTriggerProps({
                           index,
-                          role: null,
-                          tabIndex: null,
-                          style: { width: '100%', textAlign: 'inherit' }
+                          style: {
+                            WebkitAppearance: 'button',
+                            border: '1px solid',
+                            padding: 1,
+                            cursor: 'pointer'
+                          }
                         })}
                       >
                         {`Trigger ${index + 1}`}
-                      </button>
-                    </h2>
-                    <section
+                      </div>
+                    </div>
+                    <p
                       {...getPanelProps({
                         index,
-                        role: null,
                         hidden
                       })}
                     >
                       {`[Panel ${index + 1}]`}
                       Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion
                       daikon amaranth tatsoi tomatillo melon azuki bean garlic.
-                    </section>
+                    </p>
                   </div>
                 );
               })}
@@ -210,8 +210,8 @@ storiesOf('Accordion Container', module)
 
     return (
       <Accordion
-        isExpandable={boolean('isExpandable', false)}
-        isCollapsible={boolean('isCollapsible', false)}
+        expandable={boolean('expandable', true)}
+        collapsible={boolean('collapsible', true)}
       />
     );
   })

--- a/packages/accordion/stories.tsx
+++ b/packages/accordion/stories.tsx
@@ -23,7 +23,7 @@ storiesOf('Accordion Container', module)
   .add('useAccordion (uncontrolled)', () => {
     const size = number('Sections', 5, { range: true, min: 1, max: 9 });
     const defaultExpandedSections = number('defaultExpandedSections', 0, { min: 0, max: size - 1 });
-    const sections = Array(size)
+    const sectionRefs = Array(size)
       .fill(undefined)
       .map(() => createRef());
 
@@ -32,12 +32,12 @@ storiesOf('Accordion Container', module)
         defaultExpandedSections,
         isCollapsible,
         isExpandable,
-        onChange: action(`Selected panel`)
+        onChange: action('Selected panel')
       });
 
       return (
         <div style={{ width: 300 }}>
-          {sections.map((section, index) => {
+          {sectionRefs.map((sectionRef, index) => {
             const hidden = Array.isArray(expandedSections)
               ? expandedSections.indexOf(index) === -1
               : index !== expandedSections;
@@ -63,7 +63,7 @@ storiesOf('Accordion Container', module)
                     hidden
                   })}
                 >
-                  {`[Panel ${index + 1}] `}
+                  {`[Panel ${index + 1}]`}
                   Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion
                   daikon amaranth tatsoi tomatillo melon azuki bean garlic.
                 </section>
@@ -86,7 +86,8 @@ storiesOf('Accordion Container', module)
     const controlledIndex = number('index', 0, { range: false, min: 0, max: size - 1 });
     const sections = Array(size)
       .fill(undefined)
-      .map((value, index) => index);
+      .map((section, index) => index);
+    const sectionRefs = sections.map(() => createRef());
 
     const Accordion = () => {
       const [expandedSections, setExpandedSections] = useState<number | number[]>(controlledIndex);
@@ -99,43 +100,45 @@ storiesOf('Accordion Container', module)
         <>
           <div style={{ display: 'flex', justifyContent: 'space-between' }}>
             {sections.length >= 2 && (
-              <button onClick={() => setExpandedSections(1)}>Open Trigger 2</button>
+              <button onClick={() => setExpandedSections(1)}>Expand Trigger 2</button>
             )}
             <button onClick={() => setExpandedSections(sections)}>Expand All</button>
             <button onClick={() => setExpandedSections([])}>Collapse All</button>
           </div>
 
           <div style={{ width: 300, marginTop: '20px' }}>
-            {sections.map((section, index) => {
+            {sectionRefs.map((sectionRef, index) => {
               const hidden = Array.isArray(expandedSections)
                 ? !expandedSections.includes(index)
                 : index !== expandedSections;
 
               return (
                 <div key={index}>
-                  <h2 {...getHeaderProps({ role: null, ariaLevel: null })}>
-                    <button
+                  <div {...getHeaderProps({ ariaLevel: 2 })}>
+                    <div
                       {...getTriggerProps({
                         index,
-                        role: null,
-                        tabIndex: null,
-                        style: { width: '100%', textAlign: 'inherit' }
+                        style: {
+                          WebkitAppearance: 'button',
+                          border: '1px solid',
+                          padding: 1,
+                          cursor: 'pointer'
+                        }
                       })}
                     >
                       {`Trigger ${index + 1}`}
-                    </button>
-                  </h2>
-                  <section
+                    </div>
+                  </div>
+                  <p
                     {...getPanelProps({
                       index,
-                      role: null,
                       hidden
                     })}
                   >
-                    {`[Panel ${index + 1}] `}
+                    {`[Panel ${index + 1}]`}
                     Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion
                     daikon amaranth tatsoi tomatillo melon azuki bean garlic.
-                  </section>
+                  </p>
                 </div>
               );
             })}
@@ -146,12 +149,79 @@ storiesOf('Accordion Container', module)
 
     return <Accordion />;
   })
+  .add('AccordionContainer (uncontrolled)', () => {
+    const size = number('Sections', 5, { range: true, min: 1, max: 9 });
+    const sectionRefs = Array(size)
+      .fill(undefined)
+      .map(() => createRef());
+
+    const Accordion = ({ isExpandable, isCollapsible }: IUseAccordionProps) => (
+      <AccordionContainer
+        onChange={action('Selected panel')}
+        isExpandable={isExpandable}
+        isCollapsible={isCollapsible}
+      >
+        {({
+          getHeaderProps,
+          getTriggerProps,
+          getPanelProps,
+          expandedSections
+        }: IUseAccordionReturnValue) => {
+          return (
+            <div style={{ width: 300 }}>
+              {sectionRefs.map((sectionRef, index) => {
+                const hidden = Array.isArray(expandedSections)
+                  ? expandedSections.indexOf(index) === -1
+                  : index !== expandedSections;
+
+                return (
+                  <div key={index}>
+                    <h2 {...getHeaderProps({ role: null, ariaLevel: null })}>
+                      <button
+                        {...getTriggerProps({
+                          index,
+                          role: null,
+                          tabIndex: null,
+                          style: { width: '100%', textAlign: 'inherit' }
+                        })}
+                      >
+                        {`Trigger ${index + 1}`}
+                      </button>
+                    </h2>
+                    <section
+                      {...getPanelProps({
+                        index,
+                        role: null,
+                        hidden
+                      })}
+                    >
+                      {`[Panel ${index + 1}]`}
+                      Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion
+                      daikon amaranth tatsoi tomatillo melon azuki bean garlic.
+                    </section>
+                  </div>
+                );
+              })}
+            </div>
+          );
+        }}
+      </AccordionContainer>
+    );
+
+    return (
+      <Accordion
+        isExpandable={boolean('isExpandable', false)}
+        isCollapsible={boolean('isCollapsible', false)}
+      />
+    );
+  })
   .add('AccordionContainer (controlled)', () => {
     const size = number('Sections', 3, { range: true, min: 1, max: 9 });
     const controlledIndex = number('index', 0, { range: false, min: 0, max: size - 1 });
     const sections = Array(size)
       .fill(undefined)
-      .map((value, index) => index);
+      .map((section, index) => index);
+    const sectionRefs = sections.map(() => createRef());
 
     const Accordion = () => {
       const [expandedSections, setExpandedSections] = useState<number | number[]>(controlledIndex);
@@ -166,14 +236,14 @@ storiesOf('Accordion Container', module)
               <>
                 <div style={{ display: 'flex', justifyContent: 'space-between' }}>
                   {sections.length >= 2 && (
-                    <button onClick={() => setExpandedSections(1)}>Open Trigger 2</button>
+                    <button onClick={() => setExpandedSections(1)}>Expand Trigger 2</button>
                   )}
-                  <button onClick={() => setExpandedSections([0, 1, 2])}>Expand All</button>
+                  <button onClick={() => setExpandedSections(sections)}>Expand All</button>
                   <button onClick={() => setExpandedSections([])}>Collapse All</button>
                 </div>
 
                 <div style={{ width: 300, marginTop: '20px' }}>
-                  {sections.map((section, index) => {
+                  {sectionRefs.map((sectionRef, index) => {
                     const hidden = Array.isArray(expandedSections)
                       ? !expandedSections.includes(index)
                       : index !== expandedSections;
@@ -201,7 +271,7 @@ storiesOf('Accordion Container', module)
                             hidden
                           })}
                         >
-                          {`[Panel ${index + 1}] `}
+                          {`[Panel ${index + 1}]`}
                           Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh
                           onion daikon amaranth tatsoi tomatillo melon azuki bean garlic.
                         </p>
@@ -217,72 +287,4 @@ storiesOf('Accordion Container', module)
     };
 
     return <Accordion />;
-  })
-  .add('AccordionContainer (uncontrolled)', () => {
-    const size = number('Sections', 5, { range: true, min: 1, max: 9 });
-    const sections = Array(size)
-      .fill(undefined)
-      .map(() => createRef());
-
-    const Accordion = ({ isExpandable, isCollapsible }: IUseAccordionProps) => (
-      <AccordionContainer
-        onChange={action(`Selected panel`)}
-        isExpandable={isExpandable}
-        isCollapsible={isCollapsible}
-      >
-        {({
-          getHeaderProps,
-          getTriggerProps,
-          getPanelProps,
-          expandedSections
-        }: IUseAccordionReturnValue) => {
-          return (
-            <div style={{ width: 300 }}>
-              {sections.map((section, index) => {
-                const hidden = Array.isArray(expandedSections)
-                  ? expandedSections.indexOf(index) === -1
-                  : index !== expandedSections;
-
-                return (
-                  <div key={index}>
-                    <div {...getHeaderProps({ ariaLevel: 2 })}>
-                      <div
-                        {...getTriggerProps({
-                          index,
-                          style: {
-                            WebkitAppearance: 'button',
-                            border: '1px solid',
-                            padding: 1,
-                            cursor: 'pointer'
-                          }
-                        })}
-                      >
-                        {`Trigger ${index + 1}`}
-                      </div>
-                    </div>
-                    <p
-                      {...getPanelProps({
-                        index,
-                        hidden
-                      })}
-                    >
-                      {`[Panel ${index + 1}] `}
-                      Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion
-                      daikon amaranth tatsoi tomatillo melon azuki bean garlic.
-                    </p>
-                  </div>
-                );
-              })}
-            </div>
-          );
-        }}
-      </AccordionContainer>
-    );
-
-    return (
-      <Accordion
-        isExpandable={boolean('isExpandable', false)}
-        isCollapsible={boolean('isCollapsible', false)}
-      />
-    );
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3120,6 +3120,26 @@
     ts-dedent "^1.1.0"
     util-deprecate "^1.0.2"
 
+"@storybook/addon-actions@5.3.17":
+  version "5.3.17"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-5.3.17.tgz#ec7ae8fa25ef211c2a3302b6ac1d271a6247f767"
+  integrity sha512-06HQSBqWFyXcqV418Uv3oMHomNy9g3uCt0FHrqY3BAc7PldY1X0tW65oy//uBueaRaYKdhtRrrjfXRaPQWmDbA==
+  dependencies:
+    "@storybook/addons" "5.3.17"
+    "@storybook/api" "5.3.17"
+    "@storybook/client-api" "5.3.17"
+    "@storybook/components" "5.3.17"
+    "@storybook/core-events" "5.3.17"
+    "@storybook/theming" "5.3.17"
+    core-js "^3.0.1"
+    fast-deep-equal "^2.0.1"
+    global "^4.3.2"
+    polished "^3.3.1"
+    prop-types "^15.7.2"
+    react "^16.8.3"
+    react-inspector "^4.0.0"
+    uuid "^3.3.2"
+
 "@storybook/addon-centered@5.3.14":
   version "5.3.14"
   resolved "https://registry.yarnpkg.com/@storybook/addon-centered/-/addon-centered-5.3.14.tgz#8b05fafabf3ec2ffb3a999417ef12fc8bdca1071"
@@ -3186,6 +3206,19 @@
     global "^4.3.2"
     util-deprecate "^1.0.2"
 
+"@storybook/addons@5.3.17":
+  version "5.3.17"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-5.3.17.tgz#8efab65904040b0b8578eedc9a5772dbcbf6fa83"
+  integrity sha512-zg6O1bmffRsHXJOWAnSD2O3tPnVMoD8Yfu+a5zBVXDiUP1E/TGzgjjjYBUUCU3yQg1Ted5rIn4o6ql/rZNNlgA==
+  dependencies:
+    "@storybook/api" "5.3.17"
+    "@storybook/channels" "5.3.17"
+    "@storybook/client-logger" "5.3.17"
+    "@storybook/core-events" "5.3.17"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    util-deprecate "^1.0.2"
+
 "@storybook/api@5.3.14":
   version "5.3.14"
   resolved "https://registry.yarnpkg.com/@storybook/api/-/api-5.3.14.tgz#8c2bb226a4a5de7974ee2ccce36986b72f462f1b"
@@ -3212,6 +3245,32 @@
     telejson "^3.2.0"
     util-deprecate "^1.0.2"
 
+"@storybook/api@5.3.17":
+  version "5.3.17"
+  resolved "https://registry.yarnpkg.com/@storybook/api/-/api-5.3.17.tgz#1c0dad3309afef6b0a5585cb59c65824fb4d2721"
+  integrity sha512-G40jtXFY10hQo6GSw5JeFYt41loD4+7s0uU18Rm6lfa/twOgp6vqqyDCWDvpRRxRBB5uDIKKHLt13X9gWe8tQQ==
+  dependencies:
+    "@reach/router" "^1.2.1"
+    "@storybook/channels" "5.3.17"
+    "@storybook/client-logger" "5.3.17"
+    "@storybook/core-events" "5.3.17"
+    "@storybook/csf" "0.0.1"
+    "@storybook/router" "5.3.17"
+    "@storybook/theming" "5.3.17"
+    "@types/reach__router" "^1.2.3"
+    core-js "^3.0.1"
+    fast-deep-equal "^2.0.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    memoizerific "^1.11.3"
+    prop-types "^15.6.2"
+    react "^16.8.3"
+    semver "^6.0.0"
+    shallow-equal "^1.1.0"
+    store2 "^2.7.1"
+    telejson "^3.2.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/channel-postmessage@5.3.14":
   version "5.3.14"
   resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-5.3.14.tgz#768c87411d98caf09fdd92539b9edaaed26d5965"
@@ -3223,10 +3282,28 @@
     global "^4.3.2"
     telejson "^3.2.0"
 
+"@storybook/channel-postmessage@5.3.17":
+  version "5.3.17"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-5.3.17.tgz#807b6316cd0e52d9f27363d5092ad1cd896b694c"
+  integrity sha512-1aSQNeO2+roPRgMFjW3AWTO3uS93lbCMUTYCBdi20md4bQ9SutJy33rynCQcWuMj1prCQ2Ekz4BGhdcIQVKlzg==
+  dependencies:
+    "@storybook/channels" "5.3.17"
+    "@storybook/client-logger" "5.3.17"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    telejson "^3.2.0"
+
 "@storybook/channels@5.3.14":
   version "5.3.14"
   resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-5.3.14.tgz#9969e27761a80afb495bc1475f0173f9b6ef5a76"
   integrity sha512-k9QBf9Kwe+iGmdEK/kW5xprqem2SPfBVwET6LWvJkWOl9UQ9VoMuCHgV55p0tzjcugaqWWKoF9+FRMWxWRfsQg==
+  dependencies:
+    core-js "^3.0.1"
+
+"@storybook/channels@5.3.17":
+  version "5.3.17"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-5.3.17.tgz#74eccb10c2395499da6a290bcd0272d6d6c7c5b2"
+  integrity sha512-5hlBRbyk+YxC4KgecYG8wWwB2v1BzRJXhSlemFDOQk9wx37gVpne+rBydEtNFO4InmaZf6tKbBcpH0wBFLdWYA==
   dependencies:
     core-js "^3.0.1"
 
@@ -3253,10 +3330,40 @@
     ts-dedent "^1.1.0"
     util-deprecate "^1.0.2"
 
+"@storybook/client-api@5.3.17":
+  version "5.3.17"
+  resolved "https://registry.yarnpkg.com/@storybook/client-api/-/client-api-5.3.17.tgz#fc1d247caf267ebcc6ddf957fca7e02ae752d99e"
+  integrity sha512-oe55FPTGVL2k+j45eCN3oE7ePkE4VpgUQ/dhJbjU0R2L+HyRyBhd0wnMYj1f5E8uVNbtjFYAtbjjgcf1R1imeg==
+  dependencies:
+    "@storybook/addons" "5.3.17"
+    "@storybook/channel-postmessage" "5.3.17"
+    "@storybook/channels" "5.3.17"
+    "@storybook/client-logger" "5.3.17"
+    "@storybook/core-events" "5.3.17"
+    "@storybook/csf" "0.0.1"
+    "@types/webpack-env" "^1.15.0"
+    core-js "^3.0.1"
+    eventemitter3 "^4.0.0"
+    global "^4.3.2"
+    is-plain-object "^3.0.0"
+    lodash "^4.17.15"
+    memoizerific "^1.11.3"
+    qs "^6.6.0"
+    stable "^0.1.8"
+    ts-dedent "^1.1.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/client-logger@5.3.14":
   version "5.3.14"
   resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-5.3.14.tgz#85068f1b665a52163191eb5976f1581bce6df0e4"
   integrity sha512-YCHEsOvo6zPb4udlyAwqr5W0Kv9mAEQmcX73w9IDvAxbjR00T7empW7qmbjvviftKB/5MEgDdiYbj64ccs3aqg==
+  dependencies:
+    core-js "^3.0.1"
+
+"@storybook/client-logger@5.3.17":
+  version "5.3.17"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-5.3.17.tgz#bf9c7ef52da75a5c1f2c5d74724442224deea6e4"
+  integrity sha512-GYYvVGIOs+fq11LXXy7x2sr3hhC9LMI1jtIckjKV1dsY9MJ5g22M+Wl5Iw4nf6VMWsqcN9LSlYE+u/H+Q2uCHw==
   dependencies:
     core-js "^3.0.1"
 
@@ -3287,10 +3394,44 @@
     simplebar-react "^1.0.0-alpha.6"
     ts-dedent "^1.1.0"
 
+"@storybook/components@5.3.17":
+  version "5.3.17"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-5.3.17.tgz#287430fc9c5f59b1d3590b50b3c7688355b22639"
+  integrity sha512-M5oqbzcqFX4VDNI8siT3phT7rmFwChQ/xPwX9ygByBsZCoNuLMzafavfTOhZvxCPiliFbBxmxtK/ibCsSzuKZg==
+  dependencies:
+    "@storybook/client-logger" "5.3.17"
+    "@storybook/theming" "5.3.17"
+    "@types/react-syntax-highlighter" "11.0.4"
+    "@types/react-textarea-autosize" "^4.3.3"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    markdown-to-jsx "^6.9.1"
+    memoizerific "^1.11.3"
+    polished "^3.3.1"
+    popper.js "^1.14.7"
+    prop-types "^15.7.2"
+    react "^16.8.3"
+    react-dom "^16.8.3"
+    react-focus-lock "^2.1.0"
+    react-helmet-async "^1.0.2"
+    react-popper-tooltip "^2.8.3"
+    react-syntax-highlighter "^11.0.2"
+    react-textarea-autosize "^7.1.0"
+    simplebar-react "^1.0.0-alpha.6"
+    ts-dedent "^1.1.0"
+
 "@storybook/core-events@5.3.14":
   version "5.3.14"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-5.3.14.tgz#d476eea7032670db1a84bef7e5baadb04c2de529"
   integrity sha512-VCPLKqRugsOSx/smMJiJOvRgAzTrMpsbRuFw48kBGkQMP9TEV82Qe/341dv+f4GllPyBZyANG0p0m5+w7ZCURQ==
+  dependencies:
+    core-js "^3.0.1"
+
+"@storybook/core-events@5.3.17":
+  version "5.3.17"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-5.3.17.tgz#698ce0a36c29fe8fa04608f56ccca53aa1d31638"
+  integrity sha512-DOeX9fpeGW4o9Gocxa4VW9wAlAyfIVNDTzq0wVvvMBthTTo9u58NmndglEMDgDa2Cq6iAIPh7vz2bRJCNexzLw==
   dependencies:
     core-js "^3.0.1"
 
@@ -3434,6 +3575,21 @@
     qs "^6.6.0"
     util-deprecate "^1.0.2"
 
+"@storybook/router@5.3.17":
+  version "5.3.17"
+  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-5.3.17.tgz#4db96b45f39b25a3f7a4e2899c36e7e9e4ba6108"
+  integrity sha512-ANsiehGRTVSremgTW0Vt47dQ4JA86a4/w/4G6QqHU8Cm4jO3cw/wAcCxlzfcgCXOUiq+SuyPTU43+0O5uBx33g==
+  dependencies:
+    "@reach/router" "^1.2.1"
+    "@storybook/csf" "0.0.1"
+    "@types/reach__router" "^1.2.3"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    memoizerific "^1.11.3"
+    qs "^6.6.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/source-loader@5.3.14":
   version "5.3.14"
   resolved "https://registry.yarnpkg.com/@storybook/source-loader/-/source-loader-5.3.14.tgz#62428a1b12fc9f51f24d27194a06d343366d8bf5"
@@ -3458,6 +3614,24 @@
     "@emotion/core" "^10.0.20"
     "@emotion/styled" "^10.0.17"
     "@storybook/client-logger" "5.3.14"
+    core-js "^3.0.1"
+    deep-object-diff "^1.1.0"
+    emotion-theming "^10.0.19"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    polished "^3.3.1"
+    prop-types "^15.7.2"
+    resolve-from "^5.0.0"
+    ts-dedent "^1.1.0"
+
+"@storybook/theming@5.3.17":
+  version "5.3.17"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-5.3.17.tgz#cf6278c4857229c7167faf04d5b2206bc5ee04e1"
+  integrity sha512-4JeOZnDDHtb4LOt5sXe/s1Jhbb2UPsr8zL9NWmKJmTsgnyTvBipNHOmFYDUsIacB5K4GXSqm+cZ7Z4AkUgWCDw==
+  dependencies:
+    "@emotion/core" "^10.0.20"
+    "@emotion/styled" "^10.0.17"
+    "@storybook/client-logger" "5.3.17"
     core-js "^3.0.1"
     deep-object-diff "^1.1.0"
     emotion-theming "^10.0.19"
@@ -3842,6 +4016,13 @@
   version "11.0.2"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.2.tgz#a2e3ff657d7c47813f80ca930f3d959c31ec51e3"
   integrity sha512-iMNcixH8330f2dq0RY+VOXCP8JFehgmOhLOtnO85Ty+qu0fHXJNEqWx5VuFv8v0aEq0U/N9d/k1yvA+c6PEmPw==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-syntax-highlighter@11.0.4":
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.4.tgz#d86d17697db62f98046874f62fdb3e53a0bbc4cd"
+  integrity sha512-9GfTo3a0PHwQeTVoqs0g5bS28KkSY48pp5659wA+Dp4MqceDEa8EHBqrllJvvtyusszyJhViUEap0FDvlk/9Zg==
   dependencies:
     "@types/react" "*"
 
@@ -9448,6 +9629,14 @@ is-docker@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.0.0.tgz#2cb0df0e75e2d064fe1864c37cdeacb7b2dcf25b"
   integrity sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==
 
+is-dom@^1.0.9:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-dom/-/is-dom-1.1.0.tgz#af1fced292742443bb59ca3f76ab5e80907b4e8a"
+  integrity sha512-u82f6mvhYxRPKpw8V1N0W8ce1xXwOrQtgGcxl6UCL5zBmZu3is/18K0rR7uFCnMDuAsS/3W54mGL4vsaFUQlEQ==
+  dependencies:
+    is-object "^1.0.1"
+    is-window "^1.0.2"
+
 is-even@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-even/-/is-even-1.0.0.tgz#76b5055fbad8d294a86b6a949015e1c97b717c06"
@@ -9570,6 +9759,11 @@ is-obj@^1.0.0, is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
+
+is-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
+  integrity sha1-iVJojF7C/9awPsyF52ngKQMINHA=
 
 is-observable@^1.1.0:
   version "1.1.0"
@@ -9718,6 +9912,11 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
+
+is-window@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-window/-/is-window-1.0.2.tgz#2c896ca53db97de45d3c33133a65d8c9f563480d"
+  integrity sha1-LIlspT25feRdPDMTOmXYyfVjSA0=
 
 is-windows@^1.0.0, is-windows@^1.0.2:
   version "1.0.2"
@@ -13040,6 +13239,15 @@ react-input-autosize@^2.2.2:
   integrity sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==
   dependencies:
     prop-types "^15.5.8"
+
+react-inspector@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-4.0.1.tgz#0f888f78ff7daccbc7be5d452b20c96dc6d5fbb8"
+  integrity sha512-xSiM6CE79JBqSj8Fzd9dWBHv57tLTH7OM57GP3VrE5crzVF3D5Khce9w1Xcw75OAbvrA0Mi2vBneR1OajKmXFg==
+  dependencies:
+    "@babel/runtime" "^7.6.3"
+    is-dom "^1.0.9"
+    prop-types "^15.6.1"
 
 react-is@^16.12.0:
   version "16.12.0"


### PR DESCRIPTION
- [x] **BREAKING CHANGE**

## Description

This pull request updates the `useAccordion` hook so that it is ready to be used to implement an `<Accordion>`.

## Demo

The updated Storybook examples for `useAccordion` can be found [here](https://accordion-hook-1c2ad4.netlify.com/storybook/?path=/story/accordion-container--useaccordion-uncontrolled).

## Detail

These updates include:

* `onChange` no longer [dictates controlled usage](https://github.com/zendeskgarden/react-containers/pull/104#discussion_r394114898). Uncontrolled usages are driven by state, while controlled usages are driven by props. 

*  The `@storybook/addon-actions` package has been added to display data received by `onChange` to demonstrate that  `onChange` can be passed into `useAccordion`.

* The removal of `disabledSections` array return from the hook.
  - The `aria-disabled` attribute remains on a heading button when its associated panel is expanded. 

* New API to allow consumers to set default expanded panel(s) for uncontrolled usage with the `defaultExpandedSections` prop.

* Various permutations of `isExpandable` and `isCollapsible` props that covers common accordion implementations. These props only apply to uncontrolled usages because, in controlled usages, consumers have full control of the accordion behavior with a controlled prop. The permutations will allow an accordion usages to be configured to behave as follows:

  - `isExpanded === undefined && isCollapsible === undefined`
    - One panel of the accordion is always expanded, and only one panel may be expanded at a time.
  - `isExpanded`
    - Allows panels of the accordion to be expanded.
  - `isCollapsible`
    - Allows panels of the accordion to be collapsed.
  - `isExpanded && isCollapsible`
    - Allows all panels of the accordion to be collapsed and expanded at any time without regard to the state of other accordion panels.

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
