### PR TITLE
feat(accordion): add default expanded sections prop

### DIFF
--- a/packages/accordion/.size-snapshot.json
+++ b/packages/accordion/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 7189,
-    "minified": 3709,
-    "gzipped": 1449
+    "bundled": 7278,
+    "minified": 3740,
+    "gzipped": 1461
   },
   "index.esm.js": {
-    "bundled": 6579,
-    "minified": 3198,
-    "gzipped": 1336,
+    "bundled": 6668,
+    "minified": 3229,
+    "gzipped": 1347,
     "treeshaked": {
       "rollup": {
         "code": 146,
         "import_statements": 101
       },
       "webpack": {
-        "code": 3901
+        "code": 3934
       }
     }
   }

--- a/packages/accordion/src/AccordionContainer.spec.tsx
+++ b/packages/accordion/src/AccordionContainer.spec.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import { KEY_CODES } from '@zendeskgarden/container-utilities';
 import { AccordionContainer, IUseAccordionReturnValue, IUseAccordionProps } from './';
 
@@ -34,19 +34,8 @@ describe('AccordionContainer', () => {
     .map((s, i) => i);
   const CONTAINER_ID_PREFIX = 'test';
 
-  const BasicExample = ({
-    expandedSections,
-    expandable = true,
-    collapsible = true,
-    onChange
-  }: IUseAccordionProps = {}) => (
-    <AccordionContainer
-      idPrefix={CONTAINER_ID_PREFIX}
-      expandedSections={expandedSections}
-      expandable={expandable}
-      collapsible={collapsible}
-      onChange={onChange}
-    >
+  const BasicExample = (props: IUseAccordionProps = {}) => (
+    <AccordionContainer idPrefix={CONTAINER_ID_PREFIX} {...props}>
       {({ getHeaderProps, getTriggerProps, getPanelProps }) => (
         <>
           {sections.map((section, index) => {
@@ -93,6 +82,18 @@ describe('AccordionContainer', () => {
       )}
     </AccordionContainer>
   );
+
+  it('sets default expanded sections in an uncontrolled hook', () => {
+    const defaultExpandedSections = [0, 1, 2];
+
+    render(<BasicExample defaultExpandedSections={defaultExpandedSections} />);
+
+    const triggers = screen.getAllByRole('button');
+    const panels = screen.getAllByLabelText('Trigger');
+
+    triggers.forEach(trigger => expect(trigger).toHaveAttribute('aria-expanded', 'true'));
+    panels.forEach(panel => expect(panel).toBeVisible());
+  });
 
   it('calls onChange with correct sections on section selection', () => {
     const onChangeSpy = jest.fn();

--- a/packages/accordion/src/useAccordion.ts
+++ b/packages/accordion/src/useAccordion.ts
@@ -16,8 +16,10 @@ import {
 export interface IUseAccordionProps {
   /** Prefixes IDs for the accordion trigger and panels  */
   idPrefix?: string;
-  /** Determines which sections are expanded in a controlled accordion */
+  /** Sets the expanded sections in a controlled accordion */
   expandedSections?: number[];
+  /** Sets the default expanded sections in a uncontrolled accordion */
+  defaultExpandedSections?: number[];
   onChange?: (expanded: number) => any;
   /** Determines if multiple panels can be expanded at the same time in an uncontrolled accordion */
   expandable?: boolean;
@@ -57,14 +59,15 @@ export function useAccordion({
   expandedSections,
   onChange,
   expandable = true,
-  collapsible = true
+  collapsible = true,
+  defaultExpandedSections
 }: IUseAccordionProps = {}): IUseAccordionReturnValue {
   const isControlled = expandedSections !== null && expandedSections !== undefined;
   const seed = useUIDSeed();
   const [prefix] = useState<string>(idPrefix || seed(`accordion_${PACKAGE_VERSION}`));
   const TRIGGER_ID = `${prefix}--trigger`;
   const PANEL_ID = `${prefix}--panel`;
-  const [expandedState, setExpandedState] = useState<number[]>([0]);
+  const [expandedState, setExpandedState] = useState<number[]>(defaultExpandedSections || [0]);
 
   const controlledExpandedState = getControlledValue(expandedSections, expandedState)!;
 


### PR DESCRIPTION
## Description

This pull request adds a `defaultExpandedSection` prop to allow uncontrolled `useAccordion` usages to set default expanded sections.

## Detail

The accordion story isn't structured to demonstrate uncontrolled (or controlled) behavior. Feel free to pull the branch down locally and update the story's prop manually to see the behavior:

```jsx
// uncontrolled usage with default state
useAccordion({ expandable, collapsible, defaultExpandedSections: [0, 1, 2, 3, 4] });
```

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
