### PR TITLE
chore(storybook): support ie11 with webpack 5

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -16,8 +16,9 @@ module.exports = {
   core: {
     builder: 'webpack5'
   },
-  // to support IE11, we need to ensure the manager UI bundle is ES5 compatible
   managerWebpack: config => {
+    // TODO: remove after June 15, 2022 for IE 11 EOL
+    // to support IE11, we need to ensure the manager UI bundle is ES5 compatible
     config.target = ['web', 'es5'];
 
     return config;

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -19,6 +19,7 @@ module.exports = {
   // to support IE11, we need to ensure the manager UI bundle is ES5 compatible
   managerWebpack: config => {
     config.target = ['web', 'es5'];
+
     return config;
   }
 };

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -15,5 +15,10 @@ module.exports = {
   ],
   core: {
     builder: 'webpack5'
+  },
+  // to support IE11, we need to ensure the manager UI bundle is ES5 compatible
+  managerWebpack: config => {
+    config.target = ['web', 'es5'];
+    return config;
   }
 };

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -10,6 +10,8 @@ const path = require('path');
 const babelOptions = require(path.resolve(__dirname, '../babel.config.js'));
 
 module.exports = ({ config }) => {
+  config.target = ['web', 'es5'];
+
   config.resolve.extensions.push('.ts', '.tsx');
 
   config.module.rules.push({

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -10,8 +10,6 @@ const path = require('path');
 const babelOptions = require(path.resolve(__dirname, '../babel.config.js'));
 
 module.exports = ({ config }) => {
-  config.target = ['web', 'es5'];
-
   config.resolve.extensions.push('.ts', '.tsx');
 
   config.module.rules.push({
@@ -52,6 +50,10 @@ module.exports = ({ config }) => {
       PACKAGE_VERSION: JSON.stringify('storybook')
     })
   );
+
+  // TODO: remove after June 15, 2022 for IE 11 EOL
+  // to support IE11, we need to ensure the preview iframe bundle is ES5 compatible
+  config.target = ['web', 'es5'];
 
   return config;
 };


### PR DESCRIPTION
## Description

Adds support for IE 11 when using Storybook with Webpack 5.

## Detail

Although the current transpilation of `react-containers` is ES5 compatible (thanks to Babel), both the Storybook UI manager and iframe preview were using JavaScript syntax (ES6) due to the Webpack 5 runtime configuration. ES6 is only supported in modern browsers and this PR configures the UI manager and preview builds to use only ES5 syntax throughout the runtime.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
