### PR TITLE
fix(modals): ensure that modals do not close when click originates within modals

### DIFF
--- a/packages/modal/.size-snapshot.json
+++ b/packages/modal/.size-snapshot.json
@@ -19,14 +19,14 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 6011,
-    "minified": 3242,
-    "gzipped": 1201
+    "bundled": 6197,
+    "minified": 3323,
+    "gzipped": 1228
   },
   "index.esm.js": {
-    "bundled": 5339,
-    "minified": 2676,
-    "gzipped": 1088,
+    "bundled": 5525,
+    "minified": 2757,
+    "gzipped": 1113,
     "treeshaked": {
       "rollup": {
         "code": 211,

--- a/packages/modal/src/useModal.ts
+++ b/packages/modal/src/useModal.ts
@@ -55,15 +55,20 @@ export function useModal(
   };
 
   const getBackdropProps = ({ onMouseUp, ...other } = {} as any) => {
+    const containerId = 'containers.modal';
+
     return {
       onMouseUp: composeEventHandlers(onMouseUp, (event: MouseEvent) => {
-        if (!isModalMousedDownRef.current) {
+        const target = event.target as HTMLElement;
+        const isModalContainer = containerId === target.getAttribute('data-garden-container-id');
+
+        if (!isModalMousedDownRef.current && isModalContainer) {
           closeModal(event);
         }
 
         isModalMousedDownRef.current = false;
       }),
-      'data-garden-container-id': 'containers.modal',
+      'data-garden-container-id': containerId,
       'data-garden-container-version': PACKAGE_VERSION,
       ...other
     };


### PR DESCRIPTION
## Description

You can see the problem here: https://codesandbox.io/s/relaxed-varahamihira-l5k6q?file=/src/Example.tsx

The previous fix for this problem has problems with cases where `mouseup` is stopped from propagating. This fix checks the that target is the correct one.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
