### PR TITLE
build(storybook): omit static source flag in build:demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "scripts": {
     "build": "lerna run build --stream",
-    "build:demo": "build-storybook -s ./utils/storybook -o demo",
+    "build:demo": "build-storybook -o demo",
     "format": "prettier-package-json --write && yarn format:package_json --write && yarn format:js --write && yarn format:md --write",
     "format:all": "prettier-package-json --list-different && yarn format:package_json --list-different && yarn format:js --check && yarn format:md --check",
     "format:js": "prettier --loglevel warn '{packages,utils}/**/*.{js,ts,tsx}' '!packages/.template' '!packages/**/dist/**'",


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(selection):
     add keydown event to handle rtl". the title informs the semantic
     version bump if this PR is merged. -->

~~- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->~~

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

Fixed the build command for storybook static builds as it was failing.

## Detail

<!-- supporting details; screen shot, code, etc. -->

Removed `-s ./utils/storybook` from `build:demo` command in `package.json` since it was causing local builds to fail.

<!-- closes GITHUB_ISSUE -->

## Checklist

~~- [ ] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)~~
~~- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
~~- [ ] :guardsman: includes new unit tests~~
~~- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11~~
