### PR TITLE
chore(webpack): clean up ts-loader option

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -39,10 +39,6 @@ module.exports = ({ config }) => {
       {
         loader: 'ts-loader',
         options: {
-          // Temporarily ignore implicit any warnings caused by source-loader.
-          // Ignoring 7005 can be removed when the GitHub issue is resolved.
-          // See: https://github.com/storybookjs/storybook/issues/7829
-          ignoreDiagnostics: [7005],
           configFile: path.resolve(__dirname, 'tsconfig.storybook.json')
         }
       }


### PR DESCRIPTION
## Description

This PR removes a `ts-loader` option to ignore implicit any warnings originally caused by `source-loader`. The referenced [issue](https://github.com/storybookjs/storybook/issues/7829) has now been closed and Storybook internally ignores unwanted warnings.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
