### PR TITLE
fix(tabs): remove tabindex from panel

### DIFF
--- a/packages/tabs/.size-snapshot.json
+++ b/packages/tabs/.size-snapshot.json
@@ -19,14 +19,14 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 4880,
-    "minified": 2599,
-    "gzipped": 1092
+    "bundled": 4861,
+    "minified": 2588,
+    "gzipped": 1087
   },
   "index.esm.js": {
-    "bundled": 4602,
-    "minified": 2369,
-    "gzipped": 1007,
+    "bundled": 4583,
+    "minified": 2358,
+    "gzipped": 1001,
     "treeshaked": {
       "rollup": {
         "code": 210,

--- a/packages/tabs/src/TabsContainer.spec.tsx
+++ b/packages/tabs/src/TabsContainer.spec.tsx
@@ -106,7 +106,6 @@ describe('TabsContainer', () => {
       tabPanels.forEach((tabPanel, index) => {
         expect(tabPanel).toHaveAttribute('role', 'tabpanel');
         expect(tabPanel).toHaveAttribute('id', getPanelId(index));
-        expect(tabPanel).toHaveAttribute('tabIndex', '0');
         expect(tabPanel).toHaveAttribute('aria-labelledby', getTabId(index));
       });
     });

--- a/packages/tabs/src/useTabs.ts
+++ b/packages/tabs/src/useTabs.ts
@@ -88,7 +88,6 @@ export function useTabs<Item = any>({
 
     return {
       role,
-      tabIndex: 0,
       id: `${PANEL_ID}:${index}`,
       hidden: isHidden,
       'aria-labelledby': `${TAB_ID}:${index}`,


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Through research and discussion, it has been determined that `tabindex=0` is an unwanted default for `role="tabpanel"` components.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
