### PR TITLE
fix(tabs): use separate refs for separate examples

### DIFF
--- a/packages/tabs/tabs.stories.tsx
+++ b/packages/tabs/tabs.stories.tsx
@@ -12,11 +12,11 @@ import { withKnobs, boolean, text } from '@storybook/addon-knobs';
 import { TabsContainer, useTabs } from './src';
 
 const tabs = ['Tab 1', 'Tab 2', 'Tab 3'];
-const tabRefs = tabs.map(() => createRef());
 
 export const Container = () => {
   const vertical = boolean('vertical', false);
   const idPrefix = text('idPrefix', '');
+  const tabRefs = tabs.map(() => createRef());
 
   return (
     <TabsContainer vertical={vertical} idPrefix={idPrefix}>
@@ -94,6 +94,7 @@ export const Hook = () => {
   });
   const tabComponents: React.ReactElement[] = [];
   const tabPanels: React.ReactElement[] = [];
+  const tabRefs = tabs.map(() => createRef());
 
   tabs.forEach((tab, index) => {
     tabComponents.push(


### PR DESCRIPTION
## Description

This PR updates the Tabs Storybook examples so that each example uses unique refs.

## Detail

Selecting on the container tab sets focus on the hook tab. 

![2020-09-09 11 47 26](https://user-images.githubusercontent.com/1811365/92640792-a70cc380-f292-11ea-9321-4691cc8e0545.gif)




<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
