### PR TITLE
feat(field): add getMessageProps prop getter to container

### DIFF
--- a/packages/field/.size-snapshot.json
+++ b/packages/field/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 3794,
-    "minified": 1986,
-    "gzipped": 856
+    "bundled": 4452,
+    "minified": 2237,
+    "gzipped": 930
   },
   "index.esm.js": {
-    "bundled": 3324,
-    "minified": 1607,
-    "gzipped": 747,
+    "bundled": 3982,
+    "minified": 1858,
+    "gzipped": 821,
     "treeshaked": {
       "rollup": {
         "code": 81,
         "import_statements": 58
       },
       "webpack": {
-        "code": 2344
+        "code": 2544
       }
     }
   }

--- a/packages/field/.size-snapshot.json
+++ b/packages/field/.size-snapshot.json
@@ -19,13 +19,13 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 4452,
-    "minified": 2237,
+    "bundled": 4417,
+    "minified": 2232,
     "gzipped": 930
   },
   "index.esm.js": {
-    "bundled": 3982,
-    "minified": 1858,
+    "bundled": 3947,
+    "minified": 1853,
     "gzipped": 821,
     "treeshaked": {
       "rollup": {
@@ -33,7 +33,7 @@
         "import_statements": 58
       },
       "webpack": {
-        "code": 2544
+        "code": 2539
       }
     }
   }

