### PR TITLE
fix(modals): use synthetic types for close handler

### DIFF
--- a/packages/modal/src/useModal.ts
+++ b/packages/modal/src/useModal.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { useRef, useState } from 'react';
+import { useRef, useState, KeyboardEvent, MouseEvent } from 'react';
 import { useUIDSeed } from 'react-uid';
 import { composeEventHandlers, KEY_CODES } from '@zendeskgarden/container-utilities';
 import { useFocusJail } from '@zendeskgarden/container-focusjail';


### PR DESCRIPTION
## Description

The types for `onClose` handler should satisfy synthetic event constraints because consumers pass this handler to React components (e.g. `<button onClick={onClose} />`.

## Detail

Previously, a native event type was used and that caused issues upstream where consumers had to [cast the event type](https://github.com/zendeskgarden/react-components/blob/6bcf661282e629b3482c214192475f47174c1aa7/packages/modals/demo/stories/ModalStory.tsx#L26) as `any` because the lower level `container-modal` handler type did not support synthetic events.

There will be a follow-on PR in `react-components` to address the type issues when using `container-modal`.


<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [ ] ~:wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, Edge, and IE11~
