### PR TITLE
fix(selection): update reducer to not run side effect

### DIFF
--- a/packages/selection/.size-snapshot.json
+++ b/packages/selection/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 12111,
-    "minified": 5883,
-    "gzipped": 1891
+    "bundled": 12341,
+    "minified": 5905,
+    "gzipped": 1896
   },
   "index.esm.js": {
-    "bundled": 11232,
-    "minified": 5110,
-    "gzipped": 1772,
+    "bundled": 11462,
+    "minified": 5132,
+    "gzipped": 1782,
     "treeshaked": {
       "rollup": {
-        "code": 4462,
+        "code": 4484,
         "import_statements": 192
       },
       "webpack": {
-        "code": 5830
+        "code": 5852
       }
     }
   }

--- a/packages/selection/.size-snapshot.json
+++ b/packages/selection/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 12724,
-    "minified": 6055,
-    "gzipped": 1945
+    "bundled": 12111,
+    "minified": 5883,
+    "gzipped": 1891
   },
   "index.esm.js": {
-    "bundled": 11845,
-    "minified": 5282,
-    "gzipped": 1827,
+    "bundled": 11232,
+    "minified": 5110,
+    "gzipped": 1772,
     "treeshaked": {
       "rollup": {
-        "code": 4634,
+        "code": 4462,
         "import_statements": 192
       },
       "webpack": {
-        "code": 6002
+        "code": 5830
       }
     }
   }

--- a/packages/selection/.size-snapshot.json
+++ b/packages/selection/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 12341,
-    "minified": 5905,
-    "gzipped": 1896
+    "bundled": 10745,
+    "minified": 5054,
+    "gzipped": 1812
   },
   "index.esm.js": {
-    "bundled": 11462,
-    "minified": 5132,
-    "gzipped": 1782,
+    "bundled": 9942,
+    "minified": 4357,
+    "gzipped": 1696,
     "treeshaked": {
       "rollup": {
-        "code": 4484,
+        "code": 3805,
         "import_statements": 192
       },
       "webpack": {
-        "code": 5852
+        "code": 5065
       }
     }
   }

