### PR TITLE
fix(selection): stop hijacking keyboard events with modifier pressed

### DIFF
--- a/packages/selection/.size-snapshot.json
+++ b/packages/selection/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 10832,
-    "minified": 5124,
-    "gzipped": 1845
+    "bundled": 11044,
+    "minified": 5170,
+    "gzipped": 1868
   },
   "index.esm.js": {
-    "bundled": 10029,
-    "minified": 4427,
-    "gzipped": 1729,
+    "bundled": 10241,
+    "minified": 4473,
+    "gzipped": 1753,
     "treeshaked": {
       "rollup": {
         "code": 181,
         "import_statements": 83
       },
       "webpack": {
-        "code": 5081
+        "code": 5127
       }
     }
   }

--- a/packages/selection/src/SelectionContainer.spec.tsx
+++ b/packages/selection/src/SelectionContainer.spec.tsx
@@ -166,6 +166,16 @@ describe('SelectionContainer', () => {
         });
       });
 
+      describe('CTRL+ENTER keyCode', () => {
+        it('is not consumed', () => {
+          const { getByText } = render(<BasicExample />);
+          const item = getByText('Item-1');
+
+          fireEvent.keyDown(item, { keyCode: KEY_CODES.ENTER, ctrlKey: true });
+          expect(item).toHaveAttribute('aria-selected', 'false');
+        });
+      });
+
       describe('SPACE keyCode', () => {
         it('selects currently focused item', () => {
           const { getByText } = render(<BasicExample />);

--- a/packages/selection/src/useSelection.ts
+++ b/packages/selection/src/useSelection.ts
@@ -256,50 +256,54 @@ export function useSelection<Item = any>({
           onFocus && onFocus(items[nextIndex]);
         };
 
-        if (
-          (e.keyCode === KEY_CODES.UP && verticalDirection) ||
-          (e.keyCode === KEY_CODES.LEFT && horizontalDirection)
-        ) {
-          if (rtl && !verticalDirection) {
-            onIncrement();
-          } else {
-            onDecrement();
-          }
+        const hasModifierKeyPressed = e.ctrlKey || e.metaKey || e.shiftKey || e.altKey;
 
-          e.preventDefault();
-        } else if (
-          (e.keyCode === KEY_CODES.DOWN && verticalDirection) ||
-          (e.keyCode === KEY_CODES.RIGHT && horizontalDirection)
-        ) {
-          if (rtl && !verticalDirection) {
-            onDecrement();
-          } else {
-            onIncrement();
-          }
+        if (!hasModifierKeyPressed) {
+          if (
+            (e.keyCode === KEY_CODES.UP && verticalDirection) ||
+            (e.keyCode === KEY_CODES.LEFT && horizontalDirection)
+          ) {
+            if (rtl && !verticalDirection) {
+              onIncrement();
+            } else {
+              onDecrement();
+            }
 
-          e.preventDefault();
-        } else if (e.keyCode === KEY_CODES.HOME) {
-          if (!isFocusedItemControlled) {
-            dispatch({ type: 'HOME', payload: items[0] });
-          }
-          onFocus && onFocus(items[0]);
-          e.preventDefault();
-        } else if (e.keyCode === KEY_CODES.END) {
-          if (!isFocusedItemControlled) {
-            dispatch({ type: 'END', payload: items[items.length - 1] });
-          }
-          onFocus && onFocus(items[items.length - 1]);
+            e.preventDefault();
+          } else if (
+            (e.keyCode === KEY_CODES.DOWN && verticalDirection) ||
+            (e.keyCode === KEY_CODES.RIGHT && horizontalDirection)
+          ) {
+            if (rtl && !verticalDirection) {
+              onDecrement();
+            } else {
+              onIncrement();
+            }
 
-          e.preventDefault();
-        } else if (e.keyCode === KEY_CODES.SPACE || e.keyCode === KEY_CODES.ENTER) {
-          onSelect && onSelect(item);
-          if (!isSelectedItemControlled) {
-            dispatch({
-              type: 'KEYBOARD_SELECT',
-              payload: item
-            });
+            e.preventDefault();
+          } else if (e.keyCode === KEY_CODES.HOME) {
+            if (!isFocusedItemControlled) {
+              dispatch({ type: 'HOME', payload: items[0] });
+            }
+            onFocus && onFocus(items[0]);
+            e.preventDefault();
+          } else if (e.keyCode === KEY_CODES.END) {
+            if (!isFocusedItemControlled) {
+              dispatch({ type: 'END', payload: items[items.length - 1] });
+            }
+            onFocus && onFocus(items[items.length - 1]);
+
+            e.preventDefault();
+          } else if (e.keyCode === KEY_CODES.SPACE || e.keyCode === KEY_CODES.ENTER) {
+            onSelect && onSelect(item);
+            if (!isSelectedItemControlled) {
+              dispatch({
+                type: 'KEYBOARD_SELECT',
+                payload: item
+              });
+            }
+            e.preventDefault();
           }
-          e.preventDefault();
         }
       }),
       ...other


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(selection):
     add keydown event to handle rtl". the title informs the semantic
     version bump if this PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Currently the `@zendeskgarden/container-selection` consumers events event if a modifier is pressed, that prevents for events like `ctrl+enter` to bubble to parents. This PR makes sure that we only listen for the keyboard events we actually should consume. 

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
