### PR TITLE
fix(slider): prevent default screenreader cursor navigation

### DIFF
--- a/packages/slider/.size-snapshot.json
+++ b/packages/slider/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 11772,
-    "minified": 6050,
-    "gzipped": 2289
+    "bundled": 11806,
+    "minified": 6069,
+    "gzipped": 2298
   },
   "index.esm.js": {
-    "bundled": 10925,
-    "minified": 5360,
-    "gzipped": 2171,
+    "bundled": 10959,
+    "minified": 5379,
+    "gzipped": 2181,
     "treeshaked": {
       "rollup": {
         "code": 547,
         "import_statements": 64
       },
       "webpack": {
-        "code": 5539
+        "code": 5558
       }
     }
   }

--- a/packages/slider/src/useSlider.ts
+++ b/packages/slider/src/useSlider.ts
@@ -225,6 +225,7 @@ export function useSlider<T extends Element = Element, M extends HTMLElement = H
             }
 
             if (value !== undefined) {
+              event.preventDefault(); // prevent screenreader navigation
               event.stopPropagation();
               setThumbPosition(thumb)(value);
             }

--- a/packages/slider/src/useSlider.ts
+++ b/packages/slider/src/useSlider.ts
@@ -225,7 +225,7 @@ export function useSlider<T extends Element = Element, M extends HTMLElement = H
             }
 
             if (value !== undefined) {
-              event.preventDefault(); // prevent screenreader navigation
+              event.preventDefault(); // avoid screenreader behavior that hinders keyboard navigation
               event.stopPropagation();
               setThumbPosition(thumb)(value);
             }


### PR DESCRIPTION
## Description

The initial port over from `react-components` missed the `event.preventDefault()` call on keyboard interactions.

## Detail

The fix was tested against https://github.com/zendeskgarden/react-components/pull/1431.

## Checklist

- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :guardsman: ~includes new unit tests~
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
