### PR TITLE
fix(splitter)!: refactor with improved type interfaces

### DIFF
--- a/packages/splitter/.size-snapshot.json
+++ b/packages/splitter/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 15835,
-    "minified": 8810,
-    "gzipped": 2429
+    "bundled": 11483,
+    "minified": 5251,
+    "gzipped": 1937
   },
   "index.esm.js": {
-    "bundled": 14424,
-    "minified": 7552,
-    "gzipped": 2311,
+    "bundled": 10594,
+    "minified": 4484,
+    "gzipped": 1834,
     "treeshaked": {
       "rollup": {
-        "code": 1274,
-        "import_statements": 101
+        "code": 259,
+        "import_statements": 83
       },
       "webpack": {
-        "code": 7379
+        "code": 5117
       }
     }
   }

--- a/packages/splitter/.size-snapshot.json
+++ b/packages/splitter/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 11483,
-    "minified": 5251,
-    "gzipped": 1937
+    "bundled": 11757,
+    "minified": 5316,
+    "gzipped": 1975
   },
   "index.esm.js": {
-    "bundled": 10594,
-    "minified": 4484,
-    "gzipped": 1834,
+    "bundled": 10867,
+    "minified": 4547,
+    "gzipped": 1870,
     "treeshaked": {
       "rollup": {
         "code": 259,
         "import_statements": 83
       },
       "webpack": {
-        "code": 5117
+        "code": 5190
       }
     }
   }

--- a/packages/splitter/demo/splitter.stories.mdx
+++ b/packages/splitter/demo/splitter.stories.mdx
@@ -1,11 +1,6 @@
 import { Meta, ArgsTable, Canvas, Story } from '@storybook/addon-docs';
 import { useArgs } from '@storybook/client-api';
-import {
-  SplitterContainer,
-  SplitterOrientation,
-  SplitterPosition,
-  SplitterType
-} from '@zendeskgarden/container-splitter';
+import { SplitterContainer } from '@zendeskgarden/container-splitter';
 import { SplitterStory } from './stories/SplitterStory';
 
 <Meta
@@ -15,13 +10,11 @@ import { SplitterStory } from './stories/SplitterStory';
     as: 'hook',
     max: 700,
     min: 200,
-    orientation: SplitterOrientation.VERTICAL,
-    position: SplitterPosition.TRAILS,
-    type: SplitterType.VARIABLE
+    orientation: 'vertical'
   }}
   argTypes={{
     as: { options: ['container', 'hook'], control: 'radio', table: { category: 'Story' } },
-    environment: { control: false }
+    splitterRef: { control: false }
   }}
   parameters={{ layout: 'padded' }}
 />
@@ -36,20 +29,7 @@ import { SplitterStory } from './stories/SplitterStory';
 
 <Canvas>
   <Story name="Uncontrolled" argTypes={{ valueNow: { control: false } }}>
-    {({
-      orientation = SplitterOrientation.VERTICAL,
-      position = SplitterPosition.TRAILS,
-      type = SplitterType.VARIABLE,
-      ...args
-    }) => (
-      <SplitterStory
-        orientation={orientation}
-        position={position}
-        type={type}
-        {...args}
-        environment={window}
-      />
-    )}
+    {args => <SplitterStory {...args} />}
   </Story>
 </Canvas>
 
@@ -61,24 +41,10 @@ import { SplitterStory } from './stories/SplitterStory';
     args={{ valueNow: 200 }}
     argTypes={{ defaultValueNow: { control: false } }}
   >
