### PR TITLE
fix(modals): ensure that modals do not close when click originates within modals

### DIFF
--- a/packages/modal/.size-snapshot.json
+++ b/packages/modal/.size-snapshot.json
@@ -19,14 +19,14 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 5821,
-    "minified": 3189,
-    "gzipped": 1164
+    "bundled": 6021,
+    "minified": 3248,
+    "gzipped": 1190
   },
   "index.esm.js": {
-    "bundled": 5147,
-    "minified": 2622,
-    "gzipped": 1046,
+    "bundled": 5349,
+    "minified": 2682,
+    "gzipped": 1076,
     "treeshaked": {
       "rollup": {
         "code": 211,

--- a/packages/modal/.size-snapshot.json
+++ b/packages/modal/.size-snapshot.json
@@ -19,14 +19,14 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 6021,
-    "minified": 3248,
-    "gzipped": 1190
+    "bundled": 6011,
+    "minified": 3242,
+    "gzipped": 1202
   },
   "index.esm.js": {
-    "bundled": 5349,
-    "minified": 2682,
-    "gzipped": 1076,
+    "bundled": 5339,
+    "minified": 2676,
+    "gzipped": 1088,
     "treeshaked": {
       "rollup": {
         "code": 211,

--- a/packages/modal/src/ModalContainer.spec.tsx
+++ b/packages/modal/src/ModalContainer.spec.tsx
@@ -52,6 +52,14 @@ describe('FocusJailContainer', () => {
       userEvent.click(getByTestId('backdrop'));
       expect(onCloseSpy).toHaveBeenCalled();
     });
+
+    it('does not call onClose when inital click occurs within modal', () => {
+      const { getByTestId } = render(<BasicExample onClose={onCloseSpy} />);
+
+      fireEvent.mouseDown(getByTestId('modal'));
+      fireEvent.mouseUp(getByTestId('backdrop'));
+      expect(onCloseSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('getModalProps()', () => {

--- a/packages/modal/src/useModal.ts
+++ b/packages/modal/src/useModal.ts
@@ -102,10 +102,10 @@ export function useModal(
     };
   };
 
-  const getCloseProps = ({ onMouseUp, ...other } = {} as any) => {
+  const getCloseProps = ({ onClick, ...other } = {} as any) => {
     return {
       'aria-label': 'Close modal',
-      onMouseUp: composeEventHandlers(onMouseUp, (event: MouseEvent) => {
+      onClick: composeEventHandlers(onClick, (event: MouseEvent) => {
         closeModal(event);
       }),
       ...other


### PR DESCRIPTION
## Description

Our current `useModal` logic uses `onClick` to recognize when the backdrop is interacted with. To help prevent the modal from closing when the interaction occurs within the bounds of `getModalProps()`. 

I've added a boolean ref that is able to store whether this state. I chose a ref rather a `useState` reference since prop-getters would be re-generated mid click if this state is updated.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
