### PR TITLE
feat(utilities): add utilities

### DIFF
--- a/packages/grid/grid.stories.tsx
+++ b/packages/grid/grid.stories.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useState } from 'react';
+import { convertToMatrix } from '@zendeskgarden/container-utilities';
 import { useGrid, GridContainer, IUseGridReturnValue } from './src';
 
 const ARGS = {
@@ -13,22 +14,6 @@ const ARGS = {
   selection: true,
   rtl: false
 };
-
-// Given a column count, converts a flat array into a 2D array
-const convertToMatrix = (array, columnCount) =>
-  array.reduce((acc, curr) => {
-    if (acc.length === 0) {
-      return [[curr]];
-    }
-
-    if (acc[acc.length - 1].length < columnCount) {
-      acc[acc.length - 1].push(curr);
-    } else {
-      acc.push([curr]);
-    }
-
-    return acc;
-  }, []);
 
 const Grid = ({ rtl, matrix, selection, selectedRowIndex, selectedColIndex, getGridCellProps }) => (
   <table role="grid" style={{ direction: rtl ? 'rtl' : 'ltr' }}>

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -27,6 +27,9 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   },
+  "devDependencies": {
+    "@zendeskgarden/container-utilities": "^0.5.6"
+  },
   "keywords": [
     "a11y",
     "accessible",

--- a/packages/grid/yarn.lock
+++ b/packages/grid/yarn.lock
@@ -9,6 +9,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@zendeskgarden/container-utilities@^0.5.6":
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.6.tgz#f5c27c120e91d0c020773179db605010c11a72b6"
+  integrity sha512-20NH+UceCdjCprCbEVEwxGiD++RSulN5THJ7M0Y36rx7EHkbCZ6fIQwGlbj+PZhLJnH5KX87ZlZM6RwdjxNpXQ==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+
 regenerator-runtime@^0.13.4:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"

--- a/packages/utilities/.size-snapshot.json
+++ b/packages/utilities/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 2429,
-    "minified": 1456,
-    "gzipped": 722
+    "bundled": 2948,
+    "minified": 1775,
+    "gzipped": 846
   },
   "index.esm.js": {
-    "bundled": 2212,
-    "minified": 1255,
-    "gzipped": 652,
+    "bundled": 2589,
+    "minified": 1460,
+    "gzipped": 737,
     "treeshaked": {
       "rollup": {
-        "code": 14,
-        "import_statements": 14
+        "code": 37,
+        "import_statements": 37
       },
       "webpack": {
-        "code": 998
+        "code": 1054
       }
     }
   }

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -20,7 +20,8 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@babel/runtime": "^7.8.4"
+    "@babel/runtime": "^7.8.4",
+    "@reach/auto-id": "^0.16.0"
   },
   "peerDependencies": {
     "prop-types": "^15.6.1",

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -9,4 +9,6 @@ export { composeEventHandlers } from './utils/composeEventHandlers';
 export { generateId, setIdCounter } from './utils/IdManager';
 export { getControlledValue } from './utils/getControlledValue';
 export { useCombinedRefs } from './utils/useCombinedRefs';
+export { convertToMatrix } from './utils/convertToMatrix';
 export { KEY_CODES } from './utils/KEY_CODES';
+export { useId } from './utils/useId';

--- a/packages/utilities/src/utils/convertToMatrix.spec.ts
+++ b/packages/utilities/src/utils/convertToMatrix.spec.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { convertToMatrix } from './convertToMatrix';
+
+describe('convertToMatrix', () => {
+  it('converts a flat array into a 2D array', () => {
+    const list = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const matrix = convertToMatrix(list, 3);
+
+    expect(matrix).toStrictEqual([
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9]
+    ]);
+  });
+});

--- a/packages/utilities/src/utils/convertToMatrix.ts
+++ b/packages/utilities/src/utils/convertToMatrix.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+/**
+ * Given a column count, converts a flat array into a 2D array
+ * @param {Array} array an array of elements
+ * @return {columnCount} number of columns in the 2D array
+ */
+
+export const convertToMatrix = <T>(array: T[], columnCount: number) => {
+  return array.reduce((acc: T[][], curr: T) => {
+    if (acc.length === 0) return [[curr]];
+
+    if (acc[acc.length - 1].length < columnCount) {
+      acc[acc.length - 1].push(curr);
+    } else {
+      acc.push([curr]);
+    }
+
+    return acc;
+  }, []);
+};

--- a/packages/utilities/src/utils/convertToMatrix.ts
+++ b/packages/utilities/src/utils/convertToMatrix.ts
@@ -10,7 +10,6 @@
  * @param {Array} array an array of elements
  * @return {columnCount} number of columns in the 2D array
  */
-
 export const convertToMatrix = <T>(array: T[], columnCount: number) => {
   return array.reduce((acc: T[][], curr: T) => {
     if (acc.length === 0) return [[curr]];

--- a/packages/utilities/src/utils/useId.ts
+++ b/packages/utilities/src/utils/useId.ts
@@ -8,5 +8,4 @@
 /**
  * Autogenerate IDs to facilitate WAI-ARIA and server rendering from @reach, https://reach.tech/auto-id.
  */
-
 export * from '@reach/auto-id';

--- a/packages/utilities/src/utils/useId.ts
+++ b/packages/utilities/src/utils/useId.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+/**
+ * Autogenerate IDs to facilitate WAI-ARIA and server rendering from @reach, https://reach.tech/auto-id.
+ */
+
+export * from '@reach/auto-id';

--- a/packages/utilities/yarn.lock
+++ b/packages/utilities/yarn.lock
@@ -9,7 +9,33 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@reach/auto-id@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.16.0.tgz#dfabc3227844e8c04f8e6e45203a8e14a8edbaed"
+  integrity sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==
+  dependencies:
+    "@reach/utils" "0.16.0"
+    tslib "^2.3.0"
+
+"@reach/utils@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.16.0.tgz#5b0777cf16a7cab1ddd4728d5d02762df0ba84ce"
+  integrity sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==
+  dependencies:
+    tiny-warning "^1.0.3"
+    tslib "^2.3.0"
+
 regenerator-runtime@^0.13.2:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+
+tiny-warning@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
+tslib@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==


### PR DESCRIPTION
## Description

This PR exports two new utilities from `@zendeskgarden/container-utilities`.

The `useId` is a hook which generates IDs to facilitate WAI-ARIA and server rendering (credit @reach). Future React has [plans](https://github.com/facebook/react/issues/5867#issuecomment-678267054) to support SSR friendly ID generation.

The `convertToMatrix` function converts a flat array to a two-dimension array. It is useful when working with grids (as demonstrated in the `useGrid` stories). It will also be used in `react-components` stories to demonstrate Garden's new color swatch component.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