-    {({
-      orientation = SplitterOrientation.VERTICAL,
-      position = SplitterPosition.TRAILS,
-      type = SplitterType.VARIABLE,
-      ...args
-    }) => {
+    {({ ...args }) => {
       const updateArgs = useArgs()[1];
       const handleChange = valueNow => updateArgs({ valueNow });
-      return (
-        <SplitterStory
-          orientation={orientation}
-          position={position}
-          type={type}
-          {...args}
-          environment={window}
-          onChange={handleChange}
-        />
-      );
+      return <SplitterStory {...args} onChange={handleChange} />;
     }}
   </Story>
 </Canvas>

--- a/packages/splitter/package.json
+++ b/packages/splitter/package.json
@@ -21,8 +21,7 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@babel/runtime": "^7.8.4",
-    "@zendeskgarden/container-utilities": "^1.0.0",
-    "react-uid": "^2.2.0"
+    "@zendeskgarden/container-utilities": "^1.0.0"
   },
   "peerDependencies": {
     "prop-types": "^15.6.1",

--- a/packages/splitter/src/SplitterContainer.tsx
+++ b/packages/splitter/src/SplitterContainer.tsx
@@ -20,7 +20,7 @@ SplitterContainer.propTypes = {
   children: PropTypes.func,
   render: PropTypes.func,
   idPrefix: PropTypes.string,
-  environment: PropTypes.any.isRequired,
+  environment: PropTypes.any,
   isFixed: PropTypes.bool,
   min: PropTypes.number.isRequired,
   max: PropTypes.number.isRequired,

--- a/packages/splitter/src/SplitterContainer.tsx
+++ b/packages/splitter/src/SplitterContainer.tsx
@@ -7,65 +7,34 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  useSplitter,
-  IUseSplitterProps,
-  IUseSplitterReturnValue,
-  SplitterOrientation,
-  SplitterType,
-  SplitterPosition,
-  KEYBOARD_STEP
-} from './useSplitter';
+import { useSplitter, KEYBOARD_STEP } from './useSplitter';
+import { ISplitterContainerProps } from './types';
 
-export interface ISplitterContainerProps extends IUseSplitterProps {
-  /** Documents the render function */
-  render?: (options: IUseSplitterReturnValue) => React.ReactNode;
-  /** Documents the children prop */
-  children?: (options: IUseSplitterReturnValue) => React.ReactNode;
-}
-
-export const SplitterContainer: React.FC<ISplitterContainerProps> = props => {
-  const { children, render = children, ...options } = props;
-
-  return <>{render!(useSplitter(options)) as React.ReactElement}</>;
-};
+export const SplitterContainer: React.FC<ISplitterContainerProps> = ({
+  children,
+  render = children,
+  ...options
+}) => <>{render!(useSplitter(options))}</>;
 
 SplitterContainer.propTypes = {
-  idPrefix: PropTypes.string,
-  ariaLabel: PropTypes.string,
   children: PropTypes.func,
   render: PropTypes.func,
-  environment: PropTypes.oneOfType([
-    PropTypes.shape({
-      scrollX: PropTypes.number.isRequired,
-      scrollY: PropTypes.number.isRequired,
-      document: PropTypes.oneOfType([
-        PropTypes.shape({
-          addEventListener: PropTypes.func.isRequired,
-          removeEventListener: PropTypes.func.isRequired,
-          body: PropTypes.shape({
-            clientWidth: PropTypes.number.isRequired,
-            clientHeight: PropTypes.number.isRequired,
-            addEventListener: PropTypes.func.isRequired,
-            removeEventListener: PropTypes.func.isRequired
-          }).isRequired
-        })
-      ]).isRequired
-    })
-  ]).isRequired,
-  orientation: PropTypes.oneOf([SplitterOrientation.VERTICAL, SplitterOrientation.HORIZONTAL])
-    .isRequired,
-  keyboardStep: PropTypes.number,
-  type: PropTypes.oneOf([SplitterType.FIXED, SplitterType.VARIABLE]).isRequired,
+  idPrefix: PropTypes.string,
+  environment: PropTypes.any.isRequired,
+  isFixed: PropTypes.bool,
   min: PropTypes.number.isRequired,
   max: PropTypes.number.isRequired,
+  orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+  keyboardStep: PropTypes.number,
   defaultValueNow: PropTypes.number,
   valueNow: PropTypes.number,
   onChange: PropTypes.func,
-  position: PropTypes.oneOf([SplitterPosition.LEADS, SplitterPosition.TRAILS]).isRequired,
+  separatorRef: PropTypes.any.isRequired,
+  isLeading: PropTypes.bool,
   rtl: PropTypes.bool
 };
 
 SplitterContainer.defaultProps = {
-  keyboardStep: KEYBOARD_STEP
+  keyboardStep: KEYBOARD_STEP,
+  orientation: 'vertical'
 };

--- a/packages/splitter/src/index.ts
+++ b/packages/splitter/src/index.ts
@@ -6,10 +6,9 @@
  */
 
 /* Hooks */
-export { useSplitter, SplitterOrientation, SplitterType, SplitterPosition } from './useSplitter';
-
-export type { IUseSplitterProps, IUseSplitterReturnValue } from './useSplitter';
+export { useSplitter } from './useSplitter';
 
 /* Render-props */
 export { SplitterContainer } from './SplitterContainer';
-export type { ISplitterContainerProps } from './SplitterContainer';
+
+export type { IUseSplitterProps, IUseSplitterReturnValue, ISplitterContainerProps } from './types';

--- a/packages/splitter/src/types.ts
+++ b/packages/splitter/src/types.ts
@@ -11,7 +11,7 @@ export interface IUseSplitterProps<T = HTMLElement> {
   /** Prefixes IDs for the splitter */
   idPrefix?: string;
   /** Sets the window environment to attach events to */
-  environment: Document;
+  environment?: Document;
   /** Determines whether a splitter behaves in fixed or variable mode */
   isFixed?: boolean;
   /** Indicates whether the splitter leads or trails the primary pane */

--- a/packages/splitter/src/types.ts
+++ b/packages/splitter/src/types.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { HTMLProps, ReactNode, RefObject } from 'react';
+
+export interface IUseSplitterProps<T = HTMLElement> {
+  /** Prefixes IDs for the splitter */
+  idPrefix?: string;
+  /** Sets the window environment to attach events to */
+  environment: Document;
+  /** Determines whether a splitter behaves in fixed or variable mode */
+  isFixed?: boolean;
+  /** Indicates whether the splitter leads or trails the primary pane */
+  isLeading?: boolean;
+  /** Determines right-to-left layout */
+  rtl?: boolean;
+  /** Determines the orientation of the splitter */
+  orientation?: 'horizontal' | 'vertical';
+  /** Specifies the position increment for keyboard interaction */
+  keyboardStep?: number;
+  /** Specifies the minimum permitted splitter position */
+  min: number;
+  /** Specifies the maximum permitted splitter position */
+  max: number;
+  /** Determines the starting position for an uncontrolled splitter */
+  defaultValueNow?: number;
+  /** Determines current position of a controlled splitter */
+  valueNow?: number;
+  /**
+   * Handles splitter position changes
+   *
+   * @param valueNow The updated position
+   */
+  onChange?: (valueNow: number) => void;
+  /** Provides ref access to the underlying separator element */
+  separatorRef: RefObject<T>;
+}
+
+export interface IUseSplitterReturnValue {
+  getSeparatorProps: <T extends Element>(
+    props: Omit<HTMLProps<T>, 'role' | 'aria-label'> & {
+      role?: 'separator' | null;
+      'aria-label': NonNullable<HTMLProps<T>['aria-label']>;
+    }
+  ) => HTMLProps<T>;
+  getPrimaryPaneProps: <T extends Element>(props?: HTMLProps<T>) => HTMLProps<T>;
+  valueNow: number;
+}
+
+export interface ISplitterContainerProps<T = HTMLElement> extends IUseSplitterProps<T> {
+  /**
+   * Provides splitter render prop functions
+   *
+   * @param {function} [options.getSeparatorProps] Separator props getter
+   * @param {function} [options.getPrimaryPaneProps] Primary pane props getter
+   * @param {number} [options.valueNow] Current splitter position value
+   */
+  render?: (options: {
+    getSeparatorProps: IUseSplitterReturnValue['getSeparatorProps'];
+    getPrimaryPaneProps: IUseSplitterReturnValue['getPrimaryPaneProps'];
+    valueNow: IUseSplitterReturnValue['valueNow'];
+  }) => ReactNode;
+  /** @ignore */
+  children?: (options: IUseSplitterReturnValue) => ReactNode;
+}

--- a/packages/splitter/src/useSplitter.ts
+++ b/packages/splitter/src/useSplitter.ts
@@ -84,26 +84,37 @@ export const useSplitter = <T extends HTMLElement = HTMLElement>({
 
   const move = useCallback(
     (pageX: number, pageY: number) => {
-      const elem = separatorRef.current;
-      const clientWidth = xor(rtl, isLeading) ? doc.body.clientWidth : undefined;
-      const clientHeight = isLeading ? doc.body.clientHeight : undefined;
+      if (separatorRef.current) {
+        const clientWidth = xor(rtl, isLeading) ? doc.body.clientWidth : undefined;
+        const clientHeight = isLeading ? doc.body.clientHeight : undefined;
 
-      if (orientation === 'horizontal') {
-        const offset = isLeading ? offsetRef.current.bottom : offsetRef.current.top;
+        if (orientation === 'horizontal') {
+          const offset = isLeading ? offsetRef.current.bottom : offsetRef.current.top;
 
-        // normalizePointerToSeparator aligns pointer true pixel coordinates and to the separator accounting for relative DOM positioning
-        setRangedSeparatorPosition(
-          // event.pageY is in pixel values
-          normalizePointerToSeparator(offset, pageY, elem?.offsetHeight, clientHeight)
-        );
-      } else {
-        const offset = xor(rtl, isLeading) ? offsetRef.current.right : offsetRef.current.left;
+          // normalizePointerToSeparator aligns pointer true pixel coordinates and to the separator accounting for relative DOM positioning
+          setRangedSeparatorPosition(
+            // event.pageY is in pixel values
+            normalizePointerToSeparator(
+              offset,
+              pageY,
+              separatorRef.current.offsetHeight,
+              clientHeight
+            )
+          );
+        } else {
+          const offset = xor(rtl, isLeading) ? offsetRef.current.right : offsetRef.current.left;
 
-        // normalizePointerToSeparator aligns pointer true pixel coordinates and to the separator accounting for relative DOM positioning
-        setRangedSeparatorPosition(
-          // event.pageX is in pixel values
-          normalizePointerToSeparator(offset, pageX, elem?.offsetWidth, clientWidth)
-        );
+          // normalizePointerToSeparator aligns pointer true pixel coordinates and to the separator accounting for relative DOM positioning
+          setRangedSeparatorPosition(
+            // event.pageX is in pixel values
+            normalizePointerToSeparator(
+              offset,
+              pageX,
+              separatorRef.current.offsetWidth,
+              clientWidth
+            )
+          );
+        }
       }
     },
     [doc, isLeading, orientation, rtl, separatorRef, setRangedSeparatorPosition]
@@ -136,19 +147,21 @@ export const useSplitter = <T extends HTMLElement = HTMLElement>({
       // derive the distances between viewport to the outer edges of the separator position, offset by scroll
       // see https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect
       const updateOffsets = () => {
-        const rect = separatorRef.current!.getBoundingClientRect();
-        const clientWidth = doc.body.clientWidth;
-        const clientHeight = doc.body.clientHeight;
-        const win = doc.documentElement || document.body.parentNode || document.body;
+        if (separatorRef.current) {
+          const rect = separatorRef.current.getBoundingClientRect();
+          const clientWidth = doc.body.clientWidth;
+          const clientHeight = doc.body.clientHeight;
+          const win = doc.documentElement || doc.body.parentNode || doc.body;
 
-        // capture distance from left side of viewport to the separator position offset by horizontal scroll
-        offsetRef.current.left = rect.left - separatorPosition + win.scrollLeft;
-        // capture distance from right side of viewport to the separator position offset by horizontal scroll
-        offsetRef.current.right = clientWidth - rect.right - separatorPosition - win.scrollLeft;
-        // capture distance from top side of viewport to the separator position offset by vertical scroll
-        offsetRef.current.top = rect.top - separatorPosition + win.scrollTop;
-        // capture distance from bottom side of viewport to the separator position offset by vertical scroll
-        offsetRef.current.bottom = clientHeight - rect.bottom - separatorPosition - win.scrollTop;
+          // capture distance from left side of viewport to the separator position offset by horizontal scroll
+          offsetRef.current.left = rect.left - separatorPosition + win.scrollLeft;
+          // capture distance from right side of viewport to the separator position offset by horizontal scroll
+          offsetRef.current.right = clientWidth - rect.right - separatorPosition - win.scrollLeft;
+          // capture distance from top side of viewport to the separator position offset by vertical scroll
+          offsetRef.current.top = rect.top - separatorPosition + win.scrollTop;
+          // capture distance from bottom side of viewport to the separator position offset by vertical scroll
+          offsetRef.current.bottom = clientHeight - rect.bottom - separatorPosition - win.scrollTop;
+        }
       };
 
       const handleMouseDown = () => {

--- a/packages/splitter/yarn.lock
+++ b/packages/splitter/yarn.lock
@@ -9,19 +9,41 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-react-uid@^2.2.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/react-uid/-/react-uid-2.3.1.tgz#22a75d4a948a4824b9b8078cbf864d55d91ca4be"
-  integrity sha512-6C5pwNYP1udgp5feQ9MTBZBKD4su9nhD2aYCFY1bB0Bpask8wYKYz0ZhAtAJ4lcmTDC5kY1ByGTQMFDHQW6p0w==
+"@reach/auto-id@^0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.17.0.tgz#60cce65eb7a0d6de605820727f00dfe2b03b5f17"
+  integrity sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==
   dependencies:
-    tslib "^1.10.0"
+    "@reach/utils" "0.17.0"
+    tslib "^2.3.0"
+
+"@reach/utils@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.17.0.tgz#3d1d2ec56d857f04fe092710d8faee2b2b121303"
+  integrity sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==
+  dependencies:
+    tiny-warning "^1.0.3"
+    tslib "^2.3.0"
+
+"@zendeskgarden/container-utilities@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-1.0.0.tgz#135e4616613189ad31038413a93b4a2dddfe6416"
+  integrity sha512-4TsmPMGlSLslDuC0Xi/7ckQfkQyOceQtPHFWMhaP7QFAvjQgw5v/Eas6QN7okBTiUR6fmyK1PPrCUM6vOVeCEw==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@reach/auto-id" "^0.17.0"
 
 regenerator-runtime@^0.13.4:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
 
-tslib@^1.10.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+tiny-warning@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
+tslib@^2.3.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==

--- a/packages/splitter/yarn.lock
+++ b/packages/splitter/yarn.lock
@@ -9,41 +9,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@reach/auto-id@^0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.17.0.tgz#60cce65eb7a0d6de605820727f00dfe2b03b5f17"
-  integrity sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==
-  dependencies:
-    "@reach/utils" "0.17.0"
-    tslib "^2.3.0"
-
-"@reach/utils@0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.17.0.tgz#3d1d2ec56d857f04fe092710d8faee2b2b121303"
-  integrity sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==
-  dependencies:
-    tiny-warning "^1.0.3"
-    tslib "^2.3.0"
-
-"@zendeskgarden/container-utilities@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-1.0.0.tgz#135e4616613189ad31038413a93b4a2dddfe6416"
-  integrity sha512-4TsmPMGlSLslDuC0Xi/7ckQfkQyOceQtPHFWMhaP7QFAvjQgw5v/Eas6QN7okBTiUR6fmyK1PPrCUM6vOVeCEw==
-  dependencies:
-    "@babel/runtime" "^7.8.4"
-    "@reach/auto-id" "^0.17.0"
-
 regenerator-runtime@^0.13.4:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
-
-tiny-warning@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
-  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
-
-tslib@^2.3.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
-  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

This PR is a follow-on to #461 with a refactored `useSplitter` codebase and simplification (note the reduced size) of the API. The following are key elements of change:

- [breaking] make `aria-label` a required attribute of `getSeparatorProps` (will fix the missing label in `react-components`)
- [breaking] use standard `isLeading` & `isFixed` boolean types rather than `position` and `type` enums
- [breaking] shift `environment` to be optional and work off `document` rather than `window` context for API consistency
- [breaking] added `separatorRef` as a required prop. This aligns the API with other Garden containers and eliminates an awkward ownership problem where the previous returned `ref` had to merge and spread in the right order. The consumer should own element ref assignments.
- [breaking] remove `SplitterOrientation`, `SplitterType`, and `SplitterPosition` enum exports
- [breaking] `useSplitter` no longer receives arbitrary HTML prop spread. This is inconsistent with other containers and yields arbitrary results as `composeEventHandlers` was being incorrectly applied to document- (not component-) level events.
- [fix] splitter drag continues to work even if the mouse leaves the page
- [fix] enhanced API readability in Storybook
- overall major simplification of `useSplitter` code with targeted memoization for callbacks that are compute intensive

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [x] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
