### PR TITLE
chore(renovate): remove post update from config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,11 +2,6 @@
   "extends": ["config:base"],
   "rebaseStalePrs": true,
   "schedule": ["on Monday every 9 weeks of the year starting on the 3rd week"],
-  "postUpdateOptions": ["yarnDedupeHighest"],
-  "postUpgradeTasks": {
-    "commands": ["yarn install", "yarn format"],
-    "fileFilters": ["yarn.lock", "**/*.{js,ts,tsx,md,json}"]
-  },
   "packageRules": [
     {
       "matchFiles": ["package.json"],


### PR DESCRIPTION
## Description

This PR removes options from the Renovate config due to causing failures in our dependency update PRS.

## Detail

Removes [`postUpdateOptions`](https://docs.renovatebot.com/configuration-options/#postupdateoptions) and [`postUpgradeTasks`](https://docs.renovatebot.com/configuration-options/#postupgradetasks) from the configuration since both are only meant to run in self-hosted instances.

Addresses [issue #13810](https://github.com/renovatebot/renovate/issues/13810) and [discussion #13903](https://github.com/renovatebot/renovate/discussions/13903). It turns out the two configuration options were ignored initially and now throw when used due to a recent change by Renovate.

## Checklist

- [ ] :globe_with_meridians: ~~Storybook demo is up-to-date (`yarn start`)~~
- [ ] :wheelchair: ~~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~~
- [ ] :guardsman: ~~includes new unit tests~~
- [ ] :memo: ~~tested in Chrome, Firefox, Safari, Edge, and IE11~~
