### PR TITLE
chore(lock): update lockfile

### DIFF
--- a/packages/splitter/yarn.lock
+++ b/packages/splitter/yarn.lock
@@ -9,7 +9,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-react-uid@^2.3.1:
+react-uid@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/react-uid/-/react-uid-2.3.1.tgz#22a75d4a948a4824b9b8078cbf864d55d91ca4be"
   integrity sha512-6C5pwNYP1udgp5feQ9MTBZBKD4su9nhD2aYCFY1bB0Bpask8wYKYz0ZhAtAJ4lcmTDC5kY1ByGTQMFDHQW6p0w==


### PR DESCRIPTION
## Description

Correct missing lockfile updates for Splitter to allow build to pass.

## Checklist

- [ ] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
