### PR TITLE
chore(grid): Replace useGrid to use GridContainer for better test coverage

### DIFF
--- a/packages/grid/src/GridContainer.spec.tsx
+++ b/packages/grid/src/GridContainer.spec.tsx
@@ -8,7 +8,7 @@
 import React, { useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useGrid, IUseGridProps } from './useGrid';
+import { GridContainer, IUseGridProps, IUseGridReturnValue } from './';
 
 const gridCell = (text: string) => screen.getByRole('gridcell', { name: new RegExp(text, 'u') });
 
@@ -21,40 +21,34 @@ interface IExample extends IUseGridProps {
 describe('useGrid', () => {
   const idPrefix = 'some-id-prefix';
 
-  const Example = ({ rtl, matrix, onFocus, onClick, ...props }: IExample) => {
-    const { getGridCellProps } = useGrid({
-      rtl,
-      matrix,
-      idPrefix,
-      selection: true,
-      ...props
-    });
-
-    return (
-      <table role="grid">
-        <tbody>
-          {matrix.map((row: string[], rowIdx: number) => (
-            <tr key={row[0]}>
-              {row.map((rowItem: string, colIdx: number) => (
-                <td role="presentation" key={rowItem}>
-                  <button
-                    {...getGridCellProps({
-                      colIdx,
-                      rowIdx,
-                      onFocus,
-                      onClick
-                    })}
-                  >
-                    {rowItem}
-                  </button>
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    );
-  };
+  const Example = ({ rtl, matrix, onFocus, onClick, ...props }: IExample) => (
+    <GridContainer rtl={rtl} selection={true} matrix={matrix} idPrefix={idPrefix} {...props}>
+      {({ getGridCellProps }: IUseGridReturnValue) => (
+        <table role="grid">
+          <tbody>
+            {matrix.map((row: string[], rowIdx: number) => (
+              <tr key={row[0]}>
+                {row.map((rowItem: string, colIdx: number) => (
+                  <td role="presentation" key={rowItem}>
+                    <button
+                      {...getGridCellProps({
+                        colIdx,
+                        rowIdx,
+                        onFocus,
+                        onClick
+                      })}
+                    >
+                      {rowItem}
+                    </button>
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </GridContainer>
+  );
 
   test('composes gridcell onClick handler', () => {
     const onClick = jest.fn();

--- a/packages/grid/src/GridContainer.spec.tsx
+++ b/packages/grid/src/GridContainer.spec.tsx
@@ -22,7 +22,7 @@ describe('useGrid', () => {
   const idPrefix = 'some-id-prefix';
 
   const Example = ({ rtl, matrix, onFocus, onClick, ...props }: IExample) => (
-    <GridContainer rtl={rtl} selection={true} matrix={matrix} idPrefix={idPrefix} {...props}>
+    <GridContainer rtl={rtl} selection matrix={matrix} idPrefix={idPrefix} {...props}>
       {({ getGridCellProps }: IUseGridReturnValue) => (
         <table role="grid">
           <tbody>


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(selection):
     add keydown event to handle rtl". the title informs the semantic
     version bump if this PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description
Fixed `GridContainer` tests for better coverage.
<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

## Detail
In the `GridContainer.spec`, the `GridContainer` was directly imported from file instead from `index.js` preventing full coverage for `index.js`.

`GridContainer` wasn't getting full coverage in the tests because it was using hooks `useGrid` instead of renderProps; thus didn't render `GridContainer`.

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [X] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [X] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
