### PR TITLE
chore(utilities): deprecate useCombinedRefs hook

### DIFF
--- a/packages/utilities/.size-snapshot.json
+++ b/packages/utilities/.size-snapshot.json
@@ -19,14 +19,14 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 2948,
-    "minified": 1775,
-    "gzipped": 846
+    "bundled": 3103,
+    "minified": 1925,
+    "gzipped": 942
   },
   "index.esm.js": {
-    "bundled": 2589,
-    "minified": 1460,
-    "gzipped": 737,
+    "bundled": 2744,
+    "minified": 1610,
+    "gzipped": 834,
     "treeshaked": {
       "rollup": {
         "code": 37,

--- a/packages/utilities/src/utils/useCombinedRefs.ts
+++ b/packages/utilities/src/utils/useCombinedRefs.ts
@@ -12,11 +12,23 @@ type PossibleRef<T> = ((instance: T | null) => void) | RefObject<T> | null | und
 /**
  * A custom hook that combines multiple refs into a single, valid ref.
  * @param  {...any} refs
+ *
+ * @deprecated Will be removed in v1. Please use `react-merge-refs` instead.
+ *
  */
 export function useCombinedRefs<T>(...refs: PossibleRef<T>[]) {
   const targetRef = useRef<T>(null);
 
   useEffect(() => {
+    /**
+     * Deprecation warning for consumers:
+     * placing the warning in `useEffect` hook scope so it
+     * is emitted only on each mount of the hook, when used.
+     */
+    console.warn(
+      '"useCombinedRefs()" has been deprecated and will be removed in the next major version release of "@zendeskgarden/container-utilities"'
+    );
+
     refs.forEach(ref => {
       if (!ref) return;
 

--- a/packages/utilities/src/utils/useCombinedRefs.ts
+++ b/packages/utilities/src/utils/useCombinedRefs.ts
@@ -25,6 +25,7 @@ export function useCombinedRefs<T>(...refs: PossibleRef<T>[]) {
      * placing the warning in `useEffect` hook scope so it
      * is emitted only on each mount of the hook, when used.
      */
+    // eslint-disable-next-line no-console
     console.warn(
       '"useCombinedRefs()" has been deprecated and will be removed in the next major version release of "@zendeskgarden/container-utilities"'
     );


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(selection):
     add keydown event to handle rtl". the title informs the semantic
     version bump if this PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

Deprecating `useCombinedRefs` as it will be removed in next major release.

## Detail

Deprecation of `useCombinedRefs` was supplemented with `@deprecation` tag and a console warning to alert future consumers of the upcoming removal in the next major release.

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
