### PR TITLE
fix(schedule): add additional cleanup check for useSchedule

### DIFF
--- a/packages/schedule/.size-snapshot.json
+++ b/packages/schedule/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/index.cjs.js": {
-    "bundled": 2981,
-    "minified": 1391,
-    "gzipped": 674
+    "bundled": 3028,
+    "minified": 1396,
+    "gzipped": 675
   },
   "dist/index.esm.js": {
-    "bundled": 2730,
-    "minified": 1189,
-    "gzipped": 594,
+    "bundled": 2777,
+    "minified": 1194,
+    "gzipped": 596,
     "treeshaked": {
       "rollup": {
-        "code": 953,
+        "code": 958,
         "import_statements": 80
       },
       "webpack": {
-        "code": 2008
+        "code": 2013
       }
     }
   }

--- a/packages/schedule/src/useSchedule.ts
+++ b/packages/schedule/src/useSchedule.ts
@@ -48,6 +48,10 @@ export const useSchedule = ({
     };
 
     const onStart = () => {
+      if (destroyed) {
+        return;
+      }
+
       loopTimeout = setTimeout(() => {
         cancelAnimationFrame(raf);
         setTime(Date.now() - start);


### PR DESCRIPTION
## Description

Additional follow-on to #196.

This PR adds an additional `destroyed` check to stop runaway `requestAnimationFrame` calls.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
