### PR TITLE
chore(renovate): refactor config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,25 +3,23 @@
   "rebaseStalePrs": true,
   "packageRules": [
     {
-      "paths": ["package.json"],
-      "minor": {
-        "groupName": "non-major shared dependencies",
-        "groupSlug": "shared-minor-patch"
-      }
+      "matchFiles": ["package.json"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "non-major shared dependencies",
+      "groupSlug": "shared-minor-patch"
     },
     {
-      "paths": ["packages/**"],
-      "minor": {
-        "groupName": "non-major package dependencies",
-        "groupSlug": "packages-minor-patch"
-      }
+      "matchPaths": ["packages/**"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "non-major package dependencies",
+      "groupSlug": "packages-minor-patch"
     },
     {
-      "packagePatterns": ["^@zendeskgarden/container"],
+      "matchPackagePatterns": ["^@zendeskgarden/container"],
       "enabled": false
     },
     {
-      "depTypeList": ["peerDependencies"],
+      "matchDepTypes": ["peerDependencies"],
       "enabled": false
     }
   ],


### PR DESCRIPTION
## Description

Follow suit with the monorepo updates applied under https://github.com/zendeskgarden/react-components/pull/1202.

## Detail

**Context:** this should substantially decrease the amount of Renovate noise currently being generated and get us back to a place (as intended by the original config) where a majority of minor/patch updates are consolidated under a single "shared dependencies" PR.