--- a/packages/selection/src/useSelection.ts
+++ b/packages/selection/src/useSelection.ts
@@ -148,42 +148,13 @@ function stateReducer(state: IUseSelectionState<any>, action: SELECTION_ACTION<a
       return { ...state, focusedItem: action.items[action.items.length - 1] };
     }
     case 'MOUSE_SELECT': {
-      let isSelectControlled = false;
-      let isFocusControlled = false;
-
-      if (action.onSelect) {
-        action.onSelect(action.payload);
-        isSelectControlled = true;
-      }
-
-      if (action.onFocus) {
-        action.onFocus(undefined);
-        isFocusControlled = true;
-      }
-
-      if (isFocusControlled && isSelectControlled) {
-        return state;
-      }
-
-      const updatedState = { ...state };
-
-      if (!isSelectControlled) {
-        updatedState.selectedItem = action.payload;
-      }
-
-      if (!isFocusControlled) {
-        updatedState.focusedItem = undefined;
-      }
-
-      return updatedState;
+      return {
+        ...state,
+        selectedItem: action.payload,
+        focusedItem: undefined
+      };
     }
     case 'KEYBOARD_SELECT': {
-      if (action.onSelect) {
-        action.onSelect(action.payload);
-
-        return state;
-      }
-
       return { ...state, selectedItem: action.payload };
     }
     case 'EXIT_WIDGET': {
@@ -236,10 +207,10 @@ export function useSelection<Item = any>({
 
   useEffect(() => {
     if (selectedItem === undefined && defaultSelectedIndex !== undefined) {
+      onSelect && onSelect(items[defaultSelectedIndex]);
       dispatch({
         type: 'KEYBOARD_SELECT',
-        payload: items[defaultSelectedIndex],
-        onSelect
+        payload: items[defaultSelectedIndex]
       });
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
@@ -308,7 +279,9 @@ export function useSelection<Item = any>({
         }
       },
       onClick: composeEventHandlers(onClick, () => {
-        dispatch({ type: 'MOUSE_SELECT', payload: item, onSelect, onFocus });
+        onSelect && onSelect(item);
+        onFocus && onFocus();
+        dispatch({ type: 'MOUSE_SELECT', payload: item });
       }),
       onKeyDown: composeEventHandlers(onKeyDown, (e: React.KeyboardEvent) => {
         if (
@@ -340,10 +313,10 @@ export function useSelection<Item = any>({
           dispatch({ type: 'END', items, onFocus });
           e.preventDefault();
         } else if (e.keyCode === KEY_CODES.SPACE || e.keyCode === KEY_CODES.ENTER) {
+          onSelect && onSelect(item);
           dispatch({
             type: 'KEYBOARD_SELECT',
-            payload: item,
-            onSelect
+            payload: item
           });
           e.preventDefault();
         }

--- a/packages/selection/src/useSelection.ts
+++ b/packages/selection/src/useSelection.ts
@@ -51,11 +51,8 @@ export interface IUseSelectionProps<Item> {
   onFocus?: (focusedItem?: Item) => void;
 }
 
-type onFocusFn<Item> = (item?: Item) => void;
-type onSelectFn<Item> = (item?: Item) => void;
-
-export type SELECTION_ACTION<Item> =
-  | { type: 'FOCUS'; onFocus?: onFocusFn<Item>; payload?: any; focusedItem?: any }
+export type SELECTION_ACTION =
+  | { type: 'FOCUS'; payload?: any }
   | {
       type: 'INCREMENT';
       payload: any;
@@ -73,7 +70,7 @@ export type SELECTION_ACTION<Item> =
   | { type: 'KEYBOARD_SELECT'; payload: any }
   | { type: 'EXIT_WIDGET' };
 
-function stateReducer(state: IUseSelectionState<any>, action: SELECTION_ACTION<any>) {
+function stateReducer(state: IUseSelectionState<any>, action: SELECTION_ACTION) {
   switch (action.type) {
     case 'END':
     case 'HOME':

--- a/packages/selection/src/useSelection.ts
+++ b/packages/selection/src/useSelection.ts
@@ -186,6 +186,7 @@ export function useSelection<Item = any>({
   onSelect,
   onFocus
 }: IUseSelectionProps<Item> = {}): UseSelectionReturnValue<Item> {
+  const isSelectedItemControlled = selectedItem !== undefined;
   const refs: React.MutableRefObject<any | null>[] = [];
   const items: Item[] = [];
 
@@ -208,10 +209,12 @@ export function useSelection<Item = any>({
   useEffect(() => {
     if (selectedItem === undefined && defaultSelectedIndex !== undefined) {
       onSelect && onSelect(items[defaultSelectedIndex]);
-      dispatch({
-        type: 'KEYBOARD_SELECT',
-        payload: items[defaultSelectedIndex]
-      });
+      if (!isSelectedItemControlled) {
+        dispatch({
+          type: 'KEYBOARD_SELECT',
+          payload: items[defaultSelectedIndex]
+        });
+      }
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -281,7 +284,9 @@ export function useSelection<Item = any>({
       onClick: composeEventHandlers(onClick, () => {
         onSelect && onSelect(item);
         onFocus && onFocus();
-        dispatch({ type: 'MOUSE_SELECT', payload: item });
+        if (!isSelectedItemControlled) {
+          dispatch({ type: 'MOUSE_SELECT', payload: item });
+        }
       }),
       onKeyDown: composeEventHandlers(onKeyDown, (e: React.KeyboardEvent) => {
         if (
@@ -314,10 +319,12 @@ export function useSelection<Item = any>({
           e.preventDefault();
         } else if (e.keyCode === KEY_CODES.SPACE || e.keyCode === KEY_CODES.ENTER) {
           onSelect && onSelect(item);
-          dispatch({
-            type: 'KEYBOARD_SELECT',
-            payload: item
-          });
+          if (!isSelectedItemControlled) {
+            dispatch({
+              type: 'KEYBOARD_SELECT',
+              payload: item
+            });
+          }
           e.preventDefault();
         }
       }),

--- a/packages/selection/src/useSelection.ts
+++ b/packages/selection/src/useSelection.ts
@@ -58,95 +58,31 @@ export type SELECTION_ACTION<Item> =
   | { type: 'FOCUS'; onFocus?: onFocusFn<Item>; payload?: any; focusedItem?: any }
   | {
       type: 'INCREMENT';
-      focusedItem?: any;
-      selectedItem?: any;
-      items: any[];
-      onFocus?: onFocusFn<Item>;
+      payload: any;
     }
   | {
       type: 'DECREMENT';
-      focusedItem?: any;
-      selectedItem?: any;
-      items: any[];
-      onFocus?: onFocusFn<Item>;
-    }
-  | { type: 'HOME'; onFocus?: onFocusFn<Item>; items: any[] }
-  | { type: 'END'; onFocus?: onFocusFn<Item>; items: any[] }
-  | {
-      type: 'MOUSE_SELECT';
-      onSelect?: onSelectFn<Item>;
-      onFocus?: onFocusFn<Item>;
       payload: any;
     }
-  | { type: 'KEYBOARD_SELECT'; onSelect?: onSelectFn<Item>; payload: any }
-  | { type: 'EXIT_WIDGET'; onFocus?: onFocusFn<Item> };
+  | { type: 'HOME'; payload: any }
+  | { type: 'END'; payload: any }
+  | {
+      type: 'MOUSE_SELECT';
+      payload: any;
+    }
+  | { type: 'KEYBOARD_SELECT'; payload: any }
+  | { type: 'EXIT_WIDGET' };
 
 function stateReducer(state: IUseSelectionState<any>, action: SELECTION_ACTION<any>) {
   switch (action.type) {
-    case 'FOCUS': {
-      if (action.onFocus) {
-        if (action.payload !== action.focusedItem) {
-          action.onFocus(action.payload);
-        }
-
-        return state;
-      }
-
+    case 'END':
+    case 'HOME':
+    case 'FOCUS':
+    case 'INCREMENT':
+    case 'DECREMENT': {
       return { ...state, focusedItem: action.payload };
     }
-    case 'INCREMENT': {
-      const controlledFocusedItem = getControlledValue(action.focusedItem, state.focusedItem);
-      const controlledSelectedItem = getControlledValue(action.selectedItem, state.selectedItem);
-      const currentItemIndex =
-        controlledFocusedItem === undefined
-          ? action.items.indexOf(controlledSelectedItem)
-          : action.items.indexOf(controlledFocusedItem);
-      const newFocusedItem = action.items[(currentItemIndex + 1) % action.items.length];
 
-      if (action.onFocus) {
-        action.onFocus(newFocusedItem);
-
-        return state;
-      }
-
-      return { ...state, focusedItem: newFocusedItem };
-    }
-    case 'DECREMENT': {
-      const controlledFocusedItem = getControlledValue(action.focusedItem, state.focusedItem);
-      const controlledSelectedItem = getControlledValue(action.selectedItem, state.selectedItem);
-      const currentItemIndex =
-        controlledFocusedItem === undefined
-          ? action.items.indexOf(controlledSelectedItem)
-          : action.items.indexOf(controlledFocusedItem);
-      const newFocusedItem =
-        action.items[(currentItemIndex + action.items.length - 1) % action.items.length];
-
-      if (action.onFocus) {
-        action.onFocus(newFocusedItem);
-
-        return state;
-      }
-
-      return { ...state, focusedItem: newFocusedItem };
-    }
-    case 'HOME': {
-      if (action.onFocus) {
-        action.onFocus(action.items[0]);
-
-        return state;
-      }
-
-      return { ...state, focusedItem: action.items[0] };
-    }
-    case 'END': {
-      if (action.onFocus) {
-        action.onFocus(action.items[action.items.length - 1]);
-
-        return state;
-      }
-
-      return { ...state, focusedItem: action.items[action.items.length - 1] };
-    }
     case 'MOUSE_SELECT': {
       return {
         ...state,
@@ -158,12 +94,6 @@ function stateReducer(state: IUseSelectionState<any>, action: SELECTION_ACTION<a
       return { ...state, selectedItem: action.payload };
     }
     case 'EXIT_WIDGET': {
-      if (action.onFocus) {
-        action.onFocus(undefined);
-
-        return state;
-      }
-
       return { ...state, focusedItem: undefined };
     }
     default:
@@ -187,6 +117,7 @@ export function useSelection<Item = any>({
   onFocus
 }: IUseSelectionProps<Item> = {}): UseSelectionReturnValue<Item> {
   const isSelectedItemControlled = selectedItem !== undefined;
+  const isFocusedItemControlled = focusedItem !== undefined;
   const refs: React.MutableRefObject<any | null>[] = [];
   const items: Item[] = [];
 
@@ -274,11 +205,17 @@ export function useSelection<Item = any>({
       [selectedAriaKey]: selectedAriaKey ? isSelected : undefined,
       [refKey]: focusRef,
       onFocus: composeEventHandlers(onFocusCallback, () => {
-        dispatch({ type: 'FOCUS', payload: item, focusedItem, onFocus });
+        onFocus && onFocus(item);
+        if (!isFocusedItemControlled) {
+          dispatch({ type: 'FOCUS', payload: item });
+        }
       }),
       onBlur: (e: React.FocusEvent<HTMLElement>) => {
         if (e.target.tabIndex === 0) {
-          dispatch({ type: 'EXIT_WIDGET', onFocus });
+          if (!isFocusedItemControlled) {
+            dispatch({ type: 'EXIT_WIDGET' });
+          }
+          onFocus && onFocus();
         }
       },
       onClick: composeEventHandlers(onClick, () => {
@@ -289,14 +226,47 @@ export function useSelection<Item = any>({
         }
       }),
       onKeyDown: composeEventHandlers(onKeyDown, (e: React.KeyboardEvent) => {
+        let nextIndex: number;
+        let currentIndex: number;
+
+        if (isFocusedItemControlled) {
+          currentIndex = items.indexOf(focusedItem as any);
+        } else {
+          currentIndex = items.indexOf(state.focusedItem || state.selectedItem);
+        }
+
+        const onIncrement = () => {
+          nextIndex = currentIndex + 1;
+
+          if (currentIndex === items.length - 1) {
+            nextIndex = 0;
+          }
+
+          !isFocusedItemControlled && dispatch({ type: 'INCREMENT', payload: items[nextIndex] });
+
+          onFocus && onFocus(items[nextIndex]);
+        };
+
+        const onDecrement = () => {
+          nextIndex = currentIndex - 1;
+
+          if (currentIndex === 0) {
+            nextIndex = items.length - 1;
+          }
+
+          !isFocusedItemControlled && dispatch({ type: 'DECREMENT', payload: items[nextIndex] });
+
+          onFocus && onFocus(items[nextIndex]);
+        };
+
         if (
           (e.keyCode === KEY_CODES.UP && verticalDirection) ||
           (e.keyCode === KEY_CODES.LEFT && horizontalDirection)
         ) {
           if (rtl && !verticalDirection) {
-            dispatch({ type: 'INCREMENT', items, focusedItem, selectedItem, onFocus });
+            onIncrement();
           } else {
-            dispatch({ type: 'DECREMENT', items, focusedItem, selectedItem, onFocus });
+            onDecrement();
           }
 
           e.preventDefault();
@@ -305,17 +275,24 @@ export function useSelection<Item = any>({
           (e.keyCode === KEY_CODES.RIGHT && horizontalDirection)
         ) {
           if (rtl && !verticalDirection) {
-            dispatch({ type: 'DECREMENT', items, focusedItem, selectedItem, onFocus });
+            onDecrement();
           } else {
-            dispatch({ type: 'INCREMENT', items, focusedItem, selectedItem, onFocus });
+            onIncrement();
           }
 
           e.preventDefault();
         } else if (e.keyCode === KEY_CODES.HOME) {
-          dispatch({ type: 'HOME', items, onFocus });
+          if (!isFocusedItemControlled) {
+            dispatch({ type: 'HOME', payload: items[0] });
+          }
+          onFocus && onFocus(items[0]);
           e.preventDefault();
         } else if (e.keyCode === KEY_CODES.END) {
-          dispatch({ type: 'END', items, onFocus });
+          if (!isFocusedItemControlled) {
+            dispatch({ type: 'END', payload: items[items.length - 1] });
+          }
+          onFocus && onFocus(items[items.length - 1]);
+
           e.preventDefault();
         } else if (e.keyCode === KEY_CODES.SPACE || e.keyCode === KEY_CODES.ENTER) {
           onSelect && onSelect(item);


### PR DESCRIPTION
## Description

During the website refactor, we noticed a React [warning](https://github.com/zendeskgarden/website/pull/172#discussion_r498006176) indicating that a set state call happened inside the render cycle. Separately, a [GitHub issue](https://github.com/zendeskgarden/react-components/issues/891) was created, showing this problem affecting the `Tabs` component.

## Steps to Reproduce

1) Navigate to https://garden.zendesk.com/components/tabs
2) Open the first CodeSandbox [example](https://codesandbox.io/s/6h14p?module=src/Example.tsx)
3) Select a tab from the tabs component in the example
    - Both mouse and keyboard selection will trigger the React warning
4) Notice there is a React warning in the JavaScript console ⚠️ 


## Detail

The warning comes from `onSelect` (or `onChange` in `Pagination`) function call which gets called inside `useSelection`'s state reducer: 

<img width="950" alt="Screen Shot 2020-10-12 at 10 21 29 AM" src="https://user-images.githubusercontent.com/1811365/95774355-1cdec300-0c75-11eb-9a12-3c99451dc9d5.png">

These callbacks can contain anything* (in this case, it includes React set state functions). **Invoking these callbacks is problematic because `useReducer`'s reducer function should be pure. It should not contain side effects or React set state calls.** If a `useReducer` reducer calls a React set state, React will throw a [warning](https://github.com/facebook/react/issues/18178#issuecomment-595846312).

\*The `onSelect`callback is passed to `useSelection` and gets invoked in a reducer function. This snippet demonstrates that `onSelect` may contain side effects:

```jsx
const onSelect = tab => {
  setState({ activeTab: tab }); // setting state of another React component inside the reducer is bad
  fetchDataForTab(); // fetching data inside the reducer is bad
  moreSideEffects(); // side effects inside the reducer is bad
}

<Tabs onSelect={onSelect} />
```

## Solution

The reducer logic branches related to the warning message have been updated to be pure, by **moving the `onSelect` and `onFocus` calls outside of the reducer**. Set state calls are no longer invoked inside a `useReducer` reducer function and React will no longer log a warning.

## Notes

It looks like [other parts](https://github.com/zendeskgarden/react-containers/blob/main/packages/selection/src/useSelection.ts#L106) of this reducer should be updated to remove the possibility of side effects inside the reducer. That'll be reserved for a separate PR as this one is focused on resolving https://github.com/zendeskgarden/react-components/issues/891.

Feel free to explore the [hzhu/set-state-in-render-demo](https://github.com/zendeskgarden/react-containers/tree/hzhu/set-state-in-render-demo) branch which recreates the React warning in a `Tabs` story. To fix the warning, copy the `useSelection.ts` file from this PR and replace the entire file locally. Then run `yarn build`. Reload the browser and the warning should be gone.

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: leverages existing unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
