### PR TITLE
fix(schedule): cleanup all animation frames on removal

### DIFF
--- a/packages/schedule/.size-snapshot.json
+++ b/packages/schedule/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 2883,
-    "minified": 1376,
-    "gzipped": 664
+    "bundled": 2981,
+    "minified": 1391,
+    "gzipped": 674
   },
   "dist/index.esm.js": {
-    "bundled": 2632,
-    "minified": 1174,
-    "gzipped": 585,
+    "bundled": 2730,
+    "minified": 1189,
+    "gzipped": 594,
     "treeshaked": {
       "rollup": {
-        "code": 938,
+        "code": 953,
         "import_statements": 80
       },
       "webpack": {
-        "code": 1993
+        "code": 2008
       }
     }
   }

--- a/packages/schedule/src/useSchedule.ts
+++ b/packages/schedule/src/useSchedule.ts
@@ -31,8 +31,13 @@ export const useSchedule = ({
     let raf: number;
     let start: number;
     let loopTimeout: ReturnType<typeof setTimeout>;
+    let destroyed = false;
 
     const tick = () => {
+      if (destroyed) {
+        return;
+      }
+
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
       raf = requestAnimationFrame(performAnimationFrame);
     };
@@ -58,6 +63,7 @@ export const useSchedule = ({
     const renderingDelayTimeout = setTimeout(onStart, delayMS);
 
     return () => {
+      destroyed = true;
       clearTimeout(renderingDelayTimeout);
       clearTimeout(loopTimeout);
       cancelAnimationFrame(raf);


### PR DESCRIPTION
## Description

#195 found some issues with our `requestAnimationFrame` cleanup if a consuming component is unmounted at certain time intervals.

This was not only causing invalid `setState` usages, but was causing runaway `requestAnimationFrame` calls (without errors) as well 😨 

## Detail

This PR introduces a `destroyed` flag which is set during the effect teardown. This allows our `requestAnimationFrame` to check if it has been called during a timeout boundary.

I loaded the codesandbox example locally in storybook and was unable to reproduce the issue with the new changes!

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
