### PR TITLE
fix(focusjail): use tab focusTrap option in test

### DIFF
--- a/packages/focusjail/src/FocusJailContainer.spec.tsx
+++ b/packages/focusjail/src/FocusJailContainer.spec.tsx
@@ -259,7 +259,7 @@ describe('FocusJailContainer', () => {
     };
 
     it('can restore focus after unmounting', async () => {
-      const { queryByText, getByText } = render(<RestoreFocusExample />);
+      const { queryByText, getByText, getByTestId } = render(<RestoreFocusExample />);
       const openButton = getByText('open');
 
       expect(openButton).not.toHaveFocus();
@@ -268,7 +268,7 @@ describe('FocusJailContainer', () => {
 
       expect(getByText('close')).not.toHaveFocus();
 
-      userEvent.tab();
+      userEvent.tab({ focusTrap: getByTestId('container') });
 
       expect(getByText('close')).toHaveFocus();
 


### PR DESCRIPTION
## Description

Strangely the build for the `tabbable` v5 upgrade passed, but the build for `main` failed. This PR fixes the test failure reported in the failed build. It tells `userEvent` that the `tab` event is occurring within a focusjail using the `focusTrap` option.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :guardsman: includes new unit tests

