### PR TITLE
fix(grid)!: remove selection

### DIFF
--- a/packages/grid/.size-snapshot.json
+++ b/packages/grid/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 14570,
-    "minified": 5029,
-    "gzipped": 1964
+    "bundled": 15123,
+    "minified": 5486,
+    "gzipped": 2234
   },
   "index.esm.js": {
-    "bundled": 13943,
-    "minified": 4520,
-    "gzipped": 1857,
+    "bundled": 14496,
+    "minified": 4973,
+    "gzipped": 2129,
     "treeshaked": {
       "rollup": {
         "code": 445,
         "import_statements": 40
       },
       "webpack": {
-        "code": 5095
+        "code": 5039
       }
     }
   }

--- a/packages/grid/.size-snapshot.json
+++ b/packages/grid/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 15123,
-    "minified": 5486,
-    "gzipped": 2234
+    "bundled": 9471,
+    "minified": 4297,
+    "gzipped": 1913
   },
   "index.esm.js": {
-    "bundled": 14496,
-    "minified": 4973,
-    "gzipped": 2129,
+    "bundled": 8844,
+    "minified": 3784,
+    "gzipped": 1803,
     "treeshaked": {
       "rollup": {
         "code": 445,
         "import_statements": 40
       },
       "webpack": {
-        "code": 5039
+        "code": 1492
       }
     }
   }

--- a/packages/grid/.size-snapshot.json
+++ b/packages/grid/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 9471,
-    "minified": 4297,
-    "gzipped": 1913
+    "bundled": 9469,
+    "minified": 4352,
+    "gzipped": 1928
   },
   "index.esm.js": {
-    "bundled": 8844,
-    "minified": 3784,
-    "gzipped": 1803,
+    "bundled": 8822,
+    "minified": 3822,
+    "gzipped": 1820,
     "treeshaked": {
       "rollup": {
-        "code": 445,
+        "code": 451,
         "import_statements": 40
       },
       "webpack": {
-        "code": 1492
+        "code": 1500
       }
     }
   }

--- a/packages/grid/.size-snapshot.json
+++ b/packages/grid/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 16604,
-    "minified": 5729,
-    "gzipped": 2131
+    "bundled": 14570,
+    "minified": 5029,
+    "gzipped": 1964
   },
   "index.esm.js": {
-    "bundled": 15845,
-    "minified": 5106,
-    "gzipped": 2027,
+    "bundled": 13943,
+    "minified": 4520,
+    "gzipped": 1857,
     "treeshaked": {
       "rollup": {
-        "code": 495,
+        "code": 445,
         "import_statements": 40
       },
       "webpack": {
-        "code": 1550
+        "code": 5095
       }
     }
   }

--- a/packages/grid/.size-snapshot.json
+++ b/packages/grid/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "index.cjs.js": {
-    "bundled": 9469,
-    "minified": 4352,
-    "gzipped": 1928
+    "bundled": 9752,
+    "minified": 4410,
+    "gzipped": 1955
   },
   "index.esm.js": {
-    "bundled": 8822,
-    "minified": 3822,
-    "gzipped": 1820,
+    "bundled": 9105,
+    "minified": 3880,
+    "gzipped": 1845,
     "treeshaked": {
       "rollup": {
         "code": 451,

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -3,8 +3,8 @@
 [npm version badge]: https://flat.badgen.net/npm/v/@zendeskgarden/container-grid
 [npm version link]: https://www.npmjs.com/package/@zendeskgarden/container-grid
 
-This package includes containers relating to Grid in the
-[Garden Design System](https://zendeskgarden.github.io/).
+This package provides [Garden Design System](https://zendeskgarden.github.io/)
+grid containers.
 
 ## Installation
 
@@ -14,88 +14,11 @@ npm install @zendeskgarden/container-grid
 
 ## Usage
 
-This container implements the
-[grid](https://www.w3.org/TR/wai-aria-practices-1.1/#grid) design pattern. Check
-out [storybook](https://zendeskgarden.github.io/react-containers) for live
-examples.
-
-### useGrid
-
-The following code demonstrates uncontrolled usage of the `useGrid` hook. Controlled usage examples
-can be found in the stories.
-
-```jsx
-import { useGrid } from '@zendeskgarden/container-grid';
-
-const matrix = [
-  [1, 2, 3],
-  [4, 5, 6],
-  [7, 8, 9]
-];
-
-const Grid = () => {
-  const { getGridCellProps } = useGrid({ matrix });
-
-  return (
-    <table role="grid">
-      <tbody>
-        {matrix.map((row, rowIdx) => (
-          <tr key={`rowIdx-${row[0]}`}>
-            {row.map((item, colIdx) => (
-              <td role="presentation" key={item}>
-                <button
-                  {...getGridCellProps({
-                    rowIdx,
-                    colIdx,
-                    'aria-label': `cell for ${item}}`
-                  })}
-                >
-                  {item}
-                </button>
-              </td>
-            ))}
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  );
-};
-```
-
-### GridContainer
-
-```jsx
-import { GridContainer } from '@zendeskgarden/container-grid';
-
-const matrix = [
-  [1,2,3],
-  [4,5,6],
-  [7,8,9]
-]
-
-<GridContainer>
-  {({ getGridCellProps }) => (
-    <table role="grid">
-      <tbody>
-        {matrix.map((row, rowIdx) => (
-          <tr key={`rowIdx-${row[0]}`}>
-            {row.map((item, colIdx) => (
-              <td role="presentation" key={item}>
-                <button
-                  {...getGridCellProps({
-                    rowIdx,
-                    colIdx,
-                    'aria-label': `cell for ${item}}`
-                  })}
-                >
-                  {item}
-                </button>
-              </td>
-            ))}
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  )}
-</GridContainer>;
-```
+This container is a primitive implementation of the [WAI-ARIA
+grid](https://www.w3.org/TR/wai-aria-practices-1.1/#grid) design pattern
+– currently emphasizing layout row/column navigation. Check out
+[storybook](https://zendeskgarden.github.io/react-containers) for live examples.
+See the backing
+[story](https://github.com/zendeskgarden/react-containers/blob/main/packages/grid/demo/stories/GridStory.tsx)
+for example code that demonstrates accessible layouts for both hook and
+container implementations.

--- a/packages/grid/demo/grid.stories.mdx
+++ b/packages/grid/demo/grid.stories.mdx
@@ -7,9 +7,10 @@ import { MATRIX } from './stories/data';
 <Meta
   title="Packages/Grid"
   component={GridContainer}
-  args={{ as: 'hook', matrix: MATRIX }}
+  args={{ as: 'hook', layout: 'button', matrix: MATRIX }}
   argTypes={{
-    as: { options: ['container', 'hook'], control: 'radio', table: { category: 'Story' } }
+    as: { options: ['container', 'hook'], control: 'radio', table: { category: 'Story' } },
+    layout: { options: ['button', 'radio', 'text'], control: 'radio', table: { category: 'Story' } }
   }}
 />
 
@@ -26,9 +27,7 @@ import { MATRIX } from './stories/data';
     name="Uncontrolled"
     argTypes={{
       colIndex: { control: false },
-      rowIndex: { control: false },
-      selectedColIndex: { control: false },
-      selectedRowIndex: { control: false }
+      rowIndex: { control: false }
     }}
   >
     {args => <GridStory {...args} />}
@@ -42,17 +41,13 @@ import { MATRIX } from './stories/data';
     name="Controlled"
     argTypes={{
       defaultColIndex: { control: false },
-      defaultRowIndex: { control: false },
-      defaultSelectedColIndex: { control: false },
-      defaultSelectedRowIndex: { control: false }
+      defaultRowIndex: { control: false }
     }}
   >
     {args => {
       const updateArgs = useArgs()[1];
       const handleChange = (rowIndex, colIndex) => updateArgs({ rowIndex, colIndex });
-      const handleSelect = (selectedRowIndex, selectedColIndex) =>
-        updateArgs({ selectedRowIndex, selectedColIndex });
-      return <GridStory {...args} onChange={handleChange} onSelect={handleSelect} />;
+      return <GridStory {...args} onChange={handleChange} />;
     }}
   </Story>
 </Canvas>

--- a/packages/grid/demo/stories/GridStory.tsx
+++ b/packages/grid/demo/stories/GridStory.tsx
@@ -15,40 +15,46 @@ import {
   useGrid
 } from '@zendeskgarden/container-grid';
 
-interface IComponent extends IUseGridProps, IUseGridReturnValue {}
+interface IComponent extends IUseGridProps, IUseGridReturnValue {
+  layout: IArgs['layout'];
+}
 
-const Component = ({ rtl, matrix, selection, getGridCellProps }: IComponent) => (
+const Component = ({ rtl, matrix, layout, getGridCellProps }: IComponent) => (
   <table role="grid" style={{ direction: rtl ? 'rtl' : 'ltr' }}>
     <tbody>
       {matrix.map((row, rowIdx) => (
         <tr key={rowIdx}>
           {row.map((column, colIdx) => {
-            const {
-              role,
-              'aria-selected': selected, // the gridcell itself is not selectable in this implementation
-              ...props
-            } = getGridCellProps({ rowIdx, colIdx });
+            const { role, ...props } = getGridCellProps({ rowIdx, colIdx });
 
-            return (
-              <td key={colIdx} role={role}>
-                {selection ? (
-                  <label>
-                    <span className="sr-only">{matrix[rowIdx][colIdx]}</span>
-                    <input
-                      className="w-5 h-5"
-                      name="demo"
-                      type="radio"
-                      {...props}
-                      defaultChecked={selected === true}
-                    />
-                  </label>
-                ) : (
-                  <button className="h-7 w-7" type="button" {...props}>
+            switch (layout) {
+              case 'text':
+                return (
+                  <td key={colIdx} className="w-5 h-5 text-center" role={role} {...props}>
                     {matrix[rowIdx][colIdx]}
-                  </button>
-                )}
-              </td>
-            );
+                  </td>
+                );
+
+              case 'radio':
+                return (
+                  <td key={colIdx} role={role}>
+                    <label>
+                      <span className="sr-only">{matrix[rowIdx][colIdx]}</span>
+                      <input className="w-5 h-5" name="demo" type="radio" {...props} />
+                    </label>
+                  </td>
+                );
+
+              case 'button':
+              default:
+                return (
+                  <td key={colIdx} role={role}>
+                    <button className="h-7 w-7" type="button" {...props}>
+                      {matrix[rowIdx][colIdx]}
+                    </button>
+                  </td>
+                );
+            }
           })}
         </tr>
       ))}
@@ -56,13 +62,17 @@ const Component = ({ rtl, matrix, selection, getGridCellProps }: IComponent) => 
   </table>
 );
 
-const Container = (props: IGridContainerProps) => (
+interface IProps extends IGridContainerProps {
+  layout: IArgs['layout'];
+}
+
+const Container = (props: IProps) => (
   <GridContainer {...props}>
     {containerProps => <Component {...containerProps} {...props} />}
   </GridContainer>
 );
 
-const Hook = (props: IUseGridProps) => {
+const Hook = (props: IProps) => {
   const hookProps = useGrid(props);
 
   return <Component {...hookProps} {...props} />;
@@ -70,7 +80,7 @@ const Hook = (props: IUseGridProps) => {
 
 interface IArgs extends IGridContainerProps {
   as: 'hook' | 'container';
-  size: number;
+  layout: 'button' | 'radio' | 'text';
 }
 
 export const GridStory: Story<IArgs> = ({ as, ...props }) => {

--- a/packages/grid/demo/stories/GridStory.tsx
+++ b/packages/grid/demo/stories/GridStory.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { createRef, FocusEventHandler } from 'react';
+import React, { FocusEventHandler } from 'react';
 import { Story } from '@storybook/react';
 import {
   GridContainer,
@@ -36,21 +36,20 @@ const Component = ({ rtl, matrix, layout, getGridCellProps }: IComponent) => (
                 );
 
               case 'radio': {
-                const inputRef = createRef<HTMLInputElement>();
                 const handleBlur: FocusEventHandler<HTMLInputElement> = event => {
                   /**
                    * When the grid loses focus, reset the roving tab index to
                    * the checked input. Otherwise, keyboard access to the native
                    * radio group is lost.
                    */
-                  if (inputRef.current && event.relatedTarget === null) {
+                  if (event.relatedTarget === null) {
                     const selectedInput = document.querySelector(
-                      `input[name='${inputRef.current.name}']:checked`
+                      `input[name='${event.target.name}']:checked`
                     );
 
                     if (selectedInput !== null) {
                       const inputs = document.getElementsByName(
-                        inputRef.current.name
+                        event.target.name
                       ) as NodeListOf<HTMLInputElement>;
 
                       inputs.forEach(input =>
@@ -70,7 +69,6 @@ const Component = ({ rtl, matrix, layout, getGridCellProps }: IComponent) => (
                         type="radio"
                         onBlur={handleBlur}
                         {...props}
-                        ref={inputRef}
                       />
                     </label>
                   </td>

--- a/packages/grid/demo/stories/GridStory.tsx
+++ b/packages/grid/demo/stories/GridStory.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { createRef, FocusEventHandler } from 'react';
 import { Story } from '@storybook/react';
 import {
   GridContainer,
@@ -35,15 +35,47 @@ const Component = ({ rtl, matrix, layout, getGridCellProps }: IComponent) => (
                   </td>
                 );
 
-              case 'radio':
+              case 'radio': {
+                const inputRef = createRef<HTMLInputElement>();
+                const handleBlur: FocusEventHandler<HTMLInputElement> = event => {
+                  /**
+                   * When the grid loses focus, reset the roving tab index to
+                   * the checked input. Otherwise, the native radio group loses
+                   * keyboard access.
+                   */
+                  if (inputRef.current && event.relatedTarget === null) {
+                    const selectedInput = document.querySelector(
+                      `input[name='${inputRef.current.name}']:checked`
+                    );
+
+                    if (selectedInput !== null) {
+                      const inputs = document.getElementsByName(
+                        inputRef.current.name
+                      ) as NodeListOf<HTMLInputElement>;
+
+                      inputs.forEach(input =>
+                        input.setAttribute('tabIndex', input.checked ? '0' : '-1')
+                      );
+                    }
+                  }
+                };
+
                 return (
                   <td key={colIdx} role={role}>
                     <label>
                       <span className="sr-only">{matrix[rowIdx][colIdx]}</span>
-                      <input className="w-5 h-5" name="demo" type="radio" {...props} />
+                      <input
+                        className="w-5 h-5"
+                        name="demo"
+                        type="radio"
+                        onBlur={handleBlur}
+                        {...props}
+                        ref={inputRef}
+                      />
                     </label>
                   </td>
                 );
+              }
 
               case 'button':
               default:

--- a/packages/grid/demo/stories/GridStory.tsx
+++ b/packages/grid/demo/stories/GridStory.tsx
@@ -40,8 +40,8 @@ const Component = ({ rtl, matrix, layout, getGridCellProps }: IComponent) => (
                 const handleBlur: FocusEventHandler<HTMLInputElement> = event => {
                   /**
                    * When the grid loses focus, reset the roving tab index to
-                   * the checked input. Otherwise, the native radio group loses
-                   * keyboard access.
+                   * the checked input. Otherwise, keyboard access to the native
+                   * radio group is lost.
                    */
                   if (inputRef.current && event.relatedTarget === null) {
                     const selectedInput = document.querySelector(

--- a/packages/grid/src/GridContainer.spec.tsx
+++ b/packages/grid/src/GridContainer.spec.tsx
@@ -100,10 +100,12 @@ describe('useGrid', () => {
 
       userEvent.tab();
       expect(gridCell('#d1e8df')).toHaveFocus();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(0, 0);
 
       userEvent.keyboard('{arrowright}');
       expect(gridCell('#aecfc2')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledTimes(2);
       expect(onChange).toHaveBeenCalledWith(0, 1);
 
       userEvent.keyboard('{arrowright}');
@@ -111,12 +113,12 @@ describe('useGrid', () => {
 
       userEvent.keyboard('{arrowright}');
       expect(gridCell('#5eae91')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenCalledTimes(3);
       expect(onChange).toHaveBeenCalledWith(0, 2);
 
       userEvent.keyboard('{arrowleft}');
       expect(gridCell('#aecfc2')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(3);
+      expect(onChange).toHaveBeenCalledTimes(4);
       expect(onChange).toHaveBeenCalledWith(0, 1);
 
       userEvent.keyboard('{arrowdown}');
@@ -127,7 +129,7 @@ describe('useGrid', () => {
 
       userEvent.keyboard('{arrowright}');
       expect(gridCell('#f5b5ba')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(4);
+      expect(onChange).toHaveBeenCalledTimes(5);
       expect(onChange).toHaveBeenCalledWith(1, 1);
 
       userEvent.keyboard('{arrowleft}');
@@ -135,7 +137,7 @@ describe('useGrid', () => {
 
       userEvent.keyboard('{arrowleft}');
       expect(gridCell('#f5d5d8')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(5);
+      expect(onChange).toHaveBeenCalledTimes(6);
       expect(onChange).toHaveBeenCalledWith(1, 0);
 
       userEvent.keyboard('{arrowup}');
@@ -143,7 +145,7 @@ describe('useGrid', () => {
 
       userEvent.keyboard('{arrowup}');
       expect(gridCell('#d1e8df')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(6);
+      expect(onChange).toHaveBeenCalledTimes(7);
       expect(onChange).toHaveBeenCalledWith(0, 0);
     });
 
@@ -158,6 +160,8 @@ describe('useGrid', () => {
 
       userEvent.tab();
       expect(gridCell('#d1e8df')).toHaveFocus();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(0, 0);
 
       userEvent.keyboard('{arrowup}');
       expect(gridCell('#d1e8df')).toHaveFocus();
@@ -167,42 +171,42 @@ describe('useGrid', () => {
 
       userEvent.keyboard('{arrowright}');
       expect(gridCell('#aecfc2')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledTimes(2);
       expect(onChange).toHaveBeenCalledWith(0, 1);
 
       userEvent.keyboard('{arrowright}');
       expect(gridCell('#5eae91')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenCalledTimes(3);
       expect(onChange).toHaveBeenCalledWith(0, 2);
 
       userEvent.keyboard('{arrowdown}');
       expect(gridCell('#228f67')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(3);
+      expect(onChange).toHaveBeenCalledTimes(4);
       expect(onChange).toHaveBeenCalledWith(0, 3);
 
       userEvent.keyboard('{arrowright}');
       expect(gridCell('#f5d5d8')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(4);
+      expect(onChange).toHaveBeenCalledTimes(5);
       expect(onChange).toHaveBeenCalledWith(1, 0);
 
       userEvent.keyboard('{arrowleft}');
       expect(gridCell('#228f67')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(5);
+      expect(onChange).toHaveBeenCalledTimes(6);
       expect(onChange).toHaveBeenCalledWith(0, 3);
 
       userEvent.keyboard('{arrowup}');
       expect(gridCell('#5eae91')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(6);
+      expect(onChange).toHaveBeenCalledTimes(7);
       expect(onChange).toHaveBeenCalledWith(0, 2);
 
       userEvent.keyboard('{arrowup}');
       expect(gridCell('#f5b5ba')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(7);
+      expect(onChange).toHaveBeenCalledTimes(8);
       expect(onChange).toHaveBeenCalledWith(1, 1);
 
       userEvent.keyboard('{arrowdown}');
       expect(gridCell('#5eae91')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(8);
+      expect(onChange).toHaveBeenCalledTimes(9);
       expect(onChange).toHaveBeenCalledWith(0, 2);
     });
 
@@ -219,15 +223,17 @@ describe('useGrid', () => {
 
       userEvent.tab();
       expect(gridCell('#aecfc2')).toHaveFocus();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(0, 1);
 
       userEvent.keyboard('{arrowleft}');
       expect(gridCell('#5eae91')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledTimes(2);
       expect(onChange).toHaveBeenCalledWith(0, 2);
 
       userEvent.keyboard('{arrowright}');
       expect(gridCell('#aecfc2')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenCalledTimes(3);
       expect(onChange).toHaveBeenCalledWith(0, 1);
     });
 
@@ -251,20 +257,22 @@ describe('useGrid', () => {
 
       userEvent.tab();
       expect(gridCell('#aecfc2')).toHaveFocus();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(0, 1);
 
       userEvent.keyboard('{arrowleft}');
       expect(gridCell('#5eae91')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledTimes(2);
       expect(onChange).toHaveBeenCalledWith(0, 2);
 
       userEvent.keyboard('{arrowleft}');
       expect(gridCell('#f5d5d8')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenCalledTimes(3);
       expect(onChange).toHaveBeenCalledWith(1, 0);
 
       userEvent.keyboard('{arrowright}');
       expect(gridCell('#5eae91')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(3);
+      expect(onChange).toHaveBeenCalledTimes(4);
       expect(onChange).toHaveBeenCalledWith(0, 2);
     });
 
@@ -282,15 +290,17 @@ describe('useGrid', () => {
 
       userEvent.tab();
       expect(gridCell('#f5b5ba')).toHaveFocus();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(1, 1);
 
       userEvent.keyboard('{home}');
       expect(gridCell('#f5d5d8')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledTimes(2);
       expect(onChange).toHaveBeenCalledWith(1, 0);
 
       userEvent.keyboard('{end}');
       expect(gridCell('#e35b66')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenCalledTimes(3);
       expect(onChange).toHaveBeenCalledWith(1, 2);
     });
 
@@ -308,15 +318,17 @@ describe('useGrid', () => {
 
       userEvent.tab();
       expect(gridCell('#f5b5ba')).toHaveFocus();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(1, 1);
 
       userEvent.keyboard('{Control>}{home}');
       expect(gridCell('#d1e8df')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledTimes(2);
       expect(onChange).toHaveBeenCalledWith(0, 0);
 
       userEvent.keyboard('{Control>}{end}');
       expect(gridCell('#adcce4')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenCalledTimes(3);
       expect(onChange).toHaveBeenCalledWith(2, 1);
     });
 
@@ -333,35 +345,37 @@ describe('useGrid', () => {
 
       userEvent.tab();
       expect(gridCell('#0b3b29')).toHaveFocus();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(0, 4);
 
       userEvent.keyboard('{arrowup}');
       expect(gridCell('#228f67')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledTimes(2);
       expect(onChange).toHaveBeenCalledWith(0, 3);
 
       userEvent.keyboard('{arrowup}');
       expect(gridCell('#5eae91')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenCalledTimes(3);
       expect(onChange).toHaveBeenCalledWith(0, 2);
 
       userEvent.keyboard('{arrowup}');
       expect(gridCell('#f5b5ba')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(3);
+      expect(onChange).toHaveBeenCalledTimes(4);
       expect(onChange).toHaveBeenCalledWith(1, 1);
 
       userEvent.keyboard('{arrowup}');
       expect(gridCell('#aecfc2')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(4);
+      expect(onChange).toHaveBeenCalledTimes(5);
       expect(onChange).toHaveBeenCalledWith(0, 1);
 
       userEvent.keyboard('{arrowup}');
       expect(gridCell('#f5d5d8')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(5);
+      expect(onChange).toHaveBeenCalledTimes(6);
       expect(onChange).toHaveBeenCalledWith(1, 0);
 
       userEvent.keyboard('{arrowup}');
       expect(gridCell('#d1e8df')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(6);
+      expect(onChange).toHaveBeenCalledTimes(7);
       expect(onChange).toHaveBeenCalledWith(0, 0);
     });
   });
@@ -418,10 +432,12 @@ describe('useGrid', () => {
 
       userEvent.tab();
       expect(gridCell('#d1e8df')).toHaveFocus();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(0, 0);
 
       userEvent.keyboard('{arrowright}');
       expect(gridCell('#aecfc2')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledTimes(2);
       expect(onChange).toHaveBeenCalledWith(0, 1);
 
       userEvent.keyboard('{arrowright}');
@@ -429,12 +445,12 @@ describe('useGrid', () => {
 
       userEvent.keyboard('{arrowright}');
       expect(gridCell('#5eae91')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenCalledTimes(3);
       expect(onChange).toHaveBeenCalledWith(0, 2);
 
       userEvent.keyboard('{arrowleft}');
       expect(gridCell('#aecfc2')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(3);
+      expect(onChange).toHaveBeenCalledTimes(4);
       expect(onChange).toHaveBeenCalledWith(0, 1);
 
       userEvent.keyboard('{arrowdown}');
@@ -445,7 +461,7 @@ describe('useGrid', () => {
 
       userEvent.keyboard('{arrowright}');
       expect(gridCell('#f5b5ba')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(4);
+      expect(onChange).toHaveBeenCalledTimes(5);
       expect(onChange).toHaveBeenCalledWith(1, 1);
 
       userEvent.keyboard('{arrowleft}');
@@ -453,7 +469,7 @@ describe('useGrid', () => {
 
       userEvent.keyboard('{arrowleft}');
       expect(gridCell('#f5d5d8')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(5);
+      expect(onChange).toHaveBeenCalledTimes(6);
       expect(onChange).toHaveBeenCalledWith(1, 0);
 
       userEvent.keyboard('{arrowup}');
@@ -461,7 +477,7 @@ describe('useGrid', () => {
 
       userEvent.keyboard('{arrowup}');
       expect(gridCell('#d1e8df')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(6);
+      expect(onChange).toHaveBeenCalledTimes(7);
       expect(onChange).toHaveBeenCalledWith(0, 0);
     });
 
@@ -476,6 +492,8 @@ describe('useGrid', () => {
 
       userEvent.tab();
       expect(gridCell('#d1e8df')).toHaveFocus();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(0, 0);
 
       userEvent.keyboard('{arrowup}');
       expect(gridCell('#d1e8df')).toHaveFocus();
@@ -485,42 +503,42 @@ describe('useGrid', () => {
 
       userEvent.keyboard('{arrowright}');
       expect(gridCell('#aecfc2')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledTimes(2);
       expect(onChange).toHaveBeenCalledWith(0, 1);
 
       userEvent.keyboard('{arrowright}');
       expect(gridCell('#5eae91')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenCalledTimes(3);
       expect(onChange).toHaveBeenCalledWith(0, 2);
 
       userEvent.keyboard('{arrowdown}');
       expect(gridCell('#228f67')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(3);
+      expect(onChange).toHaveBeenCalledTimes(4);
       expect(onChange).toHaveBeenCalledWith(0, 3);
 
       userEvent.keyboard('{arrowright}');
       expect(gridCell('#f5d5d8')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(4);
+      expect(onChange).toHaveBeenCalledTimes(5);
       expect(onChange).toHaveBeenCalledWith(1, 0);
 
       userEvent.keyboard('{arrowleft}');
       expect(gridCell('#228f67')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(5);
+      expect(onChange).toHaveBeenCalledTimes(6);
       expect(onChange).toHaveBeenCalledWith(0, 3);
 
       userEvent.keyboard('{arrowup}');
       expect(gridCell('#5eae91')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(6);
+      expect(onChange).toHaveBeenCalledTimes(7);
       expect(onChange).toHaveBeenCalledWith(0, 2);
 
       userEvent.keyboard('{arrowup}');
       expect(gridCell('#f5b5ba')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(7);
+      expect(onChange).toHaveBeenCalledTimes(8);
       expect(onChange).toHaveBeenCalledWith(1, 1);
 
       userEvent.keyboard('{arrowdown}');
       expect(gridCell('#5eae91')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(8);
+      expect(onChange).toHaveBeenCalledTimes(9);
       expect(onChange).toHaveBeenCalledWith(0, 2);
     });
 
@@ -535,15 +553,17 @@ describe('useGrid', () => {
 
       userEvent.tab();
       expect(gridCell('#aecfc2')).toHaveFocus();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(0, 1);
 
       userEvent.keyboard('{arrowleft}');
       expect(gridCell('#5eae91')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledTimes(2);
       expect(onChange).toHaveBeenCalledWith(0, 2);
 
       userEvent.keyboard('{arrowright}');
       expect(gridCell('#aecfc2')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenCalledTimes(3);
       expect(onChange).toHaveBeenCalledWith(0, 1);
     });
 
@@ -558,20 +578,22 @@ describe('useGrid', () => {
 
       userEvent.tab();
       expect(gridCell('#aecfc2')).toHaveFocus();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(0, 1);
 
       userEvent.keyboard('{arrowleft}');
       expect(gridCell('#5eae91')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledTimes(2);
       expect(onChange).toHaveBeenCalledWith(0, 2);
 
       userEvent.keyboard('{arrowleft}');
       expect(gridCell('#f5d5d8')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenCalledTimes(3);
       expect(onChange).toHaveBeenCalledWith(1, 0);
 
       userEvent.keyboard('{arrowright}');
       expect(gridCell('#5eae91')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(3);
+      expect(onChange).toHaveBeenCalledTimes(4);
       expect(onChange).toHaveBeenCalledWith(0, 2);
     });
 
@@ -587,15 +609,17 @@ describe('useGrid', () => {
 
       userEvent.tab();
       expect(gridCell('#f5b5ba')).toHaveFocus();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(1, 1);
 
       userEvent.keyboard('{home}');
       expect(gridCell('#f5d5d8')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledTimes(2);
       expect(onChange).toHaveBeenCalledWith(1, 0);
 
       userEvent.keyboard('{end}');
       expect(gridCell('#e35b66')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenCalledTimes(3);
       expect(onChange).toHaveBeenCalledWith(1, 2);
     });
 
@@ -611,15 +635,17 @@ describe('useGrid', () => {
 
       userEvent.tab();
       expect(gridCell('#f5b5ba')).toHaveFocus();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(1, 1);
 
       userEvent.keyboard('{Control>}{home}');
       expect(gridCell('#d1e8df')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledTimes(2);
       expect(onChange).toHaveBeenCalledWith(0, 0);
 
       userEvent.keyboard('{Control>}{end}');
       expect(gridCell('#adcce4')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenCalledTimes(3);
       expect(onChange).toHaveBeenCalledWith(2, 1);
     });
 
@@ -634,36 +660,37 @@ describe('useGrid', () => {
 
       userEvent.tab();
       expect(gridCell('#0b3b29')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(0);
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(0, 4);
 
       userEvent.keyboard('{arrowup}');
       expect(gridCell('#228f67')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledTimes(2);
       expect(onChange).toHaveBeenCalledWith(0, 3);
 
       userEvent.keyboard('{arrowup}');
       expect(gridCell('#5eae91')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenCalledTimes(3);
       expect(onChange).toHaveBeenCalledWith(0, 2);
 
       userEvent.keyboard('{arrowup}');
       expect(gridCell('#f5b5ba')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(3);
+      expect(onChange).toHaveBeenCalledTimes(4);
       expect(onChange).toHaveBeenCalledWith(1, 1);
 
       userEvent.keyboard('{arrowup}');
       expect(gridCell('#aecfc2')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(4);
+      expect(onChange).toHaveBeenCalledTimes(5);
       expect(onChange).toHaveBeenCalledWith(0, 1);
 
       userEvent.keyboard('{arrowup}');
       expect(gridCell('#f5d5d8')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(5);
+      expect(onChange).toHaveBeenCalledTimes(6);
       expect(onChange).toHaveBeenCalledWith(1, 0);
 
       userEvent.keyboard('{arrowup}');
       expect(gridCell('#d1e8df')).toHaveFocus();
-      expect(onChange).toHaveBeenCalledTimes(6);
+      expect(onChange).toHaveBeenCalledTimes(7);
       expect(onChange).toHaveBeenCalledWith(0, 0);
     });
   });

--- a/packages/grid/src/GridContainer.spec.tsx
+++ b/packages/grid/src/GridContainer.spec.tsx
@@ -22,7 +22,7 @@ describe('useGrid', () => {
   const idPrefix = 'some-id-prefix';
 
   const Example = ({ rtl, matrix, onFocus, onClick, ...props }: IExample) => (
-    <GridContainer rtl={rtl} selection matrix={matrix} idPrefix={idPrefix} {...props}>
+    <GridContainer rtl={rtl} matrix={matrix} idPrefix={idPrefix} {...props}>
       {({ getGridCellProps }: IUseGridReturnValue) => (
         <table role="grid">
           <tbody>
@@ -87,49 +87,6 @@ describe('useGrid', () => {
 
       userEvent.tab();
       expect(gridCell('#f5b5ba')).toHaveFocus();
-    });
-
-    test('sets a default selected cell', () => {
-      const matrix = [
-        ['#d1e8df', '#aecfc2'],
-        ['#f5d5d8', '#f5b5ba']
-      ];
-
-      render(
-        <Example
-          selection
-          matrix={matrix}
-          defaultSelectedRowIndex={1}
-          defaultSelectedColIndex={1}
-        />
-      );
-
-      userEvent.tab();
-      expect(gridCell('#f5b5ba')).toHaveAttribute('aria-selected', 'true');
-    });
-
-    test('sets selected cell using keyboard and pointer', () => {
-      const matrix = [
-        ['#d1e8df', '#aecfc2'],
-        ['#f5d5d8', '#f5b5ba']
-      ];
-
-      render(<Example selection matrix={matrix} />);
-
-      userEvent.tab();
-      expect(gridCell('#d1e8df')).toHaveAttribute('aria-selected', 'false');
-
-      userEvent.keyboard('{enter}');
-      expect(gridCell('#d1e8df')).toHaveAttribute('aria-selected', 'true');
-
-      userEvent.keyboard('{end}');
-      userEvent.keyboard('{space}');
-      expect(gridCell('#aecfc2')).toHaveAttribute('aria-selected', 'true');
-      expect(gridCell('#d1e8df')).toHaveAttribute('aria-selected', 'false');
-
-      userEvent.click(gridCell('#f5d5d8'));
-      expect(gridCell('#f5d5d8')).toHaveAttribute('aria-selected', 'true');
-      expect(gridCell('#f5b5ba')).toHaveAttribute('aria-selected', 'false');
     });
 
     test('focus moves when arrow keys are pressed', () => {
@@ -407,33 +364,6 @@ describe('useGrid', () => {
       expect(onChange).toHaveBeenCalledTimes(6);
       expect(onChange).toHaveBeenCalledWith(0, 0);
     });
-
-    test('calls onSelect when a cell is selected', () => {
-      const onSelect = jest.fn();
-      const matrix = [
-        ['#d1e8df', '#aecfc2', '#5eae91'],
-        ['#f5d5d8', '#f5b5ba']
-      ];
-
-      render(<Example selection matrix={matrix} onSelect={onSelect} />);
-
-      userEvent.tab();
-      expect(gridCell('#d1e8df')).toHaveAttribute('aria-selected', 'false');
-      expect(onSelect).toHaveBeenCalledTimes(0);
-
-      userEvent.keyboard('{enter}');
-      expect(onSelect).toHaveBeenCalledTimes(1);
-      expect(onSelect).toHaveBeenCalledWith(0, 0);
-
-      userEvent.keyboard('{end}');
-      userEvent.keyboard('{space}');
-      expect(onSelect).toHaveBeenCalledTimes(2);
-      expect(onSelect).toHaveBeenCalledWith(0, 2);
-
-      userEvent.click(gridCell('#f5d5d8'));
-      expect(onSelect).toHaveBeenCalledTimes(3);
-      expect(onSelect).toHaveBeenCalledWith(1, 0);
-    });
   });
 
   describe('controlled usages', () => {
@@ -442,12 +372,8 @@ describe('useGrid', () => {
       wrap,
       matrix,
       onChange,
-      onSelect,
       rowIndex = 0,
-      colIndex = 0,
-      selectedRowIndex,
-      selectedColIndex,
-      selection
+      colIndex = 0
     }: IUseGridProps) => {
       const [m, setRowIdx] = useState(rowIndex);
       const [n, setColIdx] = useState(colIndex);
@@ -455,14 +381,10 @@ describe('useGrid', () => {
       return (
         <Example
           rtl={rtl}
-          selection={selection}
-          onSelect={onSelect}
           wrap={wrap}
           rowIndex={m}
           colIndex={n}
           matrix={matrix}
-          selectedRowIndex={selectedRowIndex}
-          selectedColIndex={selectedColIndex}
           onChange={(rowIdx: number, colIdx: number) => {
             onChange && onChange(rowIdx, colIdx);
             setRowIdx(rowIdx);
@@ -485,24 +407,13 @@ describe('useGrid', () => {
       expect(gridCell('#aecfc2')).toHaveFocus();
     });
 
-    test('sets the selected cell', () => {
-      const matrix = [
-        ['#d1e8df', '#aecfc2'],
-        ['#f5d5d8', '#f5b5ba']
-      ];
-
-      render(<Controlled selection matrix={matrix} selectedRowIndex={0} selectedColIndex={1} />);
-
-      expect(gridCell('#aecfc2')).toHaveAttribute('aria-selected', 'true');
-    });
-
     test('sets focus to first cell given unset grid', () => {
       const matrix = [
         ['#d1e8df', '#aecfc2'],
         ['#f5d5d8', '#f5b5ba']
       ];
 
-      render(<Example selection rowIndex={-1} colIndex={-1} matrix={matrix} />);
+      render(<Example rowIndex={-1} colIndex={-1} matrix={matrix} />);
 
       expect(gridCell('#d1e8df')).not.toHaveFocus();
       userEvent.tab();
@@ -767,27 +678,6 @@ describe('useGrid', () => {
       expect(gridCell('#d1e8df')).toHaveFocus();
       expect(onChange).toHaveBeenCalledTimes(6);
       expect(onChange).toHaveBeenCalledWith(0, 0);
-    });
-
-    test('calls onSelect when a cell is selected', () => {
-      const onSelect = jest.fn();
-      const matrix = [
-        ['#d1e8df', '#aecfc2', '#5eae91'],
-        ['#f5d5d8', '#f5b5ba']
-      ];
-
-      render(
-        <Controlled selection colIndex={1} rowIndex={1} matrix={matrix} onSelect={onSelect} />
-      );
-
-      userEvent.tab();
-      userEvent.keyboard('{enter}');
-      expect(onSelect).toHaveBeenCalledTimes(1);
-      expect(onSelect).toHaveBeenCalledWith(1, 1);
-
-      userEvent.click(gridCell('#d1e8df'));
-      expect(onSelect).toHaveBeenCalledTimes(2);
-      expect(onSelect).toHaveBeenCalledWith(0, 0);
     });
   });
 });

--- a/packages/grid/src/GridContainer.spec.tsx
+++ b/packages/grid/src/GridContainer.spec.tsx
@@ -407,19 +407,6 @@ describe('useGrid', () => {
       expect(gridCell('#aecfc2')).toHaveFocus();
     });
 
-    test('sets focus to first cell given unset grid', () => {
-      const matrix = [
-        ['#d1e8df', '#aecfc2'],
-        ['#f5d5d8', '#f5b5ba']
-      ];
-
-      render(<Example rowIndex={-1} colIndex={-1} matrix={matrix} />);
-
-      expect(gridCell('#d1e8df')).not.toHaveFocus();
-      userEvent.tab();
-      expect(gridCell('#d1e8df')).toHaveFocus();
-    });
-
     test('focus moves when arrow keys are pressed', () => {
       const onChange = jest.fn();
       const matrix = [

--- a/packages/grid/src/GridContainer.tsx
+++ b/packages/grid/src/GridContainer.tsx
@@ -33,5 +33,6 @@ GridContainer.propTypes = {
   colIndex: PropTypes.number,
   defaultRowIndex: PropTypes.number,
   defaultColIndex: PropTypes.number,
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  environment: PropTypes.any
 };

--- a/packages/grid/src/GridContainer.tsx
+++ b/packages/grid/src/GridContainer.tsx
@@ -27,17 +27,11 @@ GridContainer.propTypes = {
   render: PropTypes.func,
   rtl: PropTypes.bool,
   wrap: PropTypes.bool,
-  selection: PropTypes.bool,
   matrix: PropTypes.any,
   idPrefix: PropTypes.string,
   rowIndex: PropTypes.number,
   colIndex: PropTypes.number,
-  selectedRowIndex: PropTypes.number,
-  selectedColIndex: PropTypes.number,
   defaultRowIndex: PropTypes.number,
   defaultColIndex: PropTypes.number,
-  defaultSelectedRowIndex: PropTypes.number,
-  defaultSelectedColIndex: PropTypes.number,
-  onChange: PropTypes.func,
-  onSelect: PropTypes.func
+  onChange: PropTypes.func
 };

--- a/packages/grid/src/useGrid.ts
+++ b/packages/grid/src/useGrid.ts
@@ -21,11 +21,11 @@ export interface IUseGridProps {
   idPrefix?: string;
   /** Sets the focused row index in a controlled grid */
   rowIndex?: number;
-  /** Sets the focused col index in a controlled grid */
+  /** Sets the focused column index in a controlled grid */
   colIndex?: number;
   /** Sets the default focused row index in a uncontrolled grid */
   defaultRowIndex?: number;
-  /** Sets the default focused col index in a uncontrolled grid */
+  /** Sets the default focused column index in a uncontrolled grid */
   defaultColIndex?: number;
   /** Handles grid change event */
   onChange?: (rowIndex: number, colIndex: number) => void;

--- a/packages/grid/src/useGrid.ts
+++ b/packages/grid/src/useGrid.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { useState, HTMLProps, HTMLAttributes, KeyboardEvent } from 'react';
+import { useState, HTMLProps, HTMLAttributes, KeyboardEventHandler } from 'react';
 import { composeEventHandlers, KEYS } from '@zendeskgarden/container-utilities';
 
 const GRID_KEYS = [KEYS.LEFT, KEYS.RIGHT, KEYS.UP, KEYS.DOWN, KEYS.HOME, KEYS.END];
@@ -21,11 +21,11 @@ export interface IUseGridProps {
   idPrefix?: string;
   /** Sets the focused row index in a controlled grid */
   rowIndex?: number;
-  /** Sets the focused column index in a controlled grid */
+  /** Sets the focused col index in a controlled grid */
   colIndex?: number;
   /** Sets the default focused row index in a uncontrolled grid */
   defaultRowIndex?: number;
-  /** Sets the default focused column index in a uncontrolled grid */
+  /** Sets the default focused col index in a uncontrolled grid */
   defaultColIndex?: number;
   /** Handles grid change event */
   onChange?: (rowIndex: number, colIndex: number) => void;
@@ -46,13 +46,13 @@ export function useGrid({
   matrix,
   idPrefix,
   onChange,
-  rowIndex,
-  colIndex,
+  rowIndex: controlledRowIndex,
+  colIndex: controlledColIndex,
   defaultRowIndex,
   defaultColIndex
 }: IUseGridProps): IUseGridReturnValue {
   const rowCount = matrix.length;
-  const columnCount = matrix[0].length;
+  const colCount = matrix[0].length;
   const lastRowLength = matrix[rowCount - 1].length;
   const [uncontrolledRowIndex, setUncontrolledRowIndex] = useState(
     defaultRowIndex !== null && defaultRowIndex !== undefined ? defaultRowIndex : 0
@@ -61,280 +61,158 @@ export function useGrid({
     defaultColIndex !== null && defaultColIndex !== undefined ? defaultColIndex : 0
   );
   const isControlled =
-    rowIndex !== null && colIndex !== null && rowIndex !== undefined && colIndex !== undefined;
+    controlledRowIndex !== null &&
+    controlledColIndex !== null &&
+    controlledRowIndex !== undefined &&
+    controlledColIndex !== undefined;
+  const rowIndex = isControlled ? controlledRowIndex : uncontrolledRowIndex;
+  const colIndex = isControlled ? controlledColIndex : uncontrolledColIndex;
 
-  const setFocusedCell = (rowIdx: number, colIdx: number) => {
-    setUncontrolledRowIndex(rowIdx);
-    setUncontrolledColIndex(colIdx);
-  };
+  const getCellRight = () => {
+    let retVal: number[] = [];
+    const isLastCellFocused = rowIndex === rowCount - 1 && colIndex === lastRowLength - 1;
 
-  const setFocus = (rowIdx: number, colIdx: number) => {
-    const id = `${idPrefix}-${rowIdx}-${colIdx}`;
-    const element = document.getElementById(id);
-
-    element && element.focus();
-  };
-
-  const onNavigate = (e: KeyboardEvent<HTMLElement>) => {
-    if (GRID_KEYS.includes(e.key)) {
-      e.preventDefault();
+    if (!isLastCellFocused) {
+      if (colIndex === colCount - 1 /* last col is focused */) {
+        if (wrap) {
+          retVal = [rowIndex + 1, 0]; // first cell of next row
+        }
+      } else {
+        retVal = [rowIndex, colIndex + 1]; // next cell
+      }
     }
 
-    if (isControlled) {
-      const onLastRow = rowIndex === rowCount - 1;
-      const onLastCol = colIndex === columnCount - 1;
-      const rightEnd = onLastRow && colIndex === lastRowLength - 1;
-      const downEnd = rowIndex === rowCount - 2 && (colIndex as number) >= lastRowLength;
-      const backward = () => {
-        if ((colIndex as number) > 0) {
-          onChange && onChange(rowIndex as number, (colIndex as number) - 1);
-          setFocus(rowIndex as number, (colIndex as number) - 1);
-        }
-        if (wrap && colIndex === 0 && (rowIndex as number) > 0) {
-          onChange && onChange((rowIndex as number) - 1, columnCount - 1);
-          setFocus((rowIndex as number) - 1, columnCount - 1);
-        }
-      };
+    return retVal;
+  };
 
-      const forward = () => {
-        if ((colIndex as number) < columnCount - 1 && !rightEnd) {
-          onChange && onChange(rowIndex as number, (colIndex as number) + 1);
-          setFocus(rowIndex as number, (colIndex as number) + 1);
-        }
-        if (wrap && onLastCol && !onLastRow) {
-          onChange && onChange((rowIndex as number) + 1, 0);
-          setFocus((rowIndex as number) + 1, 0);
-        }
-      };
+  const getCellLeft = () => {
+    let retVal: number[] = [];
+    const isFirstCellFocused = rowIndex === 0 && colIndex === 0;
 
-      switch (e.key) {
-        case KEYS.LEFT:
-          return rtl ? forward() : backward();
+    if (!isFirstCellFocused) {
+      if (colIndex === 0 /* first col is focused */) {
+        if (wrap) {
+          retVal = [rowIndex - 1, colCount - 1]; // last cell of previous row
+        }
+      } else {
+        retVal = [rowIndex, colIndex - 1]; // previous cell
+      }
+    }
+
+    return retVal;
+  };
+
+  const getCellDown = () => {
+    let retVal: number[] = [];
+    const isLastCellFocused =
+      rowIndex === rowCount - (colCount > lastRowLength ? 2 : 1) && colIndex === colCount - 1;
+
+    if (!isLastCellFocused) {
+      if (rowIndex === rowCount - (colIndex >= lastRowLength ? 2 : 1) /* last row is focused */) {
+        if (wrap) {
+          retVal = [0, colIndex + 1]; // top cell of next col
+        }
+      } else {
+        retVal = [rowIndex + 1, colIndex]; // cell below
+      }
+    }
+
+    return retVal;
+  };
+
+  const getCellUp = () => {
+    let retVal: number[] = [];
+    const isFirstCellFocused = rowIndex === 0 && colIndex === 0;
+
+    if (!isFirstCellFocused) {
+      if (rowIndex === 0 /* first row is focused */) {
+        if (wrap) {
+          const col = colIndex - 1;
+          const row = rowCount - (col >= lastRowLength ? 2 : 1);
+
+          retVal = [row, col]; // bottom cell of previous col
+        }
+      } else {
+        retVal = [rowIndex - 1, colIndex]; // cell above
+      }
+    }
+
+    return retVal;
+  };
+
+  const handleKeyDown: KeyboardEventHandler = event => {
+    if (GRID_KEYS.includes(event.key)) {
+      event.preventDefault();
+
+      let row = rowIndex;
+      let col = colIndex;
+
+      switch (event.key) {
         case KEYS.RIGHT:
-          return rtl ? backward() : forward();
-        case KEYS.UP:
-          if (rowIndex === 0 && colIndex === 0) {
-            break;
-          }
-          if ((rowIndex as number) > 0) {
-            onChange && onChange((rowIndex as number) - 1, colIndex as number);
-            setFocus((rowIndex as number) - 1, colIndex as number);
-            break;
-          }
-          if (wrap) {
-            if ((colIndex as number) <= lastRowLength) {
-              setFocus(rowCount - 1, (colIndex as number) - 1);
-              onChange && onChange(rowCount - 1, (colIndex as number) - 1);
-            } else {
-              setFocus(rowCount - 2, (colIndex as number) - 1);
-              onChange && onChange(rowCount - 2, (colIndex as number) - 1);
-            }
-          }
+          [row, col] = rtl ? getCellLeft() : getCellRight();
           break;
-        case KEYS.DOWN:
-          if ((rowIndex as number) < rowCount - 1 && !downEnd) {
-            onChange && onChange((rowIndex as number) + 1, colIndex as number);
-            setFocus((rowIndex as number) + 1, colIndex as number);
-          }
-          if (wrap) {
-            if ((colIndex as number) < columnCount - 1 && onLastRow) {
-              setFocus(0, (colIndex as number) + 1);
-              onChange && onChange(0, (colIndex as number) + 1);
-            }
 
-            if (
-              (colIndex as number) >= lastRowLength &&
-              rowCount - 1 === (rowIndex as number) + 1 &&
-              (colIndex as number) < columnCount - 1
-            ) {
-              setFocus(0, (colIndex as number) + 1);
-              onChange && onChange(0, (colIndex as number) + 1);
-              break;
-            }
-          }
-          break;
-        case KEYS.HOME:
-          if (e.ctrlKey) {
-            onChange && onChange(0, 0);
-            setFocus(0, 0);
-          } else {
-            onChange && onChange(rowIndex as number, 0);
-            setFocus(rowIndex as number, 0);
-          }
-          break;
-        case KEYS.END:
-          if (e.ctrlKey) {
-            onChange && onChange(rowCount - 1, matrix[rowCount - 1].length - 1);
-            setFocus(rowCount - 1, matrix[rowCount - 1].length - 1);
-          } else {
-            onChange && onChange(rowIndex as number, matrix[rowIndex as number].length - 1);
-            setFocus(rowIndex as number, matrix[rowIndex as number].length - 1);
-          }
-          break;
-        default:
-      }
-    } else {
-      const onLastRow = uncontrolledRowIndex === rowCount - 1;
-      const onLastCol = uncontrolledColIndex === columnCount - 1;
-      const rightEnd = onLastRow && uncontrolledColIndex === lastRowLength - 1;
-      const downEnd =
-        uncontrolledRowIndex === rowCount - 2 && uncontrolledColIndex >= lastRowLength;
-
-      const forward = () => {
-        if (uncontrolledColIndex < columnCount - 1 && !rightEnd) {
-          setUncontrolledColIndex(uncontrolledColIndex + 1);
-          setFocus(uncontrolledRowIndex, uncontrolledColIndex + 1);
-          onChange && onChange(uncontrolledRowIndex, uncontrolledColIndex + 1);
-        }
-        if (wrap && onLastCol && !onLastRow) {
-          setUncontrolledRowIndex(uncontrolledRowIndex + 1);
-          setUncontrolledColIndex(0);
-          setFocus(uncontrolledRowIndex + 1, 0);
-          onChange && onChange(uncontrolledRowIndex + 1, 0);
-        }
-      };
-
-      const backward = () => {
-        if (uncontrolledColIndex > 0) {
-          setUncontrolledColIndex(uncontrolledColIndex - 1);
-          setFocus(uncontrolledRowIndex, uncontrolledColIndex - 1);
-          onChange && onChange(uncontrolledRowIndex, uncontrolledColIndex - 1);
-        }
-        if (wrap && uncontrolledColIndex === 0 && uncontrolledRowIndex > 0) {
-          setUncontrolledRowIndex(uncontrolledRowIndex - 1);
-          setUncontrolledColIndex(columnCount - 1);
-          setFocus(uncontrolledRowIndex - 1, columnCount - 1);
-          onChange && onChange(uncontrolledRowIndex - 1, columnCount - 1);
-        }
-      };
-
-      switch (e.key) {
         case KEYS.LEFT:
-          return rtl ? forward() : backward();
-        case KEYS.RIGHT:
-          return rtl ? backward() : forward();
-        case KEYS.UP:
-          if (uncontrolledRowIndex === 0 && uncontrolledColIndex === 0) {
-            break;
-          }
-          if (uncontrolledRowIndex > 0) {
-            setUncontrolledRowIndex(uncontrolledRowIndex - 1);
-            setFocus(uncontrolledRowIndex - 1, uncontrolledColIndex);
-            onChange && onChange(uncontrolledRowIndex - 1, uncontrolledColIndex);
-            break;
-          }
-          if (wrap) {
-            if (uncontrolledColIndex <= lastRowLength) {
-              setUncontrolledRowIndex(rowCount - 1);
-              setUncontrolledColIndex(uncontrolledColIndex - 1);
-              setFocus(rowCount - 1, uncontrolledColIndex - 1);
-              onChange && onChange(rowCount - 1, uncontrolledColIndex - 1);
-            } else {
-              setUncontrolledRowIndex(rowCount - 2);
-              setUncontrolledColIndex(uncontrolledColIndex - 1);
-              setFocus(rowCount - 2, uncontrolledColIndex - 1);
-              onChange && onChange(rowCount - 2, uncontrolledColIndex - 1);
-            }
-          }
+          [row, col] = rtl ? getCellRight() : getCellLeft();
           break;
+
         case KEYS.DOWN:
-          if (uncontrolledRowIndex < rowCount - 1 && !downEnd) {
-            setUncontrolledRowIndex(uncontrolledRowIndex + 1);
-            setFocus(uncontrolledRowIndex + 1, uncontrolledColIndex);
-            onChange && onChange(uncontrolledRowIndex + 1, uncontrolledColIndex);
-          }
-          if (wrap) {
-            if (uncontrolledColIndex < columnCount - 1 && onLastRow) {
-              setUncontrolledRowIndex(0);
-              setUncontrolledColIndex(uncontrolledColIndex + 1);
-              setFocus(0, uncontrolledColIndex + 1);
-              onChange && onChange(0, uncontrolledColIndex + 1);
-            }
-            if (
-              uncontrolledColIndex >= lastRowLength &&
-              rowCount - 1 === uncontrolledRowIndex + 1 &&
-              uncontrolledColIndex < columnCount - 1
-            ) {
-              setUncontrolledRowIndex(0);
-              setUncontrolledColIndex(uncontrolledColIndex + 1);
-              setFocus(0, uncontrolledColIndex + 1);
-              onChange && onChange(0, uncontrolledColIndex + 1);
-              break;
-            }
-          }
+          [row, col] = getCellDown();
           break;
+
+        case KEYS.UP:
+          [row, col] = getCellUp();
+          break;
+
         case KEYS.HOME:
-          if (e.ctrlKey) {
-            setFocusedCell(0, 0);
-            setFocus(0, 0);
-            onChange && onChange(0, 0);
-          } else {
-            setFocusedCell(uncontrolledRowIndex, 0);
-            setFocus(uncontrolledRowIndex, 0);
-            onChange && onChange(uncontrolledRowIndex, 0);
-          }
+          row = event.ctrlKey ? 0 : rowIndex;
+          col = 0;
           break;
+
         case KEYS.END:
-          if (e.ctrlKey) {
-            setFocusedCell(rowCount - 1, lastRowLength - 1);
-            setFocus(rowCount - 1, lastRowLength - 1);
-            onChange && onChange(rowCount - 1, lastRowLength - 1);
-          } else {
-            setFocusedCell(uncontrolledRowIndex, matrix[uncontrolledRowIndex].length - 1);
-            setFocus(uncontrolledRowIndex, matrix[uncontrolledRowIndex].length - 1);
-            onChange && onChange(uncontrolledRowIndex, matrix[uncontrolledRowIndex].length - 1);
-          }
+          row = event.ctrlKey ? rowCount - 1 : rowIndex;
+          col = event.ctrlKey ? lastRowLength - 1 : matrix[rowIndex].length - 1;
           break;
-        default:
-      }
-    }
-
-    return undefined;
-  };
-
-  const getTabIndex = (rowIdx: number, colIdx: number) => {
-    if (isControlled) {
-      if (rowIndex === -1 && colIndex === -1 && rowIdx === 0 && colIdx === 0) {
-        return 0;
       }
 
-      return rowIndex === rowIdx && colIndex === colIdx ? 0 : -1;
-    }
+      if (row !== rowIndex || col !== colIndex) {
+        const id = `${idPrefix}-${row}-${col}`;
+        const element = document.getElementById(id);
 
-    if (rowIdx <= 0 && colIdx <= 0 && uncontrolledRowIndex <= 0 && uncontrolledColIndex <= 0) {
-      return 0;
-    }
+        if (element) {
+          if (!isControlled) {
+            setUncontrolledRowIndex(row);
+            setUncontrolledColIndex(col);
+          }
 
-    return uncontrolledRowIndex === rowIdx && uncontrolledColIndex === colIdx ? 0 : -1;
+          element.focus();
+          onChange && onChange(row, col);
+        }
+      }
+    }
   };
 
   const getGridCellProps = ({
     rowIdx,
     colIdx,
     onClick,
-    onFocus,
     onKeyDown,
     ...other
-  }: IGetGridCellProps) => {
-    return {
-      tabIndex: getTabIndex(rowIdx, colIdx),
-      role: 'gridcell',
-      id: `${idPrefix}-${rowIdx}-${colIdx}`,
-      onClick: composeEventHandlers(onClick, () => {
-        if (isControlled === false) {
-          setFocusedCell(rowIdx, colIdx);
-        }
-        onChange && onChange(rowIdx, colIdx);
-      }),
-      onFocus: composeEventHandlers(onFocus, () => {
-        if (isControlled) {
-          rowIndex === -1 && colIndex === -1 && onChange && onChange(0, 0);
-        }
-      }),
-      onKeyDown: composeEventHandlers(onKeyDown, onNavigate),
-      ...other
-    };
-  };
+  }: IGetGridCellProps) => ({
+    tabIndex: rowIndex === rowIdx && colIndex === colIdx ? 0 : -1,
+    role: 'gridcell',
+    id: `${idPrefix}-${rowIdx}-${colIdx}`,
+    onClick: composeEventHandlers(onClick, () => {
+      if (!isControlled) {
+        setUncontrolledRowIndex(rowIdx);
+        setUncontrolledColIndex(colIdx);
+      }
+
+      onChange && onChange(rowIdx, colIdx);
+    }),
+    onKeyDown: composeEventHandlers(onKeyDown, handleKeyDown),
+    ...other
+  });
 
   return {
     getGridCellProps

--- a/packages/grid/src/useGrid.ts
+++ b/packages/grid/src/useGrid.ts
@@ -15,8 +15,6 @@ export interface IUseGridProps {
   rtl?: boolean;
   /** Enables wrapped keyboard navigation  */
   wrap?: boolean;
-  /** Enables cell selection */
-  selection?: boolean;
   /** Sets the two-dimension array to render the grid */
   matrix: any[][];
   /** Prefixes IDs for the grid and cells  */
@@ -25,22 +23,12 @@ export interface IUseGridProps {
   rowIndex?: number;
   /** Sets the focused column index in a controlled grid */
   colIndex?: number;
-  /** Sets the selected row index in a controlled grid */
-  selectedRowIndex?: number;
-  /** Sets the selected column index in a controlled grid */
-  selectedColIndex?: number;
   /** Sets the default focused row index in a uncontrolled grid */
   defaultRowIndex?: number;
   /** Sets the default focused column index in a uncontrolled grid */
   defaultColIndex?: number;
-  /** Sets the default selected row index in a uncontrolled grid */
-  defaultSelectedRowIndex?: number;
-  /** Sets the default selected column index in a uncontrolled grid */
-  defaultSelectedColIndex?: number;
   /** Handles grid change event */
   onChange?: (rowIndex: number, colIndex: number) => void;
-  /** Handles grid select event */
-  onSelect?: (rowIndex: number, colIndex: number) => void;
 }
 
 interface IGetGridCellProps extends HTMLProps<any> {
@@ -57,17 +45,11 @@ export function useGrid({
   wrap,
   matrix,
   idPrefix,
-  selection,
   onChange,
-  onSelect,
   rowIndex,
   colIndex,
-  selectedRowIndex,
-  selectedColIndex,
   defaultRowIndex,
-  defaultColIndex,
-  defaultSelectedRowIndex,
-  defaultSelectedColIndex
+  defaultColIndex
 }: IUseGridProps): IUseGridReturnValue {
   const rowCount = matrix.length;
   const columnCount = matrix[0].length;
@@ -78,33 +60,12 @@ export function useGrid({
   const [uncontrolledColIndex, setUncontrolledColIndex] = useState(
     defaultColIndex !== null && defaultColIndex !== undefined ? defaultColIndex : 0
   );
-  const controlledFocus =
+  const isControlled =
     rowIndex !== null && colIndex !== null && rowIndex !== undefined && colIndex !== undefined;
-  const controlledSelect =
-    selectedRowIndex !== null &&
-    selectedColIndex !== null &&
-    selectedRowIndex !== undefined &&
-    selectedColIndex !== undefined;
-  const [uncontrolledSelectedRowIndex, setUncontrolledSelectedIndex] = useState(
-    defaultSelectedRowIndex !== null && defaultSelectedRowIndex !== undefined
-      ? defaultSelectedRowIndex
-      : -1
-  );
-  const [uncontrolledSelectedColIndex, setUncontrolledSelectedColIndex] = useState(
-    defaultSelectedColIndex !== null && defaultSelectedColIndex !== undefined
-      ? defaultSelectedColIndex
-      : -1
-  );
-  const isControlled = controlledFocus || controlledSelect;
 
   const setFocusedCell = (rowIdx: number, colIdx: number) => {
     setUncontrolledRowIndex(rowIdx);
     setUncontrolledColIndex(colIdx);
-  };
-
-  const setSelectedCell = (rowIdx: number, colIdx: number) => {
-    setUncontrolledSelectedIndex(rowIdx);
-    setUncontrolledSelectedColIndex(colIdx);
   };
 
   const setFocus = (rowIdx: number, colIdx: number) => {
@@ -347,19 +308,6 @@ export function useGrid({
     return uncontrolledRowIndex === rowIdx && uncontrolledColIndex === colIdx ? 0 : -1;
   };
 
-  const getAriaSelected = (rowIdx: number, colIdx: number) => {
-    let ariaSelected;
-
-    if (isControlled) {
-      ariaSelected = selectedRowIndex === rowIdx && selectedColIndex === colIdx;
-    } else {
-      ariaSelected =
-        uncontrolledSelectedRowIndex === rowIdx && uncontrolledSelectedColIndex === colIdx;
-    }
-
-    return ariaSelected;
-  };
-
   const getGridCellProps = ({
     rowIdx,
     colIdx,
@@ -371,15 +319,12 @@ export function useGrid({
     return {
       tabIndex: getTabIndex(rowIdx, colIdx),
       role: 'gridcell',
-      'aria-selected': selection ? getAriaSelected(rowIdx, colIdx) : undefined,
       id: `${idPrefix}-${rowIdx}-${colIdx}`,
       onClick: composeEventHandlers(onClick, () => {
         if (isControlled === false) {
           setFocusedCell(rowIdx, colIdx);
-          selection && setSelectedCell(rowIdx, colIdx);
         }
         onChange && onChange(rowIdx, colIdx);
-        selection && onSelect && onSelect(rowIdx, colIdx);
       }),
       onFocus: composeEventHandlers(onFocus, () => {
         if (isControlled) {

--- a/packages/grid/src/useGrid.ts
+++ b/packages/grid/src/useGrid.ts
@@ -29,6 +29,8 @@ export interface IUseGridProps {
   defaultColIndex?: number;
   /** Handles grid change event */
   onChange?: (rowIndex: number, colIndex: number) => void;
+  /** The environment where the grid is rendered */
+  environment?: Document;
 }
 
 interface IGetGridCellProps extends HTMLProps<any> {
@@ -46,6 +48,7 @@ export function useGrid({
   matrix,
   idPrefix,
   onChange,
+  environment = document,
   rowIndex: controlledRowIndex,
   colIndex: controlledColIndex,
   defaultRowIndex,
@@ -177,17 +180,9 @@ export function useGrid({
 
       if (row !== rowIndex || col !== colIndex) {
         const id = `${idPrefix}-${row}-${col}`;
-        const element = document.getElementById(id);
+        const element = environment.getElementById(id);
 
-        if (element) {
-          if (!isControlled) {
-            setUncontrolledRowIndex(row);
-            setUncontrolledColIndex(col);
-          }
-
-          element.focus();
-          onChange && onChange(row, col);
-        }
+        element?.focus();
       }
     }
   };
@@ -195,14 +190,14 @@ export function useGrid({
   const getGridCellProps = ({
     rowIdx,
     colIdx,
-    onClick,
+    onFocus,
     onKeyDown,
     ...other
   }: IGetGridCellProps) => ({
     tabIndex: rowIndex === rowIdx && colIndex === colIdx ? 0 : -1,
     role: 'gridcell',
     id: `${idPrefix}-${rowIdx}-${colIdx}`,
-    onClick: composeEventHandlers(onClick, () => {
+    onFocus: composeEventHandlers(onFocus, () => {
       if (!isControlled) {
         setUncontrolledRowIndex(rowIdx);
         setUncontrolledColIndex(colIdx);

--- a/packages/grid/src/useGrid.ts
+++ b/packages/grid/src/useGrid.ts
@@ -6,9 +6,9 @@
  */
 
 import { useState, HTMLProps, HTMLAttributes, KeyboardEvent } from 'react';
-import { composeEventHandlers } from '@zendeskgarden/container-utilities';
+import { composeEventHandlers, KEYS } from '@zendeskgarden/container-utilities';
 
-const GRID_KEYS = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End'];
+const GRID_KEYS = [KEYS.LEFT, KEYS.RIGHT, KEYS.UP, KEYS.DOWN, KEYS.HOME, KEYS.END];
 
 export interface IUseGridProps {
   /** Determines if navigation uses right-to-left direction */
@@ -108,11 +108,11 @@ export function useGrid({
       };
 
       switch (e.key) {
-        case 'ArrowLeft':
+        case KEYS.LEFT:
           return rtl ? forward() : backward();
-        case 'ArrowRight':
+        case KEYS.RIGHT:
           return rtl ? backward() : forward();
-        case 'ArrowUp':
+        case KEYS.UP:
           if (rowIndex === 0 && colIndex === 0) {
             break;
           }
@@ -131,7 +131,7 @@ export function useGrid({
             }
           }
           break;
-        case 'ArrowDown':
+        case KEYS.DOWN:
           if ((rowIndex as number) < rowCount - 1 && !downEnd) {
             onChange && onChange((rowIndex as number) + 1, colIndex as number);
             setFocus((rowIndex as number) + 1, colIndex as number);
@@ -153,7 +153,7 @@ export function useGrid({
             }
           }
           break;
-        case 'Home':
+        case KEYS.HOME:
           if (e.ctrlKey) {
             onChange && onChange(0, 0);
             setFocus(0, 0);
@@ -162,7 +162,7 @@ export function useGrid({
             setFocus(rowIndex as number, 0);
           }
           break;
-        case 'End':
+        case KEYS.END:
           if (e.ctrlKey) {
             onChange && onChange(rowCount - 1, matrix[rowCount - 1].length - 1);
             setFocus(rowCount - 1, matrix[rowCount - 1].length - 1);
@@ -209,11 +209,11 @@ export function useGrid({
       };
 
       switch (e.key) {
-        case 'ArrowLeft':
+        case KEYS.LEFT:
           return rtl ? forward() : backward();
-        case 'ArrowRight':
+        case KEYS.RIGHT:
           return rtl ? backward() : forward();
-        case 'ArrowUp':
+        case KEYS.UP:
           if (uncontrolledRowIndex === 0 && uncontrolledColIndex === 0) {
             break;
           }
@@ -237,7 +237,7 @@ export function useGrid({
             }
           }
           break;
-        case 'ArrowDown':
+        case KEYS.DOWN:
           if (uncontrolledRowIndex < rowCount - 1 && !downEnd) {
             setUncontrolledRowIndex(uncontrolledRowIndex + 1);
             setFocus(uncontrolledRowIndex + 1, uncontrolledColIndex);
@@ -263,7 +263,7 @@ export function useGrid({
             }
           }
           break;
-        case 'Home':
+        case KEYS.HOME:
           if (e.ctrlKey) {
             setFocusedCell(0, 0);
             setFocus(0, 0);
@@ -274,7 +274,7 @@ export function useGrid({
             onChange && onChange(uncontrolledRowIndex, 0);
           }
           break;
-        case 'End':
+        case KEYS.END:
           if (e.ctrlKey) {
             setFocusedCell(rowCount - 1, lastRowLength - 1);
             setFocus(rowCount - 1, lastRowLength - 1);

--- a/packages/grid/src/useGrid.ts
+++ b/packages/grid/src/useGrid.ts
@@ -54,9 +54,6 @@ export function useGrid({
   defaultRowIndex,
   defaultColIndex
 }: IUseGridProps): IUseGridReturnValue {
-  const rowCount = matrix.length;
-  const colCount = matrix[0].length;
-  const lastRowLength = matrix[rowCount - 1].length;
   const [uncontrolledRowIndex, setUncontrolledRowIndex] = useState(
     defaultRowIndex !== null && defaultRowIndex !== undefined ? defaultRowIndex : 0
   );
@@ -70,10 +67,14 @@ export function useGrid({
     controlledColIndex !== undefined;
   const rowIndex = isControlled ? controlledRowIndex : uncontrolledRowIndex;
   const colIndex = isControlled ? controlledColIndex : uncontrolledColIndex;
+  const rowCount = matrix.length;
+  const colCount = matrix[0].length;
 
   const getCellRight = () => {
     let retVal: number[] = [];
-    const isLastCellFocused = rowIndex === rowCount - 1 && colIndex === lastRowLength - 1;
+    const lastRowIndex = rowCount - 1;
+    const lastColIndex = matrix[lastRowIndex].length - 1;
+    const isLastCellFocused = rowIndex === lastRowIndex && colIndex === lastColIndex;
 
     if (!isLastCellFocused) {
       if (colIndex === colCount - 1 /* last col is focused */) {
@@ -107,6 +108,7 @@ export function useGrid({
 
   const getCellDown = () => {
     let retVal: number[] = [];
+    const lastRowLength = matrix[rowCount - 1].length;
     const isLastCellFocused =
       rowIndex === rowCount - (colCount > lastRowLength ? 2 : 1) && colIndex === colCount - 1;
 
@@ -130,6 +132,7 @@ export function useGrid({
     if (!isFirstCellFocused) {
       if (rowIndex === 0 /* first row is focused */) {
         if (wrap) {
+          const lastRowLength = matrix[rowCount - 1].length;
           const col = colIndex - 1;
           const row = rowCount - (col >= lastRowLength ? 2 : 1);
 
@@ -172,10 +175,14 @@ export function useGrid({
           col = 0;
           break;
 
-        case KEYS.END:
-          row = event.ctrlKey ? rowCount - 1 : rowIndex;
-          col = event.ctrlKey ? lastRowLength - 1 : matrix[rowIndex].length - 1;
+        case KEYS.END: {
+          const lastRowIndex = rowCount - 1;
+          const lastColIndex = matrix[lastRowIndex].length - 1;
+
+          row = event.ctrlKey ? lastRowIndex : rowIndex;
+          col = event.ctrlKey ? lastColIndex : matrix[rowIndex].length - 1;
           break;
+        }
       }
 
       if (row !== rowIndex || col !== colIndex) {


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

The initial `useGrid` hook implementation conflated [data](https://www.w3.org/TR/wai-aria-practices/#dataGrid) vs. [layout](https://www.w3.org/TR/wai-aria-practices/#layoutGrid) by injecting a selection model that does not apply to the child DOM structure. This particular Garden grid implementation was built to facilitate a layout structure for the [`ColorSwatch` component](https://garden.zendesk.com/components/color-swatch) – which provides its own selection (i.e. not based on a `gridcell` marked as `aria-selected`) as a group of options. The container simply provides navigation primitives for the row/column layout. While there is room to enhance Garden's existing container, there are a couple of guiding quotes from WAI-ARIA that are illuminating:

> [ref: [link](https://www.w3.org/TR/wai-aria-practices/#keyboard-interaction-for-layout-grids)] It would be unusual for a layout grid to provide functions that require cell selection.

> [ref: [link](https://www.w3.org/TR/wai-aria-practices/examples/grid/LayoutGrids.html)] The distinguishing feature of `grid` that enables it to be used for grouping other widgets is that its cells are containers that preserve the semantics of their descendant elements. That is, grid cells do not override or suppress the semantics of the elements they contain.

This PR clarifies that selection is currently not interesting (and spreads awkwardly) for `useGrid` and should be removed until more complicated [data grid](https://www.w3.org/TR/wai-aria-practices/#dataGrid) implementations are in view. At that point, the spec will need to be consulted to understand the complexities of a selection model, cells with [actionable content](https://www.w3.org/TR/wai-aria-practices/#gridNav_focus), and perhaps cell [editing](https://www.w3.org/TR/wai-aria-practices/#gridNav_inside).

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
