### PR TITLE
feat(utilities): Created DocumentPosition, ContainerOrientation and KEYS

### DIFF
--- a/packages/utilities/.size-snapshot.json
+++ b/packages/utilities/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 3097,
-    "minified": 1925,
-    "gzipped": 942
+    "bundled": 3950,
+    "minified": 2416,
+    "gzipped": 1133
   },
   "index.esm.js": {
-    "bundled": 2744,
-    "minified": 1610,
-    "gzipped": 834,
+    "bundled": 3579,
+    "minified": 2078,
+    "gzipped": 1025,
     "treeshaked": {
       "rollup": {
-        "code": 37,
+        "code": 356,
         "import_statements": 37
       },
       "webpack": {
-        "code": 1054
+        "code": 1373
       }
     }
   }

--- a/packages/utilities/.size-snapshot.json
+++ b/packages/utilities/.size-snapshot.json
@@ -19,14 +19,14 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 3950,
-    "minified": 2416,
-    "gzipped": 1133
+    "bundled": 4530,
+    "minified": 2881,
+    "gzipped": 1341
   },
   "index.esm.js": {
-    "bundled": 3579,
-    "minified": 2078,
-    "gzipped": 1025,
+    "bundled": 4144,
+    "minified": 2530,
+    "gzipped": 1227,
     "treeshaked": {
       "rollup": {
         "code": 356,

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -11,4 +11,6 @@ export { getControlledValue } from './utils/getControlledValue';
 export { useCombinedRefs } from './utils/useCombinedRefs';
 export { convertToMatrix } from './utils/convertToMatrix';
 export { KEY_CODES } from './utils/KEY_CODES';
+export { DocumentPosition } from './utils/DocumentPosition';
 export { useId } from './utils/useId';
+export { ContainerOrientation } from './utils/ContainerOrientation';

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -10,7 +10,7 @@ export { generateId, setIdCounter } from './utils/IdManager';
 export { getControlledValue } from './utils/getControlledValue';
 export { useCombinedRefs } from './utils/useCombinedRefs';
 export { convertToMatrix } from './utils/convertToMatrix';
-export { KEY_CODES } from './utils/KEY_CODES';
+export { KEY_CODES, KEYS } from './utils/KeyboardEventValues';
 export { DocumentPosition } from './utils/DocumentPosition';
 export { useId } from './utils/useId';
 export { ContainerOrientation } from './utils/ContainerOrientation';

--- a/packages/utilities/src/utils/ContainerOrientation.ts
+++ b/packages/utilities/src/utils/ContainerOrientation.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+export enum ContainerOrientation {
+  HORIZONTAL = 'horizontal',
+  VERTICAL = 'vertical'
+}

--- a/packages/utilities/src/utils/DocumentPosition.ts
+++ b/packages/utilities/src/utils/DocumentPosition.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+/**
+ * Collection of bitmask values returned by [Node#compareDocumentPosition](https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition)
+ *
+ * Use either the equal operator (`===`) or the bitwise AND (`&`) operator to compare positions.
+ *
+ * <table>
+ * <tr>
+ * <th scope="col">Name</th>
+ * <th scope="col">Value</th>
+ * </tr>
+ * <tr>
+ * <td><code>DOCUMENT_POSITION_DISCONNECTED</code></td>
+ * <td>1</td>
+ * </tr>
+ * <tr>
+ * <td><code>DOCUMENT_POSITION_PRECEDING</code></td>
+ * <td>2</td>
+ * </tr>
+ * <tr>
+ * <td><code>DOCUMENT_POSITION_FOLLOWING</code></td>
+ * <td>4</td>
+ * </tr>
+ * <tr>
+ * <td><code>DOCUMENT_POSITION_CONTAINS</code></td>
+ * <td>8</td>
+ * </tr>
+ * <tr>
+ * <td><code>DOCUMENT_POSITION_CONTAINED_BY</code></td>
+ * <td>16</td>
+ * </tr>
+ * <tr>
+ * <td><code>DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC</code></td>
+ * <td>32</td>
+ * </tr>
+ * </table>
+ *
+ * @enum
+ */
+export enum DocumentPosition {
+  /**
+   * DOCUMENT_POSITION_DISCONNECTED	= 1
+   */
+  DISCONNECTED = 1,
+  /**
+   * DOCUMENT_POSITION_PRECEDING = 2
+   */
+  PRECEDING = 2,
+  /**
+   * DOCUMENT_POSITION_FOLLOWING = 4
+   */
+  FOLLOWING = 4,
+  /**
+   * DOCUMENT_POSITION_CONTAINS = 8
+   */
+  CONTAINS = 8,
+  /**
+   * DOCUMENT_POSITION_CONTAINED_BY = 16
+   */
+  CONTAINED_BY = 16,
+  /**
+   * DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 32
+   */
+  IMPLEMENTATION_SPECIFIC = 32
+}

--- a/packages/utilities/src/utils/KEY_CODES.ts
+++ b/packages/utilities/src/utils/KEY_CODES.ts
@@ -13,6 +13,7 @@
  */
 export const KEY_CODES = {
   ALT: 18,
+  ASTERISK: 170,
   BACKSPACE: 8,
   COMMA: 188,
   DELETE: 46,

--- a/packages/utilities/src/utils/KeyboardEventValues.ts
+++ b/packages/utilities/src/utils/KeyboardEventValues.ts
@@ -38,3 +38,32 @@ export const KEY_CODES = {
   TAB: 9,
   UP: 38
 };
+
+export const KEYS = {
+  ALT: 'Alt',
+  ASTERISK: '*',
+  BACKSPACE: 'Backspace',
+  COMMA: ',',
+  DELETE: 'Delete',
+  DOWN: 'ArrowDown',
+  END: 'End',
+  ENTER: 'Enter',
+  ESCAPE: 'Escape',
+  HOME: 'Home',
+  LEFT: 'ArrowLeft',
+  NUMPAD_ADD: 'Add',
+  NUMPAD_DECIMAL: 'Decimal',
+  NUMPAD_DIVIDE: 'Divide',
+  NUMPAD_ENTER: 'Enter',
+  NUMPAD_MULTIPLY: 'Multiply',
+  NUMPAD_SUBTRACT: 'Subtract',
+  PAGE_DOWN: 'PageDown',
+  PAGE_UP: 'PageUp',
+  PERIOD: '.',
+  RIGHT: 'ArrowRight',
+  SHIFT: 'Shift',
+  SPACE: ' ',
+  TAB: 'Tab',
+  UNIDENTIFIED: 'Unidentified',
+  UP: 'ArrowUp'
+};


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(selection):
     add keydown event to handle rtl". the title informs the semantic
     version bump if this PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

- Created DocumentPosition enum
- Created ContainerOrientation enum
- Added the Asterisk keycode to KEY_CODE
- Created KEYS dictionary using Key Values

## Detail

<!-- supporting details; screen shot, code, etc. -->
These changes are required by https://github.com/zendeskgarden/react-containers/pull/346 

This PR introduces two new enums and a dictionary in the utilities package. 

`DocumentPosition` is an enum containing the bitmask needed to determine the position of an element relative to another as defined in: https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition

`ContainerOrientation` is a simple enum aimed at bringing consistency across the different containers. I noticed different terms for the same feature. A common `orientation` option using this enum would be useful. 

The use of `event.keyCode` has been deprecated and it is now recommended to use `event.key` ([source](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode)). The new `KEYS` dictionary has the same keys as `KEY_CODES` but use [Key Values](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values).

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
