### PR TITLE
change: replace master with "main" branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,4 +75,4 @@ workflows:
           context: maintainer
           filters:
             branches:
-              only: master
+              only: main

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -2,74 +2,128 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our
-project and our community a harassment-free experience for everyone,
-regardless of age, body size, disability, ethnicity, gender identity and
-expression, level of experience, nationality, personal appearance, race,
-religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Examples of behavior that contributes to a positive environment for our
+community include:
 
-- Using welcoming and inclusive language
-- Being respectful of differing viewpoints and experiences
-- Gracefully accepting constructive criticism
-- Focusing on what is best for the community
-- Showing empathy towards other community members
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behavior include:
 
-- The use of sexualized language or imagery and unwelcome sexual
-  attention or advances
-- Trolling, insulting/derogatory comments, and personal or political
-  attacks
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
 - Public or private harassment
-- Publishing others' private information, such as a physical or
-  electronic address, without explicit permission
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
 - Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
-## Our Responsibilities
+## Enforcement Responsibilities
 
-Project maintainers are responsible for clarifying the standards of
-acceptable behavior and are expected to take appropriate and fair
-corrective action in response to any instances of unacceptable behavior.
+Community leaders are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action
+in response to any behavior that they deem inappropriate, threatening,
+offensive, or harmful.
 
-Project maintainers have the right and responsibility to remove, edit,
-or reject comments, commits, code, wiki edits, issues, and other
-contributions that are not aligned to this Code of Conduct, or to ban
-temporarily or permanently any contributor for other behaviors that they
-deem inappropriate, threatening, offensive, or harmful.
+Community leaders have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, and will communicate reasons
+for moderation decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public
-spaces when an individual is representing the project or its community.
-Examples of representing a project or community include using an
-official project e-mail address, posting via an official social media
-account, or acting as an appointed representative at an online or
-offline event. Representation of a project may be further defined and
-clarified by project maintainers.
+This Code of Conduct applies within all community spaces, and also applies
+when an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may
-be reported by contacting the project team at garden@zendesk.com. The
-project team will review and investigate all complaints, and will
-respond in a way that it deems appropriate to the circumstances. The
-project team is obligated to maintain confidentiality with regard to the
-reporter of an incident. Further details of specific enforcement
-policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+garden@zendesk.com. All complaints will be reviewed and investigated promptly
+and fairly.
 
-Project maintainers who do not follow or enforce the Code of Conduct in
-good faith may face temporary or permanent repercussions as determined
-by other members of the project's leadership.
+All community leaders are obligated to respect the privacy and security of
+the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in
+determining the consequences for any action they deem in violation of this
+Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external
+channels like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited
+interaction with those enforcing the Code of Conduct, is allowed during this
+period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor
-Covenant](https://contributor-covenant.org), version 1.4, available at
-[https://www.contributor-covenant.org/version/1/4/](https://www.contributor-covenant.org/version/1/4/)
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -70,7 +70,7 @@ implementation requirements.
    Use whatever casual commit messaging you find suitable. We'll help
    you apply an appropriate squashed [conventional
    commit](https://conventionalcommits.org/) message when it's time to
-   merge to master.
+   merge to the main branch.
 1. If your changes result in a major modification, be sure all
    documentation is up-to-date.
 1. When your branch is ready, open a new pull request via GitHub.
@@ -82,8 +82,8 @@ implementation requirements.
    considered for merge.
 1. Garden
    [maintainers](https://github.com/orgs/zendeskgarden/teams/maintainers)
-   will manage the squashed merge to master, using your PR title and
-   description as the scope, description, and body for a conventional
+   will manage the squashed merge to master the main branch, using your PR title
+   and description as the scope, description, and body for a conventional
    commit.
 
 ## License

--- a/.huskyrc
+++ b/.huskyrc
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "pre-commit": "lint-staged && yarn lerna run build --since master"
+    "pre-commit": "lint-staged && yarn lerna run build --since main"
   }
 }

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 <!-- markdownlint-enable -->
 
-[build status badge]: https://flat.badgen.net/circleci/github/zendeskgarden/react-containers/master?label=build
-[build status link]: https://circleci.com/gh/zendeskgarden/react-containers/tree/master
+[build status badge]: https://flat.badgen.net/circleci/github/zendeskgarden/react-containers/main?label=build
+[build status link]: https://circleci.com/gh/zendeskgarden/react-containers/tree/main
 [dependency status badge]: https://flat.badgen.net/david/dev/zendeskgarden/react-containers?label=dependencies
 [dependency status link]: https://david-dm.org/zendeskgarden/react-containers?type=dev
-[coverage status badge]: https://flat.badgen.net/coveralls/c/github/zendeskgarden/react-containers/master
+[coverage status badge]: https://flat.badgen.net/coveralls/c/github/zendeskgarden/react-containers/main
 [coverage status link]: https://coveralls.io/github/zendeskgarden/react-containers
 
 > :seedling: Garden is a design system for Zendesk

--- a/lerna.json
+++ b/lerna.json
@@ -8,7 +8,7 @@
     },
     "version": {
       "push": false,
-      "allowBranch": "master",
+      "allowBranch": "main",
       "message": "chore(release): publish"
     }
   }

--- a/packages/breadcrumb/README.md
+++ b/packages/breadcrumb/README.md
@@ -52,4 +52,4 @@ const Breadcrumb = () => {
 
 See [react-breadcrumbs][breadcrumbs link] component.
 
-[breadcrumbs link]: https://github.com/zendeskgarden/react-components/tree/master/packages/breadcrumbs
+[breadcrumbs link]: https://github.com/zendeskgarden/react-components/tree/main/packages/breadcrumbs

--- a/packages/schedule/README.md
+++ b/packages/schedule/README.md
@@ -42,4 +42,4 @@ const Animation = () => {
 
 See [react-loaders][loaders link] component as a non-trivial use of this.
 
-[loaders link]: https://github.com/zendeskgarden/react-components/tree/master/packages/loaders
+[loaders link]: https://github.com/zendeskgarden/react-components/tree/main/packages/loaders

--- a/utils/scripts/deploy.js
+++ b/utils/scripts/deploy.js
@@ -23,7 +23,7 @@ envalid.cleanEnv(process.env, {
     const dir = path.resolve(__dirname, '..', '..', 'demo');
     let url;
 
-    if (branch === 'master') {
+    if (branch === 'main') {
       url = await garden.githubPages({ dir });
     } else {
       const repository = await garden.githubRepository();


### PR DESCRIPTION
## Description

This PR updates the Code of Conduct and the branch name references to `main`. Once it is merged into `main`, the `master` branch can be removed and `main` can be set as the default.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
