### PR TITLE
fix(accordions): provide valid React keys

### DIFF
--- a/packages/accordion/accordion.stories.tsx
+++ b/packages/accordion/accordion.stories.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { createRef, CSSProperties } from 'react';
+import React, { CSSProperties } from 'react';
 import { AccordionContainer, useAccordion, IUseAccordionReturnValue } from './src';
 
 const visuallyHidden: CSSProperties = {
@@ -22,7 +22,7 @@ const visuallyHidden: CSSProperties = {
 export const Container = ({ sections, expandable, collapsible }) => {
   const _sections = Array(sections)
     .fill(undefined)
-    .map(() => createRef());
+    .map((s, i) => i);
 
   const Accordion = () => (
     <AccordionContainer expandable={expandable} collapsible={collapsible}>
@@ -39,7 +39,7 @@ export const Container = ({ sections, expandable, collapsible }) => {
             const hidden = expandedSections.indexOf(index) === -1;
 
             return (
-              <div key={section as any}>
+              <div key={section}>
                 <div {...getHeaderProps({ ariaLevel: 2 })}>
                   <div
                     {...getTriggerProps({
@@ -81,7 +81,7 @@ export const Container = ({ sections, expandable, collapsible }) => {
 export const Hook = ({ sections, expandable, collapsible }) => {
   const _sections = Array(sections)
     .fill(undefined)
-    .map(() => createRef());
+    .map((s, i) => i);
 
   const Accordion = () => {
     const {
@@ -99,7 +99,7 @@ export const Hook = ({ sections, expandable, collapsible }) => {
           const hidden = expandedSections.indexOf(index) === -1;
 
           return (
-            <div key={section as any}>
+            <div key={section}>
               <h2 {...getHeaderProps({ role: null, ariaLevel: null })}>
                 <button
                   {...getTriggerProps({

--- a/packages/accordion/src/AccordionContainer.spec.tsx
+++ b/packages/accordion/src/AccordionContainer.spec.tsx
@@ -30,7 +30,9 @@ describe('AccordionContainer', () => {
     expect(triggerButton).not.toHaveAttribute('disabled');
   });
 
-  const sections = Array(3).fill(undefined);
+  const sections = Array(3)
+    .fill(undefined)
+    .map((s, i) => i);
   const CONTAINER_ID_PREFIX = 'test';
 
   const BasicExample = ({


### PR DESCRIPTION
## Description

This PR addresses React key warnings seen in both local development and CI tests. The changeset modifies section lists so they contain values that can be used for the `key` prop.

## Detail
In Storybook React received invalid keys `[object Object]` in the form of refs (`createRef`):

<img width="700" alt="Screen Shot 2021-03-15 at 11 07 14 AM" src="https://user-images.githubusercontent.com/1811365/111204612-8d22a500-8583-11eb-8a28-e79f1036ecb7.png">

In the tests, React received invalid keys in the form of `undefined`:
<img width="686" alt="Screen Shot 2021-03-15 at 11 07 28 AM" src="https://user-images.githubusercontent.com/1811365/111204620-90b62c00-8583-11eb-920e-d1c09b658f8c.png">


<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
