### PR TITLE
poc of  focusJail working across multiple containers

### DIFF
--- a/packages/focusjail/stories.tsx
+++ b/packages/focusjail/stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable consistent-return */
 /**
  * Copyright Zendesk, Inc.
  *
@@ -5,7 +6,8 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useRef, createRef } from 'react';
+import React, { useRef, createRef, useState, useEffect } from 'react';
+import ReactDOM from 'react-dom';
 
 import { storiesOf } from '@storybook/react';
 import { withKnobs, boolean } from '@storybook/addon-knobs';
@@ -17,19 +19,75 @@ storiesOf('FocusJail Container', module)
   .add('useFocusJail', () => {
     const FocusJail = () => {
       const containerRef = useRef(null);
+      const containerSecRef = useRef(null);
+      const frame = useRef(null);
+      const [loaded, setLoaded] = useState(false);
+      const [isTargetReady, setIsTargetReady] = useState(false);
+
+      const rootElement = document.createElement('div');
+      const container = useRef(rootElement);
+
+      useEffect(() => {
+        const onLoad = () => {
+          setLoaded(true);
+        };
+
+        if (frame.current.contentDocument.readyState === 'complete') {
+          onLoad();
+
+          return;
+        }
+
+        const currentFrame = frame.current;
+
+        currentFrame.addEventListener('load', onLoad);
+
+        return () => currentFrame.removeEventListener('load', onLoad());
+      }, [frame]);
+
+      useEffect(() => {
+        if (!loaded) {
+          return;
+        }
+
+        const currentContainer = container.current;
+        const currentFrame = frame.current;
+
+        currentFrame.contentDocument.body.appendChild(currentContainer);
+
+        setIsTargetReady(true);
+
+        return () => currentFrame.contentDocument.body.removeChild(currentContainer);
+      }, [frame, rootElement, loaded]);
+
       const { getContainerProps } = useFocusJail({
         focusOnMount: boolean('focusOnMount', true),
-        containerRef
+        containerRef,
+        containerSecRef
       });
+
+      const child = (
+        <div {...getContainerProps({ ref: containerSecRef, tabIndex: -1 })}>
+          <p>Focus is locked within the given elements</p>
+          <input />
+          <button>Focusable Items</button>
+        </div>
+      );
 
       return (
         <>
-          <input />
           <div {...getContainerProps({ ref: containerRef, tabIndex: -1 })}>
-            <p>Focus is locked within the parent element</p>
+            <p>Focus transfers across an iframe as well</p>
             <input />
             <button>Focusable Items</button>
           </div>
+          <div>
+            <div>It skips over elements not in either container</div>
+            <input />
+          </div>
+          <iframe id="custom-frame" width="500" height="300" ref={frame} title={'test'}>
+            {loaded && isTargetReady && ReactDOM.createPortal(child, container.current)}
+          </iframe>
         </>
       );
     };


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(selection):
     add keydown event to handle rtl". the title informs the semantic
     version bump if this PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Allows for the focus jail (only implemented in the useFocusJail hook so far) to take 2 container references and locks the tabbing to all elements in both containers. This will allow for use cases for example where there are multiple connected iframes that we want to be able to tab across.

Added an iframe to the storybook for testing.

## Detail

Takes 2 container references. On each tab event it checks if it matches the last element in any of the containers (the code is mostly written to allow for any number of containers). If it matches lastElement it sets the focus to the first element in the next container. For shift+tab it does the opposite.

In the example used an iframe to better replicate the use case which we need it for, but shouldn't any need for it.

![gif_for_pr](https://user-images.githubusercontent.com/8944331/89495772-553ccd80-d7fc-11ea-9a1c-f4594de831da.gif)

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