--- a/packages/field/README.md
+++ b/packages/field/README.md
@@ -18,7 +18,8 @@ Check out [storybook](https://zendeskgarden.github.io/react-containers) for live
 examples.
 
 The `useField` hook will supply the prop getters to handle `aria-labelledby` along
-with for/id mapping and `aria-describedby` mapping when a hint is applied.
+with for/id mapping and `aria-describedby` mapping when a hint and/or status message
+is applied.
 
 ### useField
 
@@ -26,13 +27,14 @@ with for/id mapping and `aria-describedby` mapping when a hint is applied.
 import { useField } from '@zendeskgarden/container-field';
 
 const Field = () => {
-  const { getLabelProps, getInputProps, getHintProps } = useField();
+  const { getLabelProps, getInputProps, getHintProps, getMessageProps } = useField();
 
   return (
     <>
       <label {...getLabelProps()}>Accessible Native Input</label>
       <p {...getHintProps()}>Optional Hint</p>
       <input {...getInputProps()} />
+      <p {...getMessageProps()}>Optional Status Message</p>
     </>
   );
 };
@@ -46,11 +48,12 @@ FieldContainer is a render-prop wrapper for the `useField` hook.
 import { FieldContainer } from '@zendeskgarden/container-field';
 
 <FieldContainer>
-  {({ getLabelProps, getInputProps, getHintProps }) => (
+  {({ getLabelProps, getInputProps, getHintProps, getMessageProps }) => (
     <>
       <label {...getLabelProps()}>Accessible Native Input</label>
       <p {...getHintProps()}>Optional Hint</p>
       <input {...getInputProps()} />
+      <p {...getMessageProps()}>Optional Status Message</p>
     </>
   )}
 </FieldContainer>;

--- a/packages/field/demo/field.stories.mdx
+++ b/packages/field/demo/field.stories.mdx
@@ -13,7 +13,7 @@ import { FieldStory } from './stories/FieldStory';
 <Canvas>
   <Story
     name="Field"
-    args={{ as: 'hook', isDescribed: true, hasMessage: false }}
+    args={{ as: 'hook', isDescribed: true, hasMessage: true }}
     argTypes={{
       as: { options: ['container', 'hook'], control: 'radio', table: { category: 'Story' } },
       isDescribed: { table: { category: 'Story' } },

--- a/packages/field/demo/field.stories.mdx
+++ b/packages/field/demo/field.stories.mdx
@@ -13,11 +13,11 @@ import { FieldStory } from './stories/FieldStory';
 <Canvas>
   <Story
     name="Field"
-    args={{ as: 'hook', isDescribed: true, containsMessage: false }}
+    args={{ as: 'hook', isDescribed: true, hasMessage: false }}
     argTypes={{
       as: { options: ['container', 'hook'], control: 'radio', table: { category: 'Story' } },
       isDescribed: { table: { category: 'Story' } },
-      containsMessage: { table: { category: 'Story' } }
+      hasMessage: { table: { category: 'Story' } }
     }}
   >
     {args => <FieldStory {...args} />}

--- a/packages/field/demo/field.stories.mdx
+++ b/packages/field/demo/field.stories.mdx
@@ -13,10 +13,11 @@ import { FieldStory } from './stories/FieldStory';
 <Canvas>
   <Story
     name="Field"
-    args={{ as: 'hook', isDescribed: true }}
+    args={{ as: 'hook', isDescribed: true, containsMessage: false }}
     argTypes={{
       as: { options: ['container', 'hook'], control: 'radio', table: { category: 'Story' } },
-      isDescribed: { table: { category: 'Story' } }
+      isDescribed: { table: { category: 'Story' } },
+      containsMessage: { table: { category: 'Story' } }
     }}
   >
     {args => <FieldStory {...args} />}

--- a/packages/field/demo/stories/FieldStory.tsx
+++ b/packages/field/demo/stories/FieldStory.tsx
@@ -32,7 +32,11 @@ const Component = ({
     <label {...getLabelProps()}>Label</label>
     {isDescribed && <div {...getHintProps()}>Hint</div>}
     <input {...getInputProps({}, { isDescribed, hasMessage })} />
-    {hasMessage && <div {...getMessageProps()}>Message</div>}
+    {hasMessage && (
+      <div role="alert" {...getMessageProps()}>
+        Message
+      </div>
+    )}
   </>
 );
 

--- a/packages/field/demo/stories/FieldStory.tsx
+++ b/packages/field/demo/stories/FieldStory.tsx
@@ -16,42 +16,50 @@ import {
 
 interface IComponentProps extends IUseFieldPropGetters {
   isDescribed: boolean;
+  containsMessage: boolean;
 }
 
 const Component = ({
   getLabelProps,
   getHintProps,
   getInputProps,
-  isDescribed
+  getMessageProps,
+  isDescribed,
+  containsMessage
 }: IComponentProps) => (
   /* eslint-disable jsx-a11y/label-has-associated-control */
   <>
     <label {...getLabelProps()}>Label</label>
     {isDescribed && <div {...getHintProps()}>Hint</div>}
-    <input {...getInputProps({}, { isDescribed })} />
+    <input {...getInputProps({}, { isDescribed, containsMessage })} />
+    {containsMessage && <div {...getMessageProps()}>Message</div>}
   </>
 );
 
 interface IProps {
   id?: NonNullable<IFieldContainerProps['id']>;
   isDescribed: boolean;
+  containsMessage: boolean;
 }
 
-const Container = ({ id, isDescribed }: IProps) => (
+const Container = ({ id, isDescribed, containsMessage }: IProps) => (
   <FieldContainer id={id}>
-    {containerProps => <Component isDescribed={isDescribed} {...containerProps} />}
+    {containerProps => (
+      <Component isDescribed={isDescribed} containsMessage={containsMessage} {...containerProps} />
+    )}
   </FieldContainer>
 );
 
-const Hook = ({ id, isDescribed }: IProps) => {
+const Hook = ({ id, isDescribed, containsMessage }: IProps) => {
   const hookProps = useField(id);
 
-  return <Component isDescribed={isDescribed} {...hookProps} />;
+  return <Component isDescribed={isDescribed} containsMessage={containsMessage} {...hookProps} />;
 };
 
 interface IArgs extends IFieldContainerProps {
   as: 'hook' | 'container';
   isDescribed: boolean;
+  containsMessage: boolean;
 }
 
 export const FieldStory: Story<IArgs> = ({ as, ...props }) => {

--- a/packages/field/demo/stories/FieldStory.tsx
+++ b/packages/field/demo/stories/FieldStory.tsx
@@ -16,7 +16,7 @@ import {
 
 interface IComponentProps extends IUseFieldPropGetters {
   isDescribed: boolean;
-  containsMessage: boolean;
+  hasMessage: boolean;
 }
 
 const Component = ({
@@ -25,41 +25,41 @@ const Component = ({
   getInputProps,
   getMessageProps,
   isDescribed,
-  containsMessage
+  hasMessage
 }: IComponentProps) => (
   /* eslint-disable jsx-a11y/label-has-associated-control */
   <>
     <label {...getLabelProps()}>Label</label>
     {isDescribed && <div {...getHintProps()}>Hint</div>}
-    <input {...getInputProps({}, { isDescribed, containsMessage })} />
-    {containsMessage && <div {...getMessageProps()}>Message</div>}
+    <input {...getInputProps({}, { isDescribed, hasMessage })} />
+    {hasMessage && <div {...getMessageProps()}>Message</div>}
   </>
 );
 
 interface IProps {
   id?: NonNullable<IFieldContainerProps['id']>;
   isDescribed: boolean;
-  containsMessage: boolean;
+  hasMessage: boolean;
 }
 
-const Container = ({ id, isDescribed, containsMessage }: IProps) => (
+const Container = ({ id, isDescribed, hasMessage }: IProps) => (
   <FieldContainer id={id}>
     {containerProps => (
-      <Component isDescribed={isDescribed} containsMessage={containsMessage} {...containerProps} />
+      <Component isDescribed={isDescribed} hasMessage={hasMessage} {...containerProps} />
     )}
   </FieldContainer>
 );
 
-const Hook = ({ id, isDescribed, containsMessage }: IProps) => {
+const Hook = ({ id, isDescribed, hasMessage }: IProps) => {
   const hookProps = useField(id);
 
-  return <Component isDescribed={isDescribed} containsMessage={containsMessage} {...hookProps} />;
+  return <Component isDescribed={isDescribed} hasMessage={hasMessage} {...hookProps} />;
 };
 
 interface IArgs extends IFieldContainerProps {
   as: 'hook' | 'container';
   isDescribed: boolean;
-  containsMessage: boolean;
+  hasMessage: boolean;
 }
 
 export const FieldStory: Story<IArgs> = ({ as, ...props }) => {

--- a/packages/field/src/FieldContainer.spec.tsx
+++ b/packages/field/src/FieldContainer.spec.tsx
@@ -49,15 +49,13 @@ describe('FieldContainer', () => {
     it.each([
       ['options', true, true],
       ['isDescribed', true, false],
-      ['containsMessage', false, true]
-    ])(`includes aria-describedby if %s is provided`, (_, isDescribed, containsMessage) => {
+      ['hasMessage', false, true]
+    ])(`includes aria-describedby if %s is provided`, (_, isDescribed, hasMessage) => {
       const { getByTestId } = render(
         <FieldContainer id={CONTAINER_ID}>
           {({ getInputProps }) => (
             <div>
-              <input
-                {...getInputProps({ 'data-test-id': 'input' }, { isDescribed, containsMessage })}
-              />
+              <input {...getInputProps({ 'data-test-id': 'input' }, { isDescribed, hasMessage })} />
             </div>
           )}
         </FieldContainer>
@@ -65,10 +63,7 @@ describe('FieldContainer', () => {
 
       expect(getByTestId('input')).toHaveAttribute(
         'aria-describedby',
-        [
-          isDescribed ? `${CONTAINER_ID}--hint` : '',
-          containsMessage ? `${CONTAINER_ID}--message` : ''
-        ]
+        [isDescribed ? `${CONTAINER_ID}--hint` : '', hasMessage ? `${CONTAINER_ID}--message` : '']
           .join(' ')
           .trim()
       );

--- a/packages/field/src/FieldContainer.spec.tsx
+++ b/packages/field/src/FieldContainer.spec.tsx
@@ -15,11 +15,12 @@ describe('FieldContainer', () => {
 
   const BasicExample = () => (
     <FieldContainer id={CONTAINER_ID}>
-      {({ getLabelProps, getInputProps, getHintProps }) => (
+      {({ getLabelProps, getInputProps, getHintProps, getMessageProps }) => (
         <div>
           <label {...getLabelProps({ 'data-test-id': 'label' })}>Label</label>
           <div {...getHintProps({ 'data-test-id': 'hint' })}>Hint</div>
           <input {...getInputProps({ 'data-test-id': 'input' })} />
+          <div {...getMessageProps({ 'data-test-id': 'message' })}>Message</div>
         </div>
       )}
     </FieldContainer>
@@ -45,18 +46,32 @@ describe('FieldContainer', () => {
       expect(input).not.toHaveAttribute('aria-describedby');
     });
 
-    it('includes aria-describedby if option is provided', () => {
+    it.each([
+      ['options', true, true],
+      ['isDescribed', true, false],
+      ['containsMessage', false, true]
+    ])(`includes aria-describedby if %s is provided`, (_, isDescribed, containsMessage) => {
       const { getByTestId } = render(
         <FieldContainer id={CONTAINER_ID}>
           {({ getInputProps }) => (
             <div>
-              <input {...getInputProps({ 'data-test-id': 'input' }, { isDescribed: true })} />
+              <input
+                {...getInputProps({ 'data-test-id': 'input' }, { isDescribed, containsMessage })}
+              />
             </div>
           )}
         </FieldContainer>
       );
 
-      expect(getByTestId('input')).toHaveAttribute('aria-describedby', `${CONTAINER_ID}--hint`);
+      expect(getByTestId('input')).toHaveAttribute(
+        'aria-describedby',
+        [
+          isDescribed ? `${CONTAINER_ID}--hint` : '',
+          containsMessage ? `${CONTAINER_ID}--message` : ''
+        ]
+          .join(' ')
+          .trim()
+      );
     });
   });
 
@@ -65,6 +80,14 @@ describe('FieldContainer', () => {
       const { getByTestId } = render(<BasicExample />);
 
       expect(getByTestId('hint')).toHaveAttribute('id', `${CONTAINER_ID}--hint`);
+    });
+  });
+
+  describe('getMessageProps', () => {
+    it('applies correct accessibility role', () => {
+      const { getByTestId } = render(<BasicExample />);
+
+      expect(getByTestId('message')).toHaveAttribute('id', `${CONTAINER_ID}--message`);
     });
   });
 });

--- a/packages/field/src/FieldContainer.tsx
+++ b/packages/field/src/FieldContainer.tsx
@@ -8,16 +8,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { useField, IUseFieldPropGetters } from './useField';
-
-export interface IFieldContainerProps {
-  /** A render prop function which receives field prop getters */
-  render?: (options: IUseFieldPropGetters) => React.ReactNode;
-  /** A children render prop function which receives field prop getters */
-  children?: (options: IUseFieldPropGetters) => React.ReactNode;
-  /** An identifer for the field input elements */
-  id?: string;
-}
+import { IFieldContainerProps } from './types';
+import { useField } from './useField';
 
 export const FieldContainer: React.FunctionComponent<IFieldContainerProps> = ({
   children,

--- a/packages/field/src/index.ts
+++ b/packages/field/src/index.ts
@@ -7,8 +7,8 @@
 
 /* Hooks */
 export { useField } from './useField';
-export type { IUseFieldPropGetters } from './useField';
 
 /* Render-props */
 export { FieldContainer } from './FieldContainer';
-export type { IFieldContainerProps } from './FieldContainer';
+
+export type { IUseFieldPropGetters, IFieldContainerProps } from './types';

--- a/packages/field/src/types.ts
+++ b/packages/field/src/types.ts
@@ -13,7 +13,7 @@ export interface IUseFieldPropGetters {
   getLabelProps: <T>(options?: T) => T & HTMLProps<any>;
   getInputProps: <T>(
     options?: T,
-    isDescribedOptions?: { isDescribed?: boolean; containsMessage?: boolean }
+    isDescribedOptions?: { isDescribed?: boolean; hasMessage?: boolean }
   ) => T & HTMLProps<any>;
 }
 

--- a/packages/field/src/types.ts
+++ b/packages/field/src/types.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { HTMLProps, ReactNode } from 'react';
+
+export interface IUseFieldPropGetters {
+  getHintProps: <T>(options?: T) => T & HTMLProps<any>;
+  getMessageProps: <T>(options?: T) => T & HTMLProps<any>;
+  getLabelProps: <T>(options?: T) => T & HTMLProps<any>;
+  getInputProps: <T>(
+    options?: T,
+    isDescribedOptions?: { isDescribed?: boolean; containsMessage?: boolean }
+  ) => T & HTMLProps<any>;
+}
+
+export interface IFieldContainerProps {
+  /** A render prop function which receives field prop getters */
+  render?: (options: IUseFieldPropGetters) => ReactNode;
+  /** A children render prop function which receives field prop getters */
+  children?: (options: IUseFieldPropGetters) => ReactNode;
+  /** An identifer for the field input elements */
+  id?: string;
+}

--- a/packages/field/src/useField.ts
+++ b/packages/field/src/useField.ts
@@ -8,14 +8,7 @@
 import { useMemo } from 'react';
 import { useUIDSeed } from 'react-uid';
 
-export interface IUseFieldPropGetters {
-  getHintProps: <T>(options?: T) => T & React.HTMLProps<any>;
-  getLabelProps: <T>(options?: T) => T & React.HTMLProps<any>;
-  getInputProps: <T>(
-    options?: T,
-    isDescribedOptions?: { isDescribed: boolean }
-  ) => T & React.HTMLProps<any>;
-}
+import { IUseFieldPropGetters } from './types';
 
 export function useField(idPrefix?: string): IUseFieldPropGetters {
   const seed = useUIDSeed();
@@ -23,6 +16,7 @@ export function useField(idPrefix?: string): IUseFieldPropGetters {
   const inputId = `${prefix}--input`;
   const labelId = `${prefix}--label`;
   const hintId = `${prefix}--hint`;
+  const messageId = `${prefix}--message`;
 
   const getLabelProps = ({ id = labelId, htmlFor = inputId, ...other } = {}) => {
     return {
@@ -34,11 +28,19 @@ export function useField(idPrefix?: string): IUseFieldPropGetters {
     } as any;
   };
 
-  const getInputProps = ({ id = inputId, ...other } = {}, { isDescribed = false } = {}) => {
+  const getInputProps = (
+    { id = inputId, ...other } = {},
+    { isDescribed = false, containsMessage = false } = {}
+  ) => {
     return {
       id,
       'aria-labelledby': labelId,
-      'aria-describedby': isDescribed ? hintId : null,
+      'aria-describedby':
+        isDescribed || containsMessage
+          ? ([] as string[])
+              .concat(isDescribed ? hintId : [], containsMessage ? messageId : [])
+              .join(' ')
+          : null,
       ...other
     } as any;
   };
@@ -50,9 +52,17 @@ export function useField(idPrefix?: string): IUseFieldPropGetters {
     } as any;
   };
 
+  const getMessageProps = ({ id = messageId, ...other } = {}) => {
+    return {
+      id,
+      ...other
+    } as any;
+  };
+
   return {
     getLabelProps,
     getInputProps,
-    getHintProps
+    getHintProps,
+    getMessageProps
   };
 }

--- a/packages/field/src/useField.ts
+++ b/packages/field/src/useField.ts
@@ -30,15 +30,15 @@ export function useField(idPrefix?: string): IUseFieldPropGetters {
 
   const getInputProps = (
     { id = inputId, ...other } = {},
-    { isDescribed = false, containsMessage = false } = {}
+    { isDescribed = false, hasMessage = false } = {}
   ) => {
     return {
       id,
       'aria-labelledby': labelId,
       'aria-describedby':
-        isDescribed || containsMessage
+        isDescribed || hasMessage
           ? ([] as string[])
-              .concat(isDescribed ? hintId : [], containsMessage ? messageId : [])
+              .concat(isDescribed ? hintId : [], hasMessage ? messageId : [])
               .join(' ')
           : null,
       ...other


### PR DESCRIPTION
## Description

This PR adds `getMessageProps` as a return value to use with an additional message component.

## Detail

The `getMessageProps` is used to connect the input `aria-describedby` attribute as one of the space separated IDs (see [ID reference list](https://www.w3.org/TR/wai-aria/#typemapping)) that describe the element. 

Internally, the `getInputProps` has a new option added: `containsMessage`. This allows the container to only add the `messageId` to the `aria-describedby` only if it is set to true. If there is a preference to rename this option name (eg `hasMessage`), open to renaming it.

## Checklist

- [x] :globe_with_meridians: Storybook demo is up-to-date (`yarn start`)
- [ ] :wheelchair: analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver
- [x] :guardsman: includes new unit tests
- [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
