### PR TITLE
chore(accordion): update changelog 

### DIFF
--- a/packages/accordion/CHANGELOG.md
+++ b/packages/accordion/CHANGELOG.md
@@ -14,7 +14,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [0.5.3](https://github.com/zendeskgarden/react-containers/compare/@zendeskgarden/container-accordion@0.5.2...@zendeskgarden/container-accordion@0.5.3) (2020-03-23)
 
 
-### Bug Fixes
+### BREAKING CHANGES
+
+The `useAccordion` hook's `onChange` handler has been updated to be called with the index of the expanded accordion section. To migrate please update `onChange` usages to handle the newly returned index value.
 
 * **utils:** add typing to getControlledValue ([#173](https://github.com/zendeskgarden/react-containers/issues/173)) ([886ba5b](https://github.com/zendeskgarden/react-containers/commit/886ba5b6bd595c8946ec1fc6e5c2f8ec7e8ac3eb))
 


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

This PR bumps a major release for `container-accordion` as the version bump was missed during the release of #176.

The migration steps for upgrading to the major is included in the updated `CHANGELOG.md`.

## Detail

The intended squash and merge title will be:

> chore(accordion): update changelog (#184) 

and the intended squash and merge body will be:

> BREAKING CHANGE: Update container-accordion changelog.
>
> The major version for container-accordion was missed when releasing #176. This commit updates container-accordion's CHANGELOG to include information on how to migrate to the new major version.