### PR TITLE
feat(splitter): fixes focus on pointer and adds a horizontal keyboard map

### DIFF
--- a/packages/splitter/.size-snapshot.json
+++ b/packages/splitter/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 15549,
-    "minified": 8542,
-    "gzipped": 2409
+    "bundled": 15453,
+    "minified": 8483,
+    "gzipped": 2394
   },
   "index.esm.js": {
-    "bundled": 14154,
-    "minified": 7300,
-    "gzipped": 2283,
+    "bundled": 14058,
+    "minified": 7241,
+    "gzipped": 2267,
     "treeshaked": {
       "rollup": {
         "code": 1160,
         "import_statements": 101
       },
       "webpack": {
-        "code": 7284
+        "code": 7225
       }
     }
   }

--- a/packages/splitter/.size-snapshot.json
+++ b/packages/splitter/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 15453,
-    "minified": 8483,
-    "gzipped": 2394
+    "bundled": 15823,
+    "minified": 8787,
+    "gzipped": 2429
   },
   "index.esm.js": {
-    "bundled": 14058,
-    "minified": 7241,
-    "gzipped": 2267,
+    "bundled": 14412,
+    "minified": 7529,
+    "gzipped": 2307,
     "treeshaked": {
       "rollup": {
-        "code": 1160,
+        "code": 1274,
         "import_statements": 101
       },
       "webpack": {
-        "code": 7225
+        "code": 7356
       }
     }
   }

--- a/packages/splitter/src/useSplitter.ts
+++ b/packages/splitter/src/useSplitter.ts
@@ -129,6 +129,17 @@ export const verticalArrowKeys = {
   }
 };
 
+export const horizontalArrowKeys = {
+  [SplitterPosition.LEADS]: {
+    INCREASE: 'ArrowUp',
+    DECREASE: 'ArrowDown'
+  },
+  [SplitterPosition.TRAILS]: {
+    INCREASE: 'ArrowDown',
+    DECREASE: 'ArrowUp'
+  }
+};
+
 const xor = (a: boolean | undefined, b: boolean | undefined) => {
   if (a && b) {
     return false;
@@ -359,11 +370,11 @@ export function useSplitter({
       }
     } else {
       switch (event.key) {
-        case 'ArrowUp':
+        case horizontalArrowKeys[position].DECREASE:
           type === SplitterType.VARIABLE &&
             setRangedSeparatorPosition(separatorPosition - keyboardStep);
           break;
-        case 'ArrowDown':
+        case horizontalArrowKeys[position].INCREASE:
           type === SplitterType.VARIABLE &&
             setRangedSeparatorPosition(separatorPosition + keyboardStep);
           break;

--- a/packages/splitter/src/useSplitter.ts
+++ b/packages/splitter/src/useSplitter.ts
@@ -200,7 +200,6 @@ export function useSplitter({
 
   const onSplitterMouseMove = useCallback(
     (event: MouseEvent) => {
-      event.preventDefault();
       const elem = separatorRef.current;
       const clientWidth = xor(rtl, position === SplitterPosition.LEADS)
         ? environment.document.body.clientWidth
@@ -279,8 +278,7 @@ export function useSplitter({
 
   const onMouseLeaveOrUp = useMemo(
     () =>
-      composeEventHandlers(props.onMouseUp, props.onMouseLeave, (event: MouseEvent) => {
-        event.preventDefault();
+      composeEventHandlers(props.onMouseUp, props.onMouseLeave, () => {
         // must remove global events on transaction finish
         environment.document.removeEventListener('mouseup', onMouseLeaveOrUp);
         environment.document.body.removeEventListener('mouseleave', onMouseLeaveOrUp);
@@ -299,8 +297,7 @@ export function useSplitter({
     [environment, props.onTouchEnd, onTouchMove]
   );
 
-  const onMouseDown = composeEventHandlers(props.onMouseDown, (event: React.MouseEvent) => {
-    event.preventDefault();
+  const onMouseDown = composeEventHandlers(props.onMouseDown, () => {
     if (type === SplitterType.FIXED) {
       if (separatorPosition > min) {
         setSeparatorPosition(min);


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(selection):
     add keydown event to handle rtl". the title informs the semantic
     version bump if this PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Fixes bugs prior to merge of https://github.com/zendeskgarden/react-components/pull/1339

## Detail

Fixes the following scenarios:
- After mouse down, the separator is not focused and keys do not move separator
- On position leads, the keyboard up would move separator down and keyboard down would move separator up

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [ ] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
