### PR TITLE
fix(tooltip): persist timeout ids

### DIFF
--- a/packages/tooltip/.size-snapshot.json
+++ b/packages/tooltip/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 6226,
-    "minified": 3293,
-    "gzipped": 1195
+    "bundled": 6308,
+    "minified": 3371,
+    "gzipped": 1194
   },
   "index.esm.js": {
-    "bundled": 5590,
-    "minified": 2749,
-    "gzipped": 1079,
+    "bundled": 5660,
+    "minified": 2815,
+    "gzipped": 1077,
     "treeshaked": {
       "rollup": {
         "code": 131,
         "import_statements": 101
       },
       "webpack": {
-        "code": 3577
+        "code": 3663
       }
     }
   }

--- a/packages/tooltip/src/useTooltip.ts
+++ b/packages/tooltip/src/useTooltip.ts
@@ -35,11 +35,11 @@ export const useTooltip = ({
   const [_id] = useState(id || seed(`tooltip_${PACKAGE_VERSION}`));
   const isMounted = useRef(false);
 
-  let openTooltipTimeoutId: number | undefined;
-  let closeTooltipTimeoutId: number | undefined;
+  const openTooltipTimeoutId = useRef<number>();
+  const closeTooltipTimeoutId = useRef<number>();
 
   const openTooltip = (delayMs = delayMilliseconds) => {
-    clearTimeout(closeTooltipTimeoutId);
+    clearTimeout(closeTooltipTimeoutId.current);
 
     const timerId = setTimeout(() => {
       if (isMounted.current) {
@@ -47,11 +47,11 @@ export const useTooltip = ({
       }
     }, delayMs);
 
-    openTooltipTimeoutId = Number(timerId);
+    openTooltipTimeoutId.current = Number(timerId);
   };
 
   const closeTooltip = (delayMs = delayMilliseconds) => {
-    clearTimeout(openTooltipTimeoutId);
+    clearTimeout(openTooltipTimeoutId.current);
 
     const timerId = setTimeout(() => {
       if (isMounted.current) {
@@ -59,7 +59,7 @@ export const useTooltip = ({
       }
     }, delayMs);
 
-    closeTooltipTimeoutId = Number(timerId);
+    closeTooltipTimeoutId.current = Number(timerId);
   };
 
   // Sometimes the timeout will call setVisibility even after un-mount and cleanup.
@@ -76,8 +76,8 @@ export const useTooltip = ({
   // Clean up stray timeouts if tooltip un-mounts
   useEffect(() => {
     return () => {
-      clearTimeout(openTooltipTimeoutId);
-      clearTimeout(closeTooltipTimeoutId);
+      clearTimeout(openTooltipTimeoutId.current);
+      clearTimeout(closeTooltipTimeoutId.current);
     };
   }, [closeTooltipTimeoutId, openTooltipTimeoutId]);
 


### PR DESCRIPTION
## Description

While working on the color swatch component, I noticed that trigger elements that blurred before the `delayMS` resulted in a tooltip that remained visible:

<img width="294" alt="Screen Shot 2021-09-09 at 9 09 43 AM" src="https://user-images.githubusercontent.com/1811365/132764742-3c52192c-4b52-48af-9b74-781601ca3b1e.png">

## Detail

It seems like the `openTooltipTimeoutId` is wiped out when the hook re-renders. This can leave the tooltip in an open state and is noticeable when tooltips are grouped together in a grid. Instead of storing timeout IDs in a variable in scope, they are now stored inside a `useRef` so the timeout IDs can persist the duration of the component's lifecycle.

I wasn't able to come up with a new test because the asynchronous UI is a bit tricky to simulate in the testing environment. Also, no logic has been changed. Feel free to chime in if you have a test suggestion and I can explore + add it!

## Screenshots

⚠️ These images showcase the bug and the fix and are not part of this pull request. I've pushed up a temporary [branch](https://github.com/zendeskgarden/react-containers/tree/hzhu/grid-tooltip-issue) which demonstrates the bug. ⚠️ 

**BEFORE**: `delayMS` at `500ms`

<img src="https://user-images.githubusercontent.com/1811365/132765036-c790bc98-3afd-4864-b92a-c97c169f96b2.gif" width="500" />

**AFTER**: `delayMS` at `500ms`

<img src="https://user-images.githubusercontent.com/1811365/132765029-2314e566-3ed7-4682-afc6-07c9c475f43b.gif" width="500" />




<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: ~includes new unit tests~
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
