### PR TITLE
chore(tests): add user-event and improve tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
     "test:all": "jest --config=utils/test/jest.config.js",
     "version": "yarn run build && git add -A"
   },
-  "dependencies": {
-    "@testing-library/user-event": "12.1.0"
-  },
   "devDependencies": {
     "@babel/cli": "7.10.3",
     "@babel/core": "7.10.3",
@@ -51,6 +48,7 @@
     "@testing-library/dom": "7.22.0",
     "@testing-library/jest-dom": "4.2.4",
     "@testing-library/react": "10.4.3",
+    "@testing-library/user-event": "^12.1.1",
     "@types/jest": "26.0.3",
     "@types/prop-types": "15.7.3",
     "@types/react": "16.9.41",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@testing-library/dom": "7.22.0",
     "@testing-library/jest-dom": "4.2.4",
     "@testing-library/react": "10.4.3",
-    "@testing-library/user-event": "^12.1.1",
+    "@testing-library/user-event": "12.1.1",
     "@types/jest": "26.0.3",
     "@types/prop-types": "15.7.3",
     "@types/react": "16.9.41",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "test:all": "jest --config=utils/test/jest.config.js",
     "version": "yarn run build && git add -A"
   },
+  "dependencies": {
+    "@testing-library/user-event": "12.1.0"
+  },
   "devDependencies": {
     "@babel/cli": "7.10.3",
     "@babel/core": "7.10.3",
@@ -45,7 +48,7 @@
     "@storybook/preset-typescript": "^3.0.0",
     "@storybook/react": "5.3.19",
     "@storybook/theming": "5.3.19",
-    "@testing-library/dom": "6.16.0",
+    "@testing-library/dom": "7.22.0",
     "@testing-library/jest-dom": "4.2.4",
     "@testing-library/react": "10.4.3",
     "@types/jest": "26.0.3",

--- a/packages/accordion/src/AccordionContainer.spec.tsx
+++ b/packages/accordion/src/AccordionContainer.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render, fireEvent } from '@testing-library/react';
 import { KEY_CODES } from '@zendeskgarden/container-utilities';
 import { AccordionContainer } from './AccordionContainer';
@@ -98,7 +99,7 @@ describe('AccordionContainer', () => {
     const { getAllByTestId } = render(<BasicExample onChange={onChangeSpy} />);
     const triggers = getAllByTestId('trigger');
 
-    fireEvent.click(triggers[2]);
+    userEvent.click(triggers[2]);
 
     expect(onChangeSpy).toHaveBeenCalledWith(2);
   });
@@ -220,7 +221,7 @@ describe('AccordionContainer', () => {
 
       expect(secondTrigger).toHaveAttribute('aria-expanded', 'false');
 
-      fireEvent.click(secondTrigger);
+      userEvent.click(secondTrigger);
 
       expect(secondTrigger).toHaveAttribute('aria-expanded', 'true');
     });
@@ -321,7 +322,7 @@ describe('AccordionContainer', () => {
       const firstTrigger = getAllByTestId('trigger')[0];
       const firstPanel = getAllByTestId('panel')[0];
 
-      fireEvent.click(firstTrigger);
+      userEvent.click(firstTrigger);
 
       expect(firstPanel).toHaveAttribute('aria-hidden', 'false');
     });
