### PR TITLE
chore(scrollregion): remove unused react-merge-refs package

### DIFF
--- a/packages/scrollregion/package.json
+++ b/packages/scrollregion/package.json
@@ -22,8 +22,7 @@
   "dependencies": {
     "@babel/runtime": "^7.8.4",
     "lodash.debounce": "^4.0.8",
-    "prop-types": "^15.7.2",
-    "react-merge-refs": "^1.1.0"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": ">=16.8.0",

--- a/packages/scrollregion/yarn.lock
+++ b/packages/scrollregion/yarn.lock
@@ -57,11 +57,6 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-merge-refs@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
-  integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
-
 regenerator-runtime@^0.13.4:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"


### PR DESCRIPTION
## Description

This PR removes an unused dependency `react-merge-refs` in `scrollregion`.

## Checklist

- [ ] :globe_with_meridians: ~Storybook demo is up-to-date (`yarn start`)~
- [ ] :wheelchair: ~analyzed via [axe](https://www.deque.com/axe/) and evaluated using VoiceOver~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
