### PR TITLE
fix(grid): revert updated container-utilities until its published

### DIFF
--- a/packages/grid/grid.stories.tsx
+++ b/packages/grid/grid.stories.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, { useState } from 'react';
-import { convertToMatrix } from '@zendeskgarden/container-utilities';
 import { useGrid, GridContainer, IUseGridReturnValue } from './src';
 
 const ARGS = {
@@ -14,6 +13,22 @@ const ARGS = {
   selection: true,
   rtl: false
 };
+
+// Given a column count, converts a flat array into a 2D array
+const convertToMatrix = (array, columnCount) =>
+  array.reduce((acc, curr) => {
+    if (acc.length === 0) {
+      return [[curr]];
+    }
+
+    if (acc[acc.length - 1].length < columnCount) {
+      acc[acc.length - 1].push(curr);
+    } else {
+      acc.push([curr]);
+    }
+
+    return acc;
+  }, []);
 
 const Grid = ({ rtl, matrix, selection, selectedRowIndex, selectedColIndex, getGridCellProps }) => (
   <table role="grid" style={{ direction: rtl ? 'rtl' : 'ltr' }}>

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -27,9 +27,6 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   },
-  "devDependencies": {
-    "@zendeskgarden/container-utilities": "^0.6.0"
-  },
   "keywords": [
     "a11y",
     "accessible",

--- a/packages/grid/yarn.lock
+++ b/packages/grid/yarn.lock
@@ -9,13 +9,6 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@zendeskgarden/container-utilities@^0.5.6":
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-0.5.6.tgz#f5c27c120e91d0c020773179db605010c11a72b6"
-  integrity sha512-20NH+UceCdjCprCbEVEwxGiD++RSulN5THJ7M0Y36rx7EHkbCZ6fIQwGlbj+PZhLJnH5KX87ZlZM6RwdjxNpXQ==
-  dependencies:
-    "@babel/runtime" "^7.8.4"
-
 regenerator-runtime@^0.13.4:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"


### PR DESCRIPTION
## Description

In https://github.com/zendeskgarden/react-containers/pull/371, I should have kept using the utility (`convertToMatrix`) and adding it to the `container-utilities` as separate PRs. 

After seeing the [deployment fail](https://app.circleci.com/pipelines/github/zendeskgarden/react-containers/1633/workflows/934e92a5-d672-47da-af57-940fd84639fc/jobs/3199), I realized that CircleCI is probably looking to install an updated `container-utilities` package that hasn't been deployed yet. I should not have added a new utility and used it in the same PR and release.

## Detail

I would like to remove `container-utilities` from the `grid` package. Once, a release is cut and deployed for the latest `container-utilities`, then the `grid` package can be updated to consume the new utility.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
