### PR TITLE
fix(accordion): replace hidden styles to prevent Chromium auto-scroll

### DIFF
--- a/packages/accordion/accordion.stories.tsx
+++ b/packages/accordion/accordion.stories.tsx
@@ -12,14 +12,13 @@ import { AccordionContainer, useAccordion, IUseAccordionReturnValue } from './sr
 
 const visuallyHidden: CSSProperties = {
   position: 'absolute',
+  border: '0',
+  clip: 'rect(1px, 1px, 1px, 1px)',
+  padding: '0',
   width: '1px',
   height: '1px',
-  padding: '0',
-  margin: '-1px',
   overflow: 'hidden',
-  clip: 'rect(0, 0, 0, 0)',
-  whiteSpace: 'nowrap',
-  borderWidth: '0'
+  whiteSpace: 'nowrap'
 };
 
 export const Container = () => {

--- a/packages/accordion/accordion.stories.tsx
+++ b/packages/accordion/accordion.stories.tsx
@@ -5,10 +5,22 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { createRef } from 'react';
+import React, { createRef, CSSProperties } from 'react';
 
 import { boolean, number, withKnobs } from '@storybook/addon-knobs';
 import { AccordionContainer, useAccordion, IUseAccordionReturnValue } from './src';
+
+const visuallyHidden: CSSProperties = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: '0',
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  borderWidth: '0'
+};
 
 export const Container = () => {
   const size = number('Sections', 5, { range: true, min: 1, max: 9 });
@@ -52,7 +64,7 @@ export const Container = () => {
                 <p
                   {...getPanelProps({
                     index,
-                    hidden
+                    style: hidden ? visuallyHidden : null
                   })}
                 >
                   {`[Panel ${index + 1}] `}
@@ -115,7 +127,7 @@ export const Hook = () => {
                 {...getPanelProps({
                   index,
                   role: null,
-                  hidden
+                  style: hidden ? visuallyHidden : null
                 })}
               >
                 {`[Panel ${index + 1}] `}


### PR DESCRIPTION
## Description

There is an auto-scroll issue (Chromium only) with the accordion Storybook stories. 

## Detail

Given enough content to scroll in the Accordion stories, the browser quirk will become apparent. It seems like a combination of selecting a focusable element (accordion header button) and a collapse in height (accordion panel) causes Chrome to automatically scroll the window up. 

This auto-scroll issue only occurs given these factors: 

* User is on a Chrome or Edge (Chromium)
* There is enough page content to make the page scrollable
* An Accordion panel _above_ an active accordion header is collapsed
  - e.g. `expandable` prop is set to `false` and `collapsible` prop is set to `true`

I've pushed up [a branch](https://github.com/zendeskgarden/react-containers/tree/accordion-scroll-issue) and deployed a [preview app](https://focused-newton-ebed4c.netlify.app/?path=/story/accordion-container--hook) to demonstrate the issue.

## Solution

This PR only updates the Accordion Storybook stories. The following solution hides collapsed accordion panels from both visual and screen reader users without collapsing the element.

To prevent Chromium from auto-scrolling, I removed the `display: none;` CSS and replaced it with visually hidden CSS to retain the `height` while visually hiding the element. The collapsed panel is hidden with `aria-hidden` for users on screen readers. I verified that the collapsed accordion panels are [hidden](https://css-tricks.com/inclusively-hidden/) on VoiceOver.

## Screenshots

⚠️ The screenshots include green content divs to help demonstrate scrolling. These content divs aren't included in the PR changeset.

❌ **Before**: Chrome auto-scrolls each time an accordion panel is collapsed
![2020-08-19 15 14 54](https://user-images.githubusercontent.com/1811365/90697505-6beb1780-e233-11ea-81d8-ba41664ae0a0.gif)

---

✅ **After**: Chrome does not auto-scroll when an accordion panel is collapsed
![2020-08-19 15 18 15](https://user-images.githubusercontent.com/1811365/90697515-70afcb80-e233-11ea-9b95-7654dd22bd29.gif)

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] ~:guardsman: includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