@@ -400,7 +401,7 @@ describe('AccordionContainer', () => {
 
     it('only expands one section at a time', () => {
       // good
-      fireEvent.click(triggers[1]);
+      userEvent.click(triggers[1]);
       triggers.forEach((trigger, index) => {
         const expanded = index === 1 ? 'true' : 'false';
         const hidden = index === 1 ? 'false' : 'true';
@@ -411,7 +412,7 @@ describe('AccordionContainer', () => {
     });
 
     it('can collapse the expanded section', () => {
-      fireEvent.click(triggers[0]);
+      userEvent.click(triggers[0]);
       triggers.forEach((trigger, index) => {
         expect(trigger).toHaveAttribute('aria-expanded', 'false');
         expect(panels[index]).toHaveAttribute('aria-hidden', 'true');
@@ -440,7 +441,7 @@ describe('AccordionContainer', () => {
       const panels = getAllByTestId('panel');
 
       triggers.forEach((trigger, index) => {
-        fireEvent.click(trigger);
+        userEvent.click(trigger);
         expect(trigger).toHaveAttribute('aria-disabled', 'true');
         expect(trigger).toHaveAttribute('aria-expanded', 'true');
         expect(panels[index]).toHaveAttribute('aria-hidden', 'false');
@@ -459,11 +460,11 @@ describe('AccordionContainer', () => {
       expect(trigger).toHaveAttribute('aria-disabled', 'false');
       expect(trigger).toHaveAttribute('aria-expanded', 'false');
       expect(panel).toHaveAttribute('aria-hidden', 'true');
-      fireEvent.click(trigger); // expand!
+      userEvent.click(trigger); // expand!
       expect(trigger).toHaveAttribute('aria-disabled', 'true');
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
       expect(panel).toHaveAttribute('aria-hidden', 'false');
-      fireEvent.click(trigger); // collapse?
+      userEvent.click(trigger); // collapse?
       expect(trigger).toHaveAttribute('aria-disabled', 'true');
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
       expect(panel).toHaveAttribute('aria-hidden', 'false');
@@ -494,7 +495,7 @@ describe('AccordionContainer', () => {
 
     it('only expand-disables section at a time', () => {
       triggers.forEach((trigger, index) => {
-        fireEvent.click(trigger);
+        userEvent.click(trigger);
         triggers.forEach((_trigger, _index) => {
           const expanded = _index === index ? 'true' : 'false';
           const hidden = _index === index ? 'false' : 'true';
@@ -513,7 +514,7 @@ describe('AccordionContainer', () => {
       expect(trigger).toHaveAttribute('aria-disabled', 'true');
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
       expect(panel).toHaveAttribute('aria-hidden', 'false');
-      fireEvent.click(trigger); // collapse?
+      userEvent.click(trigger); // collapse?
       expect(trigger).toHaveAttribute('aria-disabled', 'true');
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
       expect(panel).toHaveAttribute('aria-hidden', 'false');

--- a/packages/buttongroup/src/ButtonGroupContainer.spec.tsx
+++ b/packages/buttongroup/src/ButtonGroupContainer.spec.tsx
@@ -6,7 +6,8 @@
  */
 
 import React, { createRef } from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
 
 import { ButtonGroupContainer } from './ButtonGroupContainer';
 
@@ -74,7 +75,7 @@ describe('ButtonGroupContainer', () => {
       const { getAllByTestId } = render(<BasicExample />);
       const firstButton = getAllByTestId('button')[0];
 
-      fireEvent.click(firstButton);
+      userEvent.click(firstButton);
 
       expect(firstButton).toHaveAttribute('aria-pressed', 'true');
     });

--- a/packages/focusjail/src/FocusJailContainer.spec.tsx
+++ b/packages/focusjail/src/FocusJailContainer.spec.tsx
@@ -8,6 +8,7 @@
 
 import React, { useRef } from 'react';
 import { KEY_CODES } from '@zendeskgarden/container-utilities';
+import userEvent from '@testing-library/user-event';
 import { render, fireEvent } from '@testing-library/react';
 
 import { FocusJailContainer } from './FocusJailContainer';
@@ -245,15 +246,15 @@ describe('FocusJailContainer', () => {
 
       expect(openButton).not.toHaveFocus();
 
-      openButton.focus();
-      fireEvent.click(openButton);
+      userEvent.click(openButton);
+      userEvent.tab();
 
       expect(getByTestId('container')).toHaveFocus();
       expect(openButton).not.toHaveFocus();
 
       const closeButton = getByText('close');
 
-      fireEvent.click(closeButton);
+      userEvent.click(closeButton);
 
       expect(openButton).toHaveFocus();
     });

--- a/packages/focusvisible/src/FocusVisibleContainer.spec.tsx
+++ b/packages/focusvisible/src/FocusVisibleContainer.spec.tsx
@@ -18,7 +18,7 @@ describe('FocusVisibleContainer', () => {
     return (
       <FocusVisibleContainer>
         {({ ref }) => (
-          <div ref={ref} data-test-id="wrapper">
+          <div ref={ref} data-test-id="wrapper" tabIndex={-1}>
             <button data-test-id="button" tabIndex={0}></button>
             <input data-test-id="input" />
             <textarea data-test-id="textarea"></textarea>
@@ -188,7 +188,7 @@ describe('FocusVisibleContainer', () => {
 
       expect(input).not.toHaveAttribute('data-garden-focus-visible');
 
-      userEvent.tab();
+      input.focus();
 
       expect(input).toHaveAttribute('data-garden-focus-visible');
     });
@@ -204,7 +204,7 @@ describe('FocusVisibleContainer', () => {
 
       expect(textarea).not.toHaveAttribute('data-garden-focus-visible');
 
-      userEvent.tab();
+      textarea.focus();
 
       expect(textarea).toHaveAttribute('data-garden-focus-visible');
     });

--- a/packages/focusvisible/src/FocusVisibleContainer.spec.tsx
+++ b/packages/focusvisible/src/FocusVisibleContainer.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render, fireEvent } from '@testing-library/react';
 
 import { FocusVisibleContainer, useFocusVisible } from './';
@@ -56,7 +57,11 @@ describe('FocusVisibleContainer', () => {
     const { getByTestId } = render(<Example />);
     const button = getByTestId('button');
 
-    fireEvent.blur(button);
+    userEvent.tab();
+
+    expect(button).toHaveAttribute('data-garden-focus-visible');
+
+    userEvent.tab();
 
     expect(button).not.toHaveAttribute('data-garden-focus-visible');
   });
@@ -72,8 +77,7 @@ describe('FocusVisibleContainer', () => {
       expect(button).not.toHaveAttribute('data-garden-focus-visible');
     });
 
-    fireEvent.keyDown(button);
-    fireEvent.focus(button);
+    userEvent.tab();
 
     expect(button).toHaveAttribute('data-garden-focus-visible');
   });
@@ -82,8 +86,7 @@ describe('FocusVisibleContainer', () => {
     const { getByTestId } = render(<Example />);
     const button = getByTestId('button');
 
-    fireEvent.mouseDown(button);
-    fireEvent.focus(button);
+    userEvent.click(button);
 
     expect(button).not.toHaveAttribute('data-garden-focus-visible');
   });
@@ -93,8 +96,7 @@ describe('FocusVisibleContainer', () => {
       const { getByTestId } = render(<Example />);
       const wrapper = getByTestId('wrapper');
 
-      fireEvent.keyDown(wrapper);
-      fireEvent.focus(wrapper);
+      userEvent.click(wrapper);
 
       expect(wrapper).not.toHaveAttribute('data-garden-focus-visible');
     });
@@ -103,9 +105,9 @@ describe('FocusVisibleContainer', () => {
       const { getByTestId } = render(<Example />);
       const button = getByTestId('button');
 
-      // Manually call focus() to allow activeElement to be updated
-      button.focus();
-      fireEvent.keyDown(button);
+      expect(button).not.toHaveAttribute('data-garden-focus-visible');
+
+      userEvent.tab();
 
       expect(button).toHaveAttribute('data-garden-focus-visible');
     });
@@ -136,9 +138,17 @@ describe('FocusVisibleContainer', () => {
       const { getByTestId } = render(<Example />);
       const button = getByTestId('button');
 
-      fireEvent.keyDown(button);
-      fireEvent.focus(button);
-      fireEvent.focus(button);
+      expect(button).not.toHaveAttribute('data-garden-focus-visible');
+
+      userEvent.tab();
+
+      expect(button).toHaveAttribute('data-garden-focus-visible');
+
+      userEvent.tab({ shift: true });
+
+      expect(button).not.toHaveAttribute('data-garden-focus-visible');
+
+      userEvent.tab();
 
       expect(button).toHaveAttribute('data-garden-focus-visible');
     });
@@ -147,9 +157,13 @@ describe('FocusVisibleContainer', () => {
       const { getByTestId } = render(<Example />);
       const button = getByTestId('button');
 
-      fireEvent.keyDown(button);
-      fireEvent.focus(button);
-      fireEvent.blur(button);
+      expect(button).not.toHaveAttribute('data-garden-focus-visible');
+
+      userEvent.tab();
+
+      expect(button).toHaveAttribute('data-garden-focus-visible');
+
+      userEvent.tab();
       jest.runOnlyPendingTimers();
 
       expect(button).not.toHaveAttribute('data-garden-focus-visible');
@@ -172,7 +186,9 @@ describe('FocusVisibleContainer', () => {
 
       const input = getByTestId('input');
 
-      fireEvent.focus(input);
+      expect(input).not.toHaveAttribute('data-garden-focus-visible');
+
+      userEvent.tab();
 
       expect(input).toHaveAttribute('data-garden-focus-visible');
     });
@@ -186,37 +202,23 @@ describe('FocusVisibleContainer', () => {
 
       const textarea = getByTestId('textarea');
 
-      fireEvent.focus(textarea);
+      expect(textarea).not.toHaveAttribute('data-garden-focus-visible');
+
+      userEvent.tab();
 
       expect(textarea).toHaveAttribute('data-garden-focus-visible');
     });
 
-    it('does not apply focus-visible to textrea with readOnly enabled', () => {
-      const { getByTestId } = render(
+    it('does not apply focus-visible when element is not reachable via sequential keyboard navigation', () => {
+      const { getByText } = render(
         <KeyboardModalityExample>
-          <textarea data-test-id="textarea" readOnly></textarea>
+          <button tabIndex={-1}>click</button>
         </KeyboardModalityExample>
       );
 
-      const textarea = getByTestId('textarea');
+      userEvent.tab();
 
-      fireEvent.focus(textarea);
-
-      expect(textarea).not.toHaveAttribute('data-garden-focus-visible');
-    });
-
-    it('does not apply focus-visible otherwise', () => {
-      const { getByTestId } = render(
-        <KeyboardModalityExample>
-          <div data-test-id="content" tabIndex={-1}></div>
-        </KeyboardModalityExample>
-      );
-
-      const content = getByTestId('content');
-
-      fireEvent.focus(content);
-
-      expect(content).not.toHaveAttribute('data-garden-focus-visible');
+      expect(getByText('click')).not.toHaveAttribute('data-garden-focus-visible');
     });
   });
 });

--- a/packages/keyboardfocus/src/KeyboardFocusContainer.spec.tsx
+++ b/packages/keyboardfocus/src/KeyboardFocusContainer.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render, fireEvent } from '@testing-library/react';
 
 import { KeyboardFocusContainer } from './KeyboardFocusContainer';
@@ -16,9 +17,7 @@ describe('KeyboardFocusContainer', () => {
   const BasicExample = () => (
     <KeyboardFocusContainer>
       {({ getFocusProps, keyboardFocused }) => (
-        <div {...getFocusProps({ 'data-test-id': 'trigger', 'data-focused': keyboardFocused })}>
-          trigger
-        </div>
+        <div {...getFocusProps({ 'data-focused': keyboardFocused })}>trigger</div>
       )}
     </KeyboardFocusContainer>
   );
@@ -26,63 +25,40 @@ describe('KeyboardFocusContainer', () => {
   describe('getFocusProps', () => {
     describe('onFocus', () => {
       it('should not apply focused prop if focused by mouse', () => {
-        const { container, getByTestId } = render(<BasicExample />);
+        const { container, getByText } = render(<BasicExample />);
 
-        fireEvent.mouseDown(container);
+        userEvent.click(container);
         jest.runOnlyPendingTimers();
-        expect(getByTestId('trigger')).toHaveAttribute('data-focused', 'false');
+        expect(getByText('trigger')).toHaveAttribute('data-focused', 'false');
       });
 
       it('should apply focused prop if focused by keyboard', () => {
-        const { getByTestId } = render(<BasicExample />);
-        const trigger = getByTestId('trigger');
+        const { getByText } = render(<BasicExample />);
+        const trigger = getByText('trigger');
 
-        fireEvent.focus(trigger);
+        userEvent.tab();
         expect(trigger).toHaveAttribute('data-focused', 'true');
       });
 
       it('should apply focused prop if focused by keyboard after mouse event', () => {
-        const { getByTestId } = render(<BasicExample />);
-        const trigger = getByTestId('trigger');
+        const { getByText } = render(<BasicExample />);
+        const trigger = getByText('trigger');
 
-        fireEvent.mouseDown(trigger);
+        userEvent.click(trigger);
         jest.runOnlyPendingTimers();
 
         expect(trigger).toHaveAttribute('data-focused', 'false');
 
-        fireEvent.focus(trigger);
+        userEvent.tab({ shift: true });
+        userEvent.tab();
         expect(trigger).toHaveAttribute('data-focused', 'true');
-      });
-    });
-
-    describe('onMouseDown', () => {
-      it('should not apply focused prop if mouseddown', () => {
-        const { getByTestId } = render(<BasicExample />);
-        const trigger = getByTestId('trigger');
-
-        fireEvent.mouseDown(trigger);
-        jest.runOnlyPendingTimers();
-
-        expect(trigger).toHaveAttribute('data-focused', 'false');
-      });
-    });
-
-    describe('onPointerDown', () => {
-      it('should not apply focused prop if pointerdown is triggered', () => {
-        const { getByTestId } = render(<BasicExample />);
-        const trigger = getByTestId('trigger');
-
-        fireEvent(trigger, new MouseEvent('pointerdown'));
-        jest.runOnlyPendingTimers();
-
-        expect(trigger).toHaveAttribute('data-focused', 'false');
       });
     });
 
     describe('onTouchStart', () => {
       it('should not apply focused prop if touchstart is triggered', () => {
-        const { getByTestId } = render(<BasicExample />);
-        const trigger = getByTestId('trigger');
+        const { getByText } = render(<BasicExample />);
+        const trigger = getByText('trigger');
 
         fireEvent.touchStart(trigger);
         jest.runOnlyPendingTimers();
@@ -93,12 +69,12 @@ describe('KeyboardFocusContainer', () => {
 
     describe('onBlur', () => {
       it('should remove focused prop if blurred', () => {
-        const { getByTestId } = render(<BasicExample />);
-        const trigger = getByTestId('trigger');
+        const { getByText } = render(<BasicExample />);
+        const trigger = getByText('trigger');
 
-        fireEvent.focus(trigger);
+        userEvent.tab();
         expect(trigger).toHaveAttribute('data-focused', 'true');
-        fireEvent.blur(trigger);
+        userEvent.tab();
         expect(trigger).toHaveAttribute('data-focused', 'false');
       });
     });

--- a/packages/modal/src/ModalContainer.spec.tsx
+++ b/packages/modal/src/ModalContainer.spec.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { createRef } from 'react';
+import userEvent from '@testing-library/user-event';
 import { render, fireEvent } from '@testing-library/react';
 import { KEY_CODES } from '@zendeskgarden/container-utilities';
 import { ModalContainer } from './ModalContainer';
@@ -48,15 +49,15 @@ describe('FocusJailContainer', () => {
     it('calls onClose when clicked', () => {
       const { getByTestId } = render(<BasicExample onClose={onCloseSpy} />);
 
-      fireEvent.click(getByTestId('backdrop'));
+      userEvent.click(getByTestId('backdrop'));
       expect(onCloseSpy).toHaveBeenCalled();
     });
   });
 
   describe('getModalProps()', () => {
     it('applies accessibility props', () => {
-      const { getByTestId } = render(<BasicExample onClose={onCloseSpy} />);
-      const modal = getByTestId('modal');
+      const { getByRole } = render(<BasicExample onClose={onCloseSpy} />);
+      const modal = getByRole('dialog');
 
       expect(modal).toHaveAttribute('role', 'dialog');
       expect(modal).toHaveAttribute('tabIndex', '-1');
@@ -68,22 +69,22 @@ describe('FocusJailContainer', () => {
     it('does not trigger onClose when clicked', () => {
       const { getByTestId } = render(<BasicExample onClose={onCloseSpy} />);
 
-      fireEvent.click(getByTestId('modal'));
+      userEvent.click(getByTestId('modal'));
       expect(onCloseSpy).not.toHaveBeenCalled();
     });
 
     describe('onKeyDown', () => {
       it('closes modal when ESC is pressed', () => {
-        const { getByTestId } = render(<BasicExample onClose={onCloseSpy} />);
+        const { getByRole } = render(<BasicExample onClose={onCloseSpy} />);
 
-        fireEvent.keyDown(getByTestId('modal'), { keyCode: KEY_CODES.ESCAPE });
+        fireEvent.keyDown(getByRole('dialog'), { keyCode: KEY_CODES.ESCAPE });
         expect(onCloseSpy).toHaveBeenCalled();
       });
 
       it('does not close modal when other keys are pressed', () => {
-        const { getByTestId } = render(<BasicExample onClose={onCloseSpy} />);
+        const { getByRole } = render(<BasicExample onClose={onCloseSpy} />);
 
-        fireEvent.keyDown(getByTestId('modal'), { keyCode: KEY_CODES.ENTER });
+        fireEvent.keyDown(getByRole('dialog'), { keyCode: KEY_CODES.ENTER });
         expect(onCloseSpy).not.toHaveBeenCalled();
       });
     });
@@ -107,24 +108,24 @@ describe('FocusJailContainer', () => {
 
   describe('getCloseProps()', () => {
     it('applies accessibility props', () => {
-      const { getByTestId } = render(<BasicExample onClose={onCloseSpy} />);
+      const { getByLabelText } = render(<BasicExample onClose={onCloseSpy} />);
 
-      expect(getByTestId('close')).toHaveAttribute('aria-label', 'Close modal');
+      expect(getByLabelText('Close modal')).toBeVisible();
     });
 
     it('closes modal onClick', () => {
-      const { getByTestId } = render(<BasicExample onClose={onCloseSpy} />);
+      const { getByLabelText } = render(<BasicExample onClose={onCloseSpy} />);
 
-      fireEvent.click(getByTestId('close'));
+      userEvent.click(getByLabelText('Close modal'));
       expect(onCloseSpy).toHaveBeenCalled();
     });
   });
 
   describe('closeModal callback', () => {
     it('triggers onClose if callback is triggered', () => {
-      const { getByTestId } = render(<BasicExample onClose={onCloseSpy} />);
+      const { getByText } = render(<BasicExample onClose={onCloseSpy} />);
 
-      fireEvent.click(getByTestId('additional-close'));
+      userEvent.click(getByText('Additional close option'));
       expect(onCloseSpy).toHaveBeenCalled();
     });
   });

--- a/packages/pagination/src/PaginationContainer.spec.tsx
+++ b/packages/pagination/src/PaginationContainer.spec.tsx
@@ -6,7 +6,8 @@
  */
 
 import React, { useRef } from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
 import { IGetPageProps } from './usePagination';
 import { PaginationContainer } from './PaginationContainer';
 
@@ -252,7 +253,7 @@ describe('PaginationContainer', () => {
       });
       const page = getByTestId('page');
 
-      fireEvent.click(page);
+      userEvent.click(page);
       expect(page).toHaveAttribute('aria-label', 'Current page, Page 1');
     });
 

--- a/packages/selection/src/SelectionContainer.spec.tsx
+++ b/packages/selection/src/SelectionContainer.spec.tsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import { KEY_CODES } from '@zendeskgarden/container-utilities';
+import userEvent from '@testing-library/user-event';
 import { render, fireEvent } from '@testing-library/react';
 
 import { SelectionContainer, ISelectionContainerProps } from './SelectionContainer';
@@ -36,12 +37,11 @@ describe('SelectionContainer', () => {
       onFocus={onFocus ? onFocus : undefined}
       onSelect={onSelect ? onSelect : undefined}
     >
-      {({ getContainerProps, getItemProps, focusedItem, selectedItem }) => (
+      {({ getContainerProps, getItemProps, selectedItem }) => (
         <div {...getContainerProps({ 'data-test-id': 'container' })}>
           {itemValues.map(item => {
             const ref = React.createRef();
             const isSelected = item === selectedItem;
-            const isFocused = item === focusedItem;
 
             return (
               <div
@@ -51,8 +51,7 @@ describe('SelectionContainer', () => {
                   item,
                   focusRef: ref,
                   'data-test-id': 'item',
-                  'data-focused': isFocused,
-                  'data-selected': isSelected
+                  'aria-selected': isSelected
                 } as any)}
               >
                 {item}
@@ -76,10 +75,10 @@ describe('SelectionContainer', () => {
     describe('onFocus', () => {
       it('should call onFocus callback', () => {
         const onFocusSpy = jest.fn();
-        const { getAllByTestId } = render(<BasicExample onFocus={onFocusSpy} />);
-        const [item] = getAllByTestId('item');
 
-        fireEvent.focus(item);
+        render(<BasicExample onFocus={onFocusSpy} />);
+
+        userEvent.tab();
 
         expect(onFocusSpy).toHaveBeenCalledWith(itemValues[0]);
       });
@@ -88,10 +87,10 @@ describe('SelectionContainer', () => {
     describe('onSelect', () => {
       it('should call onSelect callback', () => {
         const onSelectSpy = jest.fn();
-        const { getAllByTestId } = render(<BasicExample onSelect={onSelectSpy} />);
-        const [item] = getAllByTestId('item');
+        const { getByText } = render(<BasicExample onSelect={onSelectSpy} />);
+        const item = getByText('Item-1');
 
-        fireEvent.click(item);
+        userEvent.click(item);
 
         expect(onSelectSpy).toHaveBeenCalledWith(itemValues[0]);
       });
@@ -107,317 +106,322 @@ describe('SelectionContainer', () => {
     });
 
     it('first item in container defaults as the only initial focusable item', () => {
-      const { getAllByTestId } = render(<BasicExample />);
-      const [item] = getAllByTestId('item');
+      const { getByText } = render(<BasicExample />);
+      const item = getByText('Item-1');
 
-      fireEvent.focus(item);
+      expect(document.activeElement).not.toBe(item);
+
+      userEvent.tab();
+
       expect(item).toHaveAttribute('tabIndex', '0');
-      expect(item).toHaveAttribute('data-focused', 'true');
+      expect(document.activeElement).toBe(item);
     });
 
     describe('onFocus', () => {
-      it('does not focus item if item is moused down', () => {
-        const { getAllByTestId } = render(<BasicExample />);
-        const [item] = getAllByTestId('item');
-
-        fireEvent.click(item);
-        expect(item).toHaveAttribute('data-focused', 'false');
-        expect(item).toHaveAttribute('data-selected', 'true');
-      });
-
       it('focuses first item if no item is currently selected', () => {
-        const { getAllByTestId } = render(<BasicExample />);
-        const [item] = getAllByTestId('item');
+        const { getByText } = render(<BasicExample />);
+        const item = getByText('Item-1');
 
-        fireEvent.focus(item);
-        expect(item).toHaveAttribute('data-focused', 'true');
+        expect(document.activeElement).not.toBe(item);
+        userEvent.tab();
+        expect(document.activeElement).toBe(item);
       });
 
       it('focuses last item if no item is currently selected and defaultFocusedIndex is provided', () => {
-        const { getAllByTestId } = render(
-          <BasicExample defaultFocusedIndex={itemValues.length - 1} />
-        );
-        const [, , item] = getAllByTestId('item');
+        const { getByText } = render(<BasicExample defaultFocusedIndex={itemValues.length - 1} />);
+        const lastItem = getByText('Item-3');
 
-        expect(item).toHaveAttribute('tabIndex', '0');
+        expect(lastItem).toHaveAttribute('tabIndex', '0');
       });
 
       it('will focus currently selected item if available', () => {
-        const { getAllByTestId } = render(<BasicExample />);
-        const [, , item] = getAllByTestId('item');
+        const { getByText } = render(<BasicExample />);
+        const lastItem = getByText('Item-3');
 
-        fireEvent.click(item);
-        expect(item).toHaveAttribute('tabIndex', '0');
+        userEvent.click(lastItem);
+        expect(lastItem).toHaveAttribute('tabIndex', '0');
       });
     });
 
     describe('onBlur', () => {
       it('clears currently focused item', () => {
-        const { getAllByTestId } = render(<BasicExample />);
-        const [item] = getAllByTestId('item');
+        const { getByText } = render(<BasicExample />);
+        const item = getByText('Item-1');
 
-        fireEvent.focus(item);
-        expect(item).toHaveAttribute('data-focused', 'true');
+        userEvent.tab();
+        expect(document.activeElement).toBe(item);
 
-        fireEvent.blur(item);
-        expect(item).toHaveAttribute('data-focused', 'false');
+        userEvent.tab();
+        expect(document.activeElement).not.toBe(item);
       });
     });
 
     describe('onKeyDown', () => {
       describe('ENTER keyCode', () => {
         it('selects currently focused item', () => {
-          const { getAllByTestId } = render(<BasicExample />);
-          const [item] = getAllByTestId('item');
+          const { getByText } = render(<BasicExample />);
+          const item = getByText('Item-1');
 
-          fireEvent.focus(item);
           fireEvent.keyDown(item, { keyCode: KEY_CODES.ENTER });
-          expect(item).toHaveAttribute('data-selected', 'true');
+          expect(item).toHaveAttribute('aria-selected', 'true');
         });
       });
 
       describe('SPACE keyCode', () => {
         it('selects currently focused item', () => {
-          const { getAllByTestId } = render(<BasicExample />);
-          const [item] = getAllByTestId('item');
+          const { getByText } = render(<BasicExample />);
+          const item = getByText('Item-1');
 
-          fireEvent.focus(item);
           fireEvent.keyDown(item, { keyCode: KEY_CODES.SPACE });
-          expect(item).toHaveAttribute('data-selected', 'true');
+          expect(item).toHaveAttribute('aria-selected', 'true');
         });
       });
 
       describe('HOME keyCode', () => {
         it('focuses first available item', () => {
-          const { getAllByTestId } = render(<BasicExample />);
-          const [item] = getAllByTestId('item');
+          const { getByText } = render(<BasicExample />);
+          const item = getByText('Item-1');
 
-          fireEvent.focus(item);
           fireEvent.keyDown(item, { keyCode: KEY_CODES.HOME });
-          expect(item).toHaveAttribute('data-focused', 'true');
+          expect(document.activeElement).toBe(item);
         });
       });
 
       describe('END keyCode', () => {
         it('focuses last available item', () => {
-          const { getAllByTestId } = render(<BasicExample />);
-          const [item, , lastItem] = getAllByTestId('item');
+          const { getByText } = render(<BasicExample />);
+          const item = getByText('Item-2');
+          const lastItem = getByText('Item-3');
 
-          fireEvent.focus(item);
           fireEvent.keyDown(item, { keyCode: KEY_CODES.END });
-          expect(lastItem).toHaveAttribute('data-focused', 'true');
+          expect(document.activeElement).toBe(lastItem);
         });
       });
 
       describe('while in horizontal mode', () => {
         describe('LEFT keyCode', () => {
           describe('when dir is LTR', () => {
-            it('decrements focusedIndex if currently greater than 0', () => {
-              const { getAllByTestId } = render(<BasicExample />);
-              const [item, secondItem] = getAllByTestId('item');
+            it('focuses on the first item when triggered from second item', () => {
+              const { getByText } = render(<BasicExample />);
+              const item = getByText('Item-1');
+              const secondItem = getByText('Item-2');
 
-              fireEvent.focus(secondItem);
+              userEvent.click(secondItem);
               fireEvent.keyDown(secondItem, { keyCode: KEY_CODES.LEFT });
 
-              expect(item).toHaveAttribute('data-focused', 'true');
+              expect(document.activeElement).toBe(item);
+              expect(item).toHaveAttribute('aria-selected', 'false');
             });
 
-            it('decrements and wraps focusedIndex if currently less than or equal to 0', () => {
-              const { getAllByTestId } = render(<BasicExample />);
-              const [item, , lastItem] = getAllByTestId('item');
+            it('focuses on the last item after pressing left arrow key on first item', () => {
+              const { getByText } = render(<BasicExample />);
+              const item = getByText('Item-1');
+              const lastItem = getByText('Item-3');
 
-              fireEvent.focus(item);
+              userEvent.tab();
               fireEvent.keyDown(item, { keyCode: KEY_CODES.LEFT });
-              expect(lastItem).toHaveAttribute('data-focused', 'true');
+
+              expect(document.activeElement).toBe(lastItem);
+              expect(lastItem).toHaveAttribute('aria-selected', 'false');
             });
           });
 
           describe('when dir is RTL', () => {
-            it('increments focusedIndex if currently less than items length', () => {
-              const { getAllByTestId } = render(<BasicExample rtl={true} />);
-              const [item, secondItem] = getAllByTestId('item');
+            it('focuses on the second item when triggered from first item', () => {
+              const { getByText } = render(<BasicExample rtl={true} />);
+              const item = getByText('Item-1');
+              const secondItem = getByText('Item-2');
 
-              fireEvent.focus(item);
+              userEvent.tab();
               fireEvent.keyDown(item, { keyCode: KEY_CODES.LEFT });
 
-              expect(secondItem).toHaveAttribute('data-focused', 'true');
+              expect(document.activeElement).toBe(secondItem);
+              expect(secondItem).toHaveAttribute('aria-selected', 'false');
             });
 
-            it('increments and wraps focusedIndex if currently greater than or equal to items length', () => {
-              const { getAllByTestId } = render(<BasicExample rtl={true} />);
-              const [item, , lastItem] = getAllByTestId('item');
+            it('focuses on the first item when triggered from last item', () => {
+              const { getByText } = render(<BasicExample rtl={true} />);
+              const item = getByText('Item-1');
+              const lastItem = getByText('Item-3');
 
-              fireEvent.focus(lastItem);
+              userEvent.click(lastItem);
               fireEvent.keyDown(lastItem, { keyCode: KEY_CODES.LEFT });
 
-              expect(item).toHaveAttribute('data-focused', 'true');
+              expect(document.activeElement).toBe(item);
+              expect(item).toHaveAttribute('aria-selected', 'false');
             });
           });
         });
 
         describe('RIGHT keyCode', () => {
           describe('when dir is LTR', () => {
-            it('increments focusedIndex if currently less than items length', () => {
-              const { getAllByTestId } = render(<BasicExample />);
-              const [item, secondItem] = getAllByTestId('item');
+            it('focuses on the second next item when triggered from first item', () => {
+              const { getByText } = render(<BasicExample />);
+              const item = getByText('Item-1');
+              const secondItem = getByText('Item-2');
 
-              fireEvent.click(item);
+              userEvent.click(item);
               fireEvent.keyDown(item, { keyCode: KEY_CODES.RIGHT });
-              expect(secondItem).toHaveAttribute('data-focused', 'true');
+              expect(secondItem).toBe(document.activeElement);
             });
 
-            it('increments and wrap focusedIndex if currently greater than or equal to items length', () => {
-              const { getAllByTestId } = render(<BasicExample />);
-              const [item, , lastItem] = getAllByTestId('item');
+            it('focuses on the first item when triggered from last item', () => {
+              const { getByText } = render(<BasicExample />);
+              const item = getByText('Item-1');
+              const lastItem = getByText('Item-3');
 
-              fireEvent.focus(lastItem);
+              userEvent.click(lastItem);
               fireEvent.keyDown(lastItem, { keyCode: KEY_CODES.RIGHT });
-              expect(item).toHaveAttribute('data-focused', 'true');
+              expect(item).toBe(document.activeElement);
             });
           });
 
           describe('when dir is RTL', () => {
-            it('decrements focusedIndex if currently greater than 0', () => {
-              const { getAllByTestId } = render(<BasicExample rtl={true} />);
-              const [item, secondItem] = getAllByTestId('item');
+            it('focuses on the first item when triggered from second item', () => {
+              const { getByText } = render(<BasicExample rtl={true} />);
+              const item = getByText('Item-1');
+              const secondItem = getByText('Item-2');
 
-              fireEvent.focus(secondItem);
+              userEvent.click(secondItem);
               fireEvent.keyDown(secondItem, { keyCode: KEY_CODES.RIGHT });
 
-              expect(item).toHaveAttribute('data-focused', 'true');
+              expect(item).toBe(document.activeElement);
             });
 
-            it('decrements and wraps focusedIndex if currently 0', () => {
-              const { getAllByTestId } = render(<BasicExample rtl={true} />);
-              const [item, , lastItem] = getAllByTestId('item');
+            it('focuses on the last item when triggered from first item', () => {
+              const { getByText } = render(<BasicExample rtl={true} />);
+              const item = getByText('Item-1');
+              const lastItem = getByText('Item-3');
 
-              fireEvent.focus(item);
+              userEvent.click(item);
               fireEvent.keyDown(item, { keyCode: KEY_CODES.RIGHT });
 
-              expect(lastItem).toHaveAttribute('data-focused', 'true');
+              expect(lastItem).toBe(document.activeElement);
             });
           });
         });
 
         describe('UP keyCode', () => {
           it('does not perform any action', () => {
-            const { getAllByTestId } = render(<BasicExample />);
-            const [item, secondItem, lastItem] = getAllByTestId('item');
+            const { getByText } = render(<BasicExample />);
+            const item = getByText('Item-1');
 
-            fireEvent.click(item);
+            userEvent.click(item);
+            expect(item).toBe(document.activeElement);
+
             fireEvent.keyDown(item, { keyCode: KEY_CODES.UP });
-
-            expect(item).toHaveAttribute('data-focused', 'false');
-            expect(secondItem).toHaveAttribute('data-focused', 'false');
-            expect(lastItem).toHaveAttribute('data-focused', 'false');
+            expect(item).toBe(document.activeElement);
           });
         });
 
         describe('DOWN keyCode', () => {
           it('does not perform any action', () => {
-            const { getAllByTestId } = render(<BasicExample />);
-            const [item, secondItem, lastItem] = getAllByTestId('item');
+            const { getByText } = render(<BasicExample />);
+            const item = getByText('Item-1');
 
-            fireEvent.click(item);
+            userEvent.click(item);
+            expect(item).toBe(document.activeElement);
+
             fireEvent.keyDown(item, { keyCode: KEY_CODES.DOWN });
-
-            expect(item).toHaveAttribute('data-focused', 'false');
-            expect(secondItem).toHaveAttribute('data-focused', 'false');
-            expect(lastItem).toHaveAttribute('data-focused', 'false');
+            expect(item).toBe(document.activeElement);
           });
         });
       });
 
       describe('while using vertical direction', () => {
         describe('UP keyCode', () => {
-          it('decrements focusedIndex if currently greater than 0', () => {
-            const { getAllByTestId } = render(<BasicExample direction="vertical" />);
-            const [item, secondItem] = getAllByTestId('item');
+          it('focuses on the first item when triggered from second item', () => {
+            const { getByText } = render(<BasicExample direction="vertical" />);
+            const item = getByText('Item-1');
+            const secondItem = getByText('Item-2');
 
-            fireEvent.click(secondItem);
+            userEvent.click(secondItem);
             fireEvent.keyDown(secondItem, { keyCode: KEY_CODES.UP });
 
-            expect(item).toHaveAttribute('data-focused', 'true');
+            expect(item).toBe(document.activeElement);
           });
 
-          it('decrements focusedIndex in RTL mode', () => {
-            const { getAllByTestId } = render(<BasicExample direction="vertical" rtl />);
-            const [item, secondItem] = getAllByTestId('item');
+          it('focuses on the first item when triggered from second item in RTL', () => {
+            const { getByText } = render(<BasicExample direction="vertical" rtl />);
+            const item = getByText('Item-1');
+            const secondItem = getByText('Item-2');
 
-            fireEvent.click(secondItem);
+            userEvent.click(secondItem);
             fireEvent.keyDown(secondItem, { keyCode: KEY_CODES.UP });
 
-            expect(item).toHaveAttribute('data-focused', 'true');
+            expect(item).toBe(document.activeElement);
           });
 
-          it('decrements and wraps focusedIndex if currently less than or equal to 0', () => {
-            const { getAllByTestId } = render(<BasicExample direction="vertical" />);
-            const [item, , lastItem] = getAllByTestId('item');
+          it('focuses on the last item when triggered from first item', () => {
+            const { getByText } = render(<BasicExample direction="vertical" />);
+            const item = getByText('Item-1');
+            const lastItem = getByText('Item-3');
 
-            fireEvent.click(item);
+            userEvent.click(item);
             fireEvent.keyDown(item, { keyCode: KEY_CODES.UP });
 
-            expect(lastItem).toHaveAttribute('data-focused', 'true');
+            expect(lastItem).toBe(document.activeElement);
           });
         });
 
         describe('DOWN keyCode', () => {
-          it('increments focusedIndex if currently less than items length', () => {
-            const { getAllByTestId } = render(<BasicExample direction="vertical" />);
-            const [item, secondItem] = getAllByTestId('item');
+          it('focuses on the second item when triggered from first item', () => {
+            const { getByText } = render(<BasicExample direction="vertical" />);
+            const item = getByText('Item-1');
+            const secondItem = getByText('Item-2');
 
-            fireEvent.click(item);
+            userEvent.click(item);
             fireEvent.keyDown(item, { keyCode: KEY_CODES.DOWN });
 
-            expect(secondItem).toHaveAttribute('data-focused', 'true');
+            expect(secondItem).toBe(document.activeElement);
           });
 
-          it('increments focusedIndex in RTL mode', () => {
-            const { getAllByTestId } = render(<BasicExample direction="vertical" rtl />);
-            const [item, secondItem] = getAllByTestId('item');
+          it('focuses on the second item when triggered from first item in RTL', () => {
+            const { getByText } = render(<BasicExample direction="vertical" rtl />);
+            const item = getByText('Item-1');
+            const secondItem = getByText('Item-2');
 
-            fireEvent.click(item);
+            userEvent.click(item);
             fireEvent.keyDown(item, { keyCode: KEY_CODES.DOWN });
 
-            expect(secondItem).toHaveAttribute('data-focused', 'true');
+            expect(secondItem).toBe(document.activeElement);
           });
 
-          it('increments and wraps focusedIndex if currently greater than or equal to items length', () => {
-            const { getAllByTestId } = render(<BasicExample direction="vertical" />);
-            const [item, , lastItem] = getAllByTestId('item');
+          it('focuses on the first item when triggered from last item', () => {
+            const { getByText } = render(<BasicExample direction="vertical" />);
+            const item = getByText('Item-1');
+            const lastItem = getByText('Item-3');
 
-            fireEvent.click(lastItem);
+            userEvent.click(lastItem);
             fireEvent.keyDown(lastItem, { keyCode: KEY_CODES.DOWN });
 
-            expect(item).toHaveAttribute('data-focused', 'true');
+            expect(item).toBe(document.activeElement);
           });
         });
 
         describe('LEFT keyCode', () => {
           it('does not perform any action', () => {
-            const { getAllByTestId } = render(<BasicExample direction="vertical" />);
-            const [item, secondItem, lastItem] = getAllByTestId('item');
+            const { getByText } = render(<BasicExample direction="vertical" />);
+            const item = getByText('Item-1');
 
-            fireEvent.click(item);
+            userEvent.click(item);
+            expect(item).toBe(document.activeElement);
+
             fireEvent.keyDown(item, { keyCode: KEY_CODES.LEFT });
-
-            expect(item).toHaveAttribute('data-focused', 'false');
-            expect(secondItem).toHaveAttribute('data-focused', 'false');
-            expect(lastItem).toHaveAttribute('data-focused', 'false');
+            expect(item).toBe(document.activeElement);
           });
         });
 
         describe('RIGHT keyCode', () => {
           it('does not perform any action', () => {
-            const { getAllByTestId } = render(<BasicExample direction="vertical" />);
-            const [item, secondItem, lastItem] = getAllByTestId('item');
+            const { getByText } = render(<BasicExample direction="vertical" />);
+            const item = getByText('Item-1');
 
-            fireEvent.click(item);
+            userEvent.click(item);
+            expect(item).toBe(document.activeElement);
+
             fireEvent.keyDown(item, { keyCode: KEY_CODES.RIGHT });
-
-            expect(item).toHaveAttribute('data-focused', 'false');
-            expect(secondItem).toHaveAttribute('data-focused', 'false');
-            expect(lastItem).toHaveAttribute('data-focused', 'false');
+            expect(item).toBe(document.activeElement);
           });
         });
       });
@@ -456,52 +460,42 @@ describe('SelectionContainer', () => {
     });
 
     it('applies accessibility role attribute', () => {
-      const { getAllByTestId } = render(<BasicExample />);
-      const [item] = getAllByTestId('item');
+      const { getByText } = render(<BasicExample />);
+      const item = getByText('Item-1');
 
       expect(item).toHaveAttribute('role', 'option');
     });
 
     it('applies default selected aria value if none provided', () => {
-      const { getAllByTestId } = render(<BasicExample />);
-      const [item] = getAllByTestId('item');
+      const { getByText } = render(<BasicExample />);
+      const item = getByText('Item-1');
 
       expect(item).toHaveAttribute('aria-selected', 'false');
     });
 
     it('applies selected aria value if defaultSelectedIndex is passed', () => {
-      const { getAllByTestId } = render(<BasicExample defaultSelectedIndex={1} />);
-      const [, item] = getAllByTestId('item');
+      const { getByText } = render(<BasicExample defaultSelectedIndex={1} />);
+      const secondItem = getByText('Item-2');
 
-      expect(item).toHaveAttribute('aria-selected', 'true');
+      expect(secondItem).toHaveAttribute('aria-selected', 'true');
     });
 
     it('applies custom selected aria value if provided', () => {
-      const { getAllByTestId } = render(<BasicExample selectedAriaKey="aria-pressed" />);
-      const [item] = getAllByTestId('item');
+      const { getByText } = render(<BasicExample selectedAriaKey="aria-pressed" />);
+      const item = getByText('Item-1');
 
       expect(item).toHaveAttribute('aria-pressed', 'false');
     });
 
     describe('onClick', () => {
-      it('should select item that was clicked', () => {
-        const { getAllByTestId } = render(<BasicExample />);
-        const [, , lastItem] = getAllByTestId('item');
+      it('should select and focus item that was clicked', () => {
+        const { getByText } = render(<BasicExample />);
+        const lastItem = getByText('Item-3');
 
-        fireEvent.click(lastItem);
+        userEvent.click(lastItem);
 
         expect(lastItem).toHaveAttribute('aria-selected', 'true');
-      });
-
-      it('should remove focus from all items', () => {
-        const { getAllByTestId } = render(<BasicExample />);
-        const [item, secondItem, lastItem] = getAllByTestId('item');
-
-        fireEvent.click(lastItem);
-
-        expect(item).toHaveAttribute('data-focused', 'false');
-        expect(secondItem).toHaveAttribute('data-focused', 'false');
-        expect(lastItem).toHaveAttribute('data-focused', 'false');
+        expect(lastItem).toBe(document.activeElement);
       });
     });
   });

--- a/packages/tabs/src/TabsContainer.spec.tsx
+++ b/packages/tabs/src/TabsContainer.spec.tsx
@@ -7,7 +7,8 @@
  */
 
 import React, { createRef } from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
 
 import { TabsContainer, ITabsContainerProps } from './TabsContainer';
 
@@ -63,7 +64,7 @@ describe('TabsContainer', () => {
     const { getAllByTestId } = render(<BasicExample onSelect={onSelectSpy} />);
     const [tab] = getAllByTestId('tab');
 
-    fireEvent.click(tab);
+    userEvent.click(tab);
 
     expect(onSelectSpy).toHaveBeenCalledWith('tab-1');
   });
@@ -123,7 +124,7 @@ describe('TabsContainer', () => {
         const [, , tab] = getAllByTestId('tab');
         const [firstPanel, secondPanel] = getAllByTestId('tab-panel');
 
-        fireEvent.click(tab);
+        userEvent.click(tab);
 
         expect(firstPanel).toHaveAttribute('hidden');
         expect(secondPanel).toHaveAttribute('hidden');
@@ -134,7 +135,7 @@ describe('TabsContainer', () => {
         const [, tab] = getAllByTestId('tab');
         const [, tabPanel] = getAllByTestId('tab-panel');
 
-        fireEvent.click(tab);
+        userEvent.click(tab);
 
         expect(tabPanel).not.toHaveAttribute('hidden');
       });

--- a/packages/tooltip/src/TooltipContainer.spec.tsx
+++ b/packages/tooltip/src/TooltipContainer.spec.tsx
@@ -6,8 +6,10 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render, fireEvent } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
+import { KEY_CODES } from '@zendeskgarden/container-utilities';
 
 import { TooltipContainer, ITooltipContainerProps } from './TooltipContainer';
 
@@ -21,14 +23,8 @@ describe('TooltipContainer', () => {
       <TooltipContainer id={TOOLTIP_ID} {...props}>
         {({ getTooltipProps, getTriggerProps }) => (
           <>
-            <div {...getTriggerProps({ 'data-test-id': 'trigger' })}>trigger</div>
-            <div
-              {...getTooltipProps({
-                'data-test-id': 'tooltip'
-              })}
-            >
-              tooltip
-            </div>
+            <div {...getTriggerProps()}>trigger</div>
+            <div {...getTooltipProps()}>tooltip</div>
           </>
         )}
       </TooltipContainer>
@@ -40,15 +36,15 @@ describe('TooltipContainer', () => {
   });
 
   it('defaults visibility state with isVisible prop', () => {
-    const { getByTestId } = render(<BasicExample isVisible={true} />);
+    const { getByText } = render(<BasicExample isVisible={true} />);
 
-    expect(getByTestId('tooltip')).toHaveAttribute('aria-hidden', 'false');
+    expect(getByText('tooltip')).toHaveAttribute('aria-hidden', 'false');
   });
 
   describe('getTriggerProps', () => {
     it('applies correct accessibility attributes', () => {
-      const { getByTestId } = render(<BasicExample />);
-      const trigger = getByTestId('trigger');
+      const { getByText } = render(<BasicExample />);
+      const trigger = getByText('trigger');
 
       expect(trigger).toHaveAttribute('tabIndex', '0');
       expect(trigger).toHaveAttribute('aria-describedby', TOOLTIP_ID);
@@ -56,64 +52,69 @@ describe('TooltipContainer', () => {
 
     describe('onFocus()', () => {
       it('should not display tooltip immediately when focused', () => {
-        const { getByTestId } = render(<BasicExample />);
+        const { getByText } = render(<BasicExample />);
 
-        fireEvent.focus(getByTestId('trigger'));
+        userEvent.tab();
 
-        expect(getByTestId('tooltip')).toHaveAttribute('aria-hidden', 'true');
+        expect(getByText('tooltip')).toHaveAttribute('aria-hidden', 'true');
       });
 
       it('should display tooltip after delay when focused', () => {
-        const { getByTestId } = render(<BasicExample />);
+        const { getByRole } = render(<BasicExample />);
 
-        fireEvent.focus(getByTestId('trigger'));
+        userEvent.tab();
         act(() => {
           jest.runOnlyPendingTimers();
         });
 
-        expect(getByTestId('tooltip')).toHaveAttribute('aria-hidden', 'false');
+        expect(getByRole('tooltip')).toHaveAttribute('aria-hidden', 'false');
       });
     });
 
     describe('onBlur()', () => {
       it('should close tooltip immediately after blur', () => {
-        const { getByTestId } = render(<BasicExample />);
-        const trigger = getByTestId('trigger');
+        const { getByText, getByRole } = render(<BasicExample />);
 
-        fireEvent.focus(trigger);
-        fireEvent.blur(trigger);
+        userEvent.tab();
         act(() => {
           jest.runOnlyPendingTimers();
         });
 
-        expect(getByTestId('tooltip')).toHaveAttribute('aria-hidden', 'true');
+        expect(getByRole('tooltip')).toHaveAttribute('aria-hidden', 'false');
+
+        userEvent.tab();
+        act(() => {
+          jest.runOnlyPendingTimers();
+        });
+
+        expect(getByText('tooltip')).toHaveAttribute('aria-hidden', 'true');
       });
     });
 
     describe('onMouseEnter()', () => {
       it('should not display tooltip immediately when clicked', () => {
-        const { getByTestId } = render(<BasicExample />);
+        const { getByText } = render(<BasicExample />);
 
-        fireEvent.mouseEnter(getByTestId('trigger'));
+        userEvent.hover(getByText('trigger'));
 
-        expect(getByTestId('tooltip')).toHaveAttribute('aria-hidden', 'true');
+        expect(getByText('tooltip')).toHaveAttribute('aria-hidden', 'true');
       });
 
       it('should display tooltip after delay when clicked', () => {
-        const { getByTestId } = render(<BasicExample />);
+        const { getByText, getByRole } = render(<BasicExample />);
 
-        fireEvent.mouseEnter(getByTestId('trigger'));
+        userEvent.hover(getByText('trigger'));
         act(() => {
           jest.runOnlyPendingTimers();
         });
 
-        expect(getByTestId('tooltip')).toHaveAttribute('aria-hidden', 'false');
+        expect(getByRole('tooltip')).toHaveAttribute('aria-hidden', 'false');
       });
 
       it('should clear open timeout if unmounted during interval', () => {
-        const { getByTestId, unmount } = render(<BasicExample />);
+        const { getByText, unmount } = render(<BasicExample />);
 
-        fireEvent.mouseEnter(getByTestId('trigger'));
+        userEvent.hover(getByText('trigger'));
 
         unmount();
         // 3 total clearTimeouts occur during this action
@@ -123,59 +124,58 @@ describe('TooltipContainer', () => {
 
     describe('onMouseLeave()', () => {
       it('should not hide tooltip immediately when mouseleaved', () => {
-        const { getByTestId } = render(<BasicExample />);
-        const trigger = getByTestId('trigger');
-        const tooltip = getByTestId('tooltip');
+        const { getByText, getByRole } = render(<BasicExample />);
+        const trigger = getByText('trigger');
 
-        fireEvent.mouseEnter(trigger);
+        userEvent.hover(trigger);
         act(() => {
           jest.runOnlyPendingTimers();
         });
 
-        expect(tooltip).toHaveAttribute('aria-hidden', 'false');
+        expect(getByRole('tooltip')).toHaveAttribute('aria-hidden', 'false');
 
-        fireEvent.mouseLeave(trigger);
+        userEvent.unhover(trigger);
 
-        expect(tooltip).toHaveAttribute('aria-hidden', 'false');
+        expect(getByText('tooltip')).toHaveAttribute('aria-hidden', 'false');
       });
 
       it('should hide tooltip after delay when mouseleaved', () => {
-        const { getByTestId } = render(<BasicExample />);
-        const trigger = getByTestId('trigger');
+        const { getByText } = render(<BasicExample />);
+        const trigger = getByText('trigger');
 
-        fireEvent.mouseEnter(trigger);
-        fireEvent.mouseLeave(trigger);
+        userEvent.hover(trigger);
+        userEvent.unhover(trigger);
         act(() => {
           jest.runOnlyPendingTimers();
         });
 
-        expect(getByTestId('tooltip')).toHaveAttribute('aria-hidden', 'true');
+        expect(getByText('tooltip')).toHaveAttribute('aria-hidden', 'true');
       });
     });
 
     describe('onKeyDown()', () => {
       it('should hide tooltip when escape is pressed', () => {
-        const { getByTestId } = render(<BasicExample />);
-        const trigger = getByTestId('trigger');
+        const { getByText } = render(<BasicExample />);
+        const trigger = getByText('trigger');
 
-        fireEvent.focus(trigger);
+        userEvent.tab();
         act(() => {
           jest.runOnlyPendingTimers();
         });
 
-        fireEvent.keyDown(trigger, { keyCode: 27 });
+        fireEvent.keyDown(trigger, { keyCode: KEY_CODES.ESCAPE });
         act(() => {
           jest.runOnlyPendingTimers();
         });
 
-        expect(getByTestId('tooltip')).toHaveAttribute('aria-hidden', 'true');
+        expect(getByText('tooltip')).toHaveAttribute('aria-hidden', 'true');
       });
 
       it('should not hide tooltip if escape is not pressed', () => {
-        const { getByTestId } = render(<BasicExample />);
-        const trigger = getByTestId('trigger');
+        const { getByText, getByRole } = render(<BasicExample />);
+        const trigger = getByText('trigger');
 
-        fireEvent.focus(trigger);
+        userEvent.tab();
         act(() => {
           jest.runOnlyPendingTimers();
         });
@@ -185,15 +185,15 @@ describe('TooltipContainer', () => {
           jest.runOnlyPendingTimers();
         });
 
-        expect(getByTestId('tooltip')).toHaveAttribute('aria-hidden', 'false');
+        expect(getByRole('tooltip')).toHaveAttribute('aria-hidden', 'false');
       });
     });
   });
 
   describe('getTooltipProps', () => {
     it('applies correct accessibility attributes', () => {
-      const { getByTestId } = render(<BasicExample />);
-      const tooltip = getByTestId('tooltip');
+      const { getByText } = render(<BasicExample />);
+      const tooltip = getByText('tooltip');
 
       expect(tooltip).toHaveAttribute('role', 'tooltip');
       expect(tooltip).toHaveAttribute('aria-hidden', 'true');
@@ -201,39 +201,40 @@ describe('TooltipContainer', () => {
     });
 
     it('should not close tooltip if mouseenter during close delay period', () => {
-      const { getByTestId } = render(<BasicExample />);
-      const trigger = getByTestId('trigger');
+      const { getByText, getByRole } = render(<BasicExample />);
+      const trigger = getByText('trigger');
 
-      fireEvent.mouseEnter(trigger);
+      userEvent.hover(trigger);
       act(() => {
         jest.runOnlyPendingTimers();
       });
 
-      fireEvent.mouseLeave(trigger);
-      fireEvent.mouseEnter(trigger);
+      userEvent.unhover(trigger);
+      userEvent.hover(trigger);
       act(() => {
         jest.runOnlyPendingTimers();
       });
 
-      expect(getByTestId('tooltip')).toHaveAttribute('aria-hidden', 'false');
+      expect(getByRole('tooltip')).toHaveAttribute('aria-hidden', 'false');
     });
 
     it('should close tooltip if mouseleaveed', () => {
-      const { getByTestId } = render(<BasicExample />);
-      const trigger = getByTestId('trigger');
+      const { getByText, getByRole } = render(<BasicExample />);
+      const trigger = getByText('trigger');
 
-      fireEvent.mouseEnter(trigger);
+      userEvent.hover(trigger);
       act(() => {
         jest.runOnlyPendingTimers();
       });
 
-      fireEvent.mouseEnter(trigger);
-      fireEvent.mouseLeave(trigger);
+      expect(getByRole('tooltip')).toHaveAttribute('aria-hidden', 'false');
+
+      userEvent.unhover(trigger);
       act(() => {
         jest.runOnlyPendingTimers();
       });
 
-      expect(getByTestId('tooltip')).toHaveAttribute('aria-hidden', 'true');
+      expect(getByText('tooltip')).toHaveAttribute('aria-hidden', 'true');
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5188,7 +5188,7 @@
     "@babel/runtime" "^7.10.3"
     "@testing-library/dom" "^7.17.1"
 
-"@testing-library/user-event@^12.1.1":
+"@testing-library/user-event@12.1.1":
   version "12.1.1"
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.1.1.tgz#ff985f97f7f6b8f8c3c8ae5a7deb883007bc6820"
   integrity sha512-gJ2lD3tANqVLS6GWh2gEqvEYDPlxzR+6uLAvzdb5CH6KIM6kXfCwsvK0oLhmDRFAuj8WfnBH9CaM5YDplkWFrQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5188,10 +5188,10 @@
     "@babel/runtime" "^7.10.3"
     "@testing-library/dom" "^7.17.1"
 
-"@testing-library/user-event@12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.1.0.tgz#a2597419466a93e338c91baa7bb22d4da0309d1d"
-  integrity sha512-aH/XuNFpPD6dA+fh754EGqKeAzpH66HpLJYkv9vOAih2yGmTM8JiZ8uisQDGWRPkc6sxE2zCqDwLR4ZskhRCxw==
+"@testing-library/user-event@^12.1.1":
+  version "12.1.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.1.1.tgz#ff985f97f7f6b8f8c3c8ae5a7deb883007bc6820"
+  integrity sha512-gJ2lD3tANqVLS6GWh2gEqvEYDPlxzR+6uLAvzdb5CH6KIM6kXfCwsvK0oLhmDRFAuj8WfnBH9CaM5YDplkWFrQ==
   dependencies:
     "@babel/runtime" "^7.10.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2718,14 +2718,6 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime-corejs3@^7.7.4":
-  version "7.8.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.8.4.tgz#ccc4e042e2fae419c67fa709567e5d2179ed3940"
-  integrity sha512-+wpLqy5+fbQhvbllvlJEVRIpYj+COUWnnsm+I4jZlA8Lo7/MJmBhGTCHyk1/RWfOqBRJ2MbadddG6QltTKTlrg==
-  dependencies:
-    core-js-pure "^3.0.0"
-    regenerator-runtime "^0.13.2"
-
 "@babel/runtime@7.10.3", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3":
   version "7.10.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.3.tgz#670d002655a7c366540c67f6fd3342cd09500364"
@@ -2740,7 +2732,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.3.1", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.4", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.3.1", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
   integrity sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==
@@ -3511,16 +3503,6 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
-
-"@jest/types@^25.1.0":
-  version "25.1.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.1.0.tgz#b26831916f0d7c381e11dbb5e103a72aed1b4395"
-  integrity sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^15.0.0"
-    chalk "^3.0.0"
 
 "@jest/types@^25.5.0":
   version "25.5.0"
@@ -4577,11 +4559,6 @@
   dependencies:
     estree-walker "^1.0.1"
 
-"@sheerun/mutationobserver-shim@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
-  integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
-
 "@sinonjs/commons@^1.7.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.0.tgz#f90ffc52a2e519f018b13b6c4da03cbff36ebed6"
@@ -5167,18 +5144,16 @@
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
 
-"@testing-library/dom@6.16.0":
-  version "6.16.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.16.0.tgz#04ada27ed74ad4c0f0d984a1245bb29b1fd90ba9"
-  integrity sha512-lBD88ssxqEfz0wFL6MeUyyWZfV/2cjEZZV3YRpb2IoJRej/4f1jB0TzqIOznTpfR1r34CNesrubxwIlAQ8zgPA==
+"@testing-library/dom@7.22.0":
+  version "7.22.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.22.0.tgz#07cc67f4670c2ce564b8d7f0e1826d7caf0645e3"
+  integrity sha512-soXVCM/F2WxMidqGlZsSvTkmLsmi72q5N2IrB7o1aTFpMCfEL+Kl0kzv+2Lk/dLxny/c7CWUDa+yjve5VEsjMg==
   dependencies:
-    "@babel/runtime" "^7.8.4"
-    "@sheerun/mutationobserver-shim" "^0.3.2"
-    "@types/testing-library__dom" "^6.12.1"
-    aria-query "^4.0.2"
-    dom-accessibility-api "^0.3.0"
-    pretty-format "^25.1.0"
-    wait-for-expect "^3.0.2"
+    "@babel/runtime" "^7.10.3"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    dom-accessibility-api "^0.4.6"
+    pretty-format "^25.5.0"
 
 "@testing-library/dom@^7.17.1":
   version "7.19.0"
@@ -5213,10 +5188,22 @@
     "@babel/runtime" "^7.10.3"
     "@testing-library/dom" "^7.17.1"
 
+"@testing-library/user-event@12.1.0":
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.1.0.tgz#a2597419466a93e338c91baa7bb22d4da0309d1d"
+  integrity sha512-aH/XuNFpPD6dA+fh754EGqKeAzpH66HpLJYkv9vOAih2yGmTM8JiZ8uisQDGWRPkc6sxE2zCqDwLR4ZskhRCxw==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"
+  integrity sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==
 
 "@types/babel-types@*", "@types/babel-types@^7.0.0":
   version "7.0.8"
@@ -5518,13 +5505,6 @@
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.4.tgz#b4ffc7dc97b498c969b360a41eee247f82616370"
   integrity sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ==
-
-"@types/testing-library__dom@^6.12.1":
-  version "6.12.1"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-6.12.1.tgz#37af28fae051f9e3feed5684535b1540c97ae28b"
-  integrity sha512-cgqnEjxKk31tQt29j4baSWaZPNjQf3bHalj2gcHQTpW5SuHRal76gOpF0vypeEo6o+sS5inOvvNdzLY0B3FB2A==
-  dependencies:
-    pretty-format "^24.3.0"
 
 "@types/uglify-js@*":
   version "3.0.4"
@@ -6630,14 +6610,6 @@ argparse@^1.0.10, argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
-
-aria-query@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.0.2.tgz#250687b4ccde1ab86d127da0432ae3552fc7b145"
-  integrity sha512-S1G1V790fTaigUSM/Gd0NngzEfiMy9uTUfMyHhKhVyy4cH5O/eTuR01ydhGL0z4Za1PXFTRGH3qL8VhUQuEO5w==
-  dependencies:
-    "@babel/runtime" "^7.7.4"
-    "@babel/runtime-corejs3" "^7.7.4"
 
 aria-query@^4.2.2:
   version "4.2.2"
@@ -9406,15 +9378,15 @@ doctypes@^1.1.0:
   resolved "https://registry.yarnpkg.com/doctypes/-/doctypes-1.1.0.tgz#ea80b106a87538774e8a3a4a5afe293de489e0a9"
   integrity sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk=
 
-dom-accessibility-api@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz#511e5993dd673b97c87ea47dba0e3892f7e0c983"
-  integrity sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==
-
 dom-accessibility-api@^0.4.5:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.4.5.tgz#d9c1cefa89f509d8cf132ab5d250004d755e76e3"
   integrity sha512-HcPDilI95nKztbVikaN2vzwvmv0sE8Y2ZJFODy/m15n7mGXLeOKGiys9qWVbFbh+aq/KYj2lqMLybBOkYAEXqg==
+
+dom-accessibility-api@^0.4.6:
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.4.7.tgz#31d01c113af49f323409b3ed09e56967aba485a8"
+  integrity sha512-5+GzhTpCQYHz4NjL8loYTDVBnXIjNLBadWQBKxXk+osFEplLt3EsSYBu2YZcdZ8QqrvCHgW6TSMGMbmgfhrn2g==
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -16025,7 +15997,7 @@ pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
-pretty-format@^24.0.0, pretty-format@^24.3.0, pretty-format@^24.9.0:
+pretty-format@^24.0.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
@@ -16034,16 +16006,6 @@ pretty-format@^24.0.0, pretty-format@^24.3.0, pretty-format@^24.9.0:
     ansi-regex "^4.0.0"
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
-
-pretty-format@^25.1.0:
-  version "25.1.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.1.0.tgz#ed869bdaec1356fc5ae45de045e2c8ec7b07b0c8"
-  integrity sha512-46zLRSGLd02Rp+Lhad9zzuNZ+swunitn8zIpfD2B4OPCRLXbM87RJT2aBLBWYOznNUML/2l/ReMyWNC80PJBUQ==
-  dependencies:
-    "@jest/types" "^25.1.0"
-    ansi-regex "^5.0.0"
-    ansi-styles "^4.0.0"
-    react-is "^16.12.0"
 
 pretty-format@^25.2.1, pretty-format@^25.5.0:
   version "25.5.0"
@@ -19909,11 +19871,6 @@ w3c-xmlserializer@^2.0.0:
   integrity sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
   dependencies:
     xml-name-validator "^3.0.0"
-
-wait-for-expect@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
-  integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
## Description

This PR adds the [`@testing-library/user-event`](https://www.npmjs.com/package/@testing-library/user-event#typeelement-text-options) package to the project. It also required an update of `@testing-library/dom`.

## Detail

Most of this PR is a straight forward migration from `fireEvent` to `userEvent`. I saw some opportunity for clean-up and left relevant comments. The largest section of cleanup is located in `SelectionContainer.spec.tsx`. In some areas, I saw an opportunity to use higher [priority queries](https://testing-library.com/docs/guide-which-query) to select elements.

This PR only affects `package.json` and `.spec.tsx` files.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :guardsman: includes new unit tests
