### PR TITLE
fix(splitter): use WAI-ARIA specified actions and values

### DIFF
--- a/packages/splitter/.size-snapshot.json
+++ b/packages/splitter/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 9607,
-    "minified": 4475,
-    "gzipped": 1676
+    "bundled": 10107,
+    "minified": 4673,
+    "gzipped": 1739
   },
   "index.esm.js": {
-    "bundled": 8717,
-    "minified": 3706,
-    "gzipped": 1554,
+    "bundled": 9154,
+    "minified": 3841,
+    "gzipped": 1619,
     "treeshaked": {
       "rollup": {
         "code": 259,
         "import_statements": 83
       },
       "webpack": {
-        "code": 4502
+        "code": 4653
       }
     }
   }

--- a/packages/splitter/.size-snapshot.json
+++ b/packages/splitter/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 10493,
-    "minified": 4823,
-    "gzipped": 1790
+    "bundled": 10559,
+    "minified": 4836,
+    "gzipped": 1794
   },
   "index.esm.js": {
-    "bundled": 9540,
-    "minified": 3991,
-    "gzipped": 1675,
+    "bundled": 9606,
+    "minified": 4004,
+    "gzipped": 1680,
     "treeshaked": {
       "rollup": {
         "code": 259,
         "import_statements": 83
       },
       "webpack": {
-        "code": 4803
+        "code": 4816
       }
     }
   }

--- a/packages/splitter/.size-snapshot.json
+++ b/packages/splitter/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 10107,
-    "minified": 4673,
-    "gzipped": 1739
+    "bundled": 10243,
+    "minified": 4753,
+    "gzipped": 1751
   },
   "index.esm.js": {
-    "bundled": 9154,
-    "minified": 3841,
-    "gzipped": 1619,
+    "bundled": 9290,
+    "minified": 3921,
+    "gzipped": 1635,
     "treeshaked": {
       "rollup": {
         "code": 259,
         "import_statements": 83
       },
       "webpack": {
-        "code": 4653
+        "code": 4733
       }
     }
   }

--- a/packages/splitter/.size-snapshot.json
+++ b/packages/splitter/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 10243,
-    "minified": 4753,
-    "gzipped": 1751
+    "bundled": 10493,
+    "minified": 4823,
+    "gzipped": 1790
   },
   "index.esm.js": {
-    "bundled": 9290,
-    "minified": 3921,
-    "gzipped": 1635,
+    "bundled": 9540,
+    "minified": 3991,
+    "gzipped": 1675,
     "treeshaked": {
       "rollup": {
         "code": 259,
         "import_statements": 83
       },
       "webpack": {
-        "code": 4733
+        "code": 4803
       }
     }
   }

--- a/packages/splitter/.size-snapshot.json
+++ b/packages/splitter/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 10559,
-    "minified": 4836,
-    "gzipped": 1794
+    "bundled": 10632,
+    "minified": 4848,
+    "gzipped": 1804
   },
   "index.esm.js": {
-    "bundled": 9606,
-    "minified": 4004,
-    "gzipped": 1680,
+    "bundled": 9679,
+    "minified": 4016,
+    "gzipped": 1684,
     "treeshaked": {
       "rollup": {
         "code": 259,
         "import_statements": 83
       },
       "webpack": {
-        "code": 4816
+        "code": 4828
       }
     }
   }

--- a/packages/splitter/src/SplitterContainer.spec.tsx
+++ b/packages/splitter/src/SplitterContainer.spec.tsx
@@ -10,6 +10,7 @@ import { render, fireEvent } from '@testing-library/react';
 import { IUseSplitterProps, IUseSplitterReturnValue } from './types';
 import { SplitterContainer } from './';
 import { KEYBOARD_STEP } from './useSplitter';
+import userEvent from '@testing-library/user-event';
 
 const paneStyle: React.CSSProperties = {
   flexGrow: 0,
@@ -275,6 +276,16 @@ describe('SplitterContainer', () => {
         });
       });
 
+      it('should return from min to previous position on double click', () => {
+        const { getByRole } = render(<UncontrolledTestSplitter defaultValueNow={50} />);
+        const element = getByRole('separator');
+
+        userEvent.dblClick(element);
+        userEvent.dblClick(element);
+
+        expect(element).toHaveAttribute('aria-valuenow', '50');
+      });
+
       describe('fixed', () => {
         type MouseDownMatrix = [IUseSplitterProps['orientation'], number, number];
         it.each<MouseDownMatrix>([
@@ -376,10 +387,14 @@ describe('SplitterContainer', () => {
           ['vertical', 'ArrowLeft', 70, 70 - KEYBOARD_STEP],
           ['vertical', 'Enter', 20, 0],
           ['vertical', 'Enter', 0, 100],
+          ['vertical', 'Home', 100, 0],
+          ['vertical', 'End', 0, 100],
           ['horizontal', 'ArrowUp', 70, 70 - KEYBOARD_STEP],
           ['horizontal', 'ArrowDown', 20, 20 + KEYBOARD_STEP],
           ['horizontal', 'Enter', 20, 0],
-          ['horizontal', 'Enter', 0, 100]
+          ['horizontal', 'Enter', 0, 100],
+          ['horizontal', 'Home', 100, 0],
+          ['horizontal', 'End', 0, 100]
         ])('should move %s splitter using %s from %i to %i', (orientation, key, start, end) => {
           const { getByRole } = render(
             <UncontrolledTestSplitter orientation={orientation} defaultValueNow={start} />
@@ -396,8 +411,12 @@ describe('SplitterContainer', () => {
         it.each<KeyDownMatrix>([
           ['vertical', 'Enter', 20, 0],
           ['vertical', 'Enter', 0, 100],
+          ['vertical', 'Home', 100, 0],
+          ['vertical', 'End', 0, 100],
           ['horizontal', 'Enter', 20, 0],
-          ['horizontal', 'Enter', 0, 100]
+          ['horizontal', 'Enter', 0, 100],
+          ['horizontal', 'Home', 100, 0],
+          ['horizontal', 'End', 0, 100]
         ])('should move %s splitter using %s from %i to %i', (orientation, key, start, end) => {
           const { getByRole } = render(
             <UncontrolledTestSplitter isFixed orientation={orientation} defaultValueNow={start} />
@@ -408,6 +427,16 @@ describe('SplitterContainer', () => {
 
           expect(element).toHaveAttribute('aria-valuenow', String(end));
         });
+      });
+
+      it('should return from min to previous position on <enter>', () => {
+        const { getByRole } = render(<UncontrolledTestSplitter defaultValueNow={50} />);
+        const element = getByRole('separator');
+
+        fireEvent.keyDown(element, { key: 'Enter' });
+        fireEvent.keyDown(element, { key: 'Enter' });
+
+        expect(element).toHaveAttribute('aria-valuenow', '50');
       });
     });
 

--- a/packages/splitter/src/SplitterContainer.spec.tsx
+++ b/packages/splitter/src/SplitterContainer.spec.tsx
@@ -438,6 +438,16 @@ describe('SplitterContainer', () => {
 
         expect(element).toHaveAttribute('aria-valuenow', '50');
       });
+
+      it('should return from <home> to previous position on <enter>', () => {
+        const { getByRole } = render(<UncontrolledTestSplitter defaultValueNow={50} />);
+        const element = getByRole('separator');
+
+        fireEvent.keyDown(element, { key: 'Home' });
+        fireEvent.keyDown(element, { key: 'Enter' });
+
+        expect(element).toHaveAttribute('aria-valuenow', '50');
+      });
     });
 
     describe('controlled mode', () => {

--- a/packages/splitter/src/useSplitter.ts
+++ b/packages/splitter/src/useSplitter.ts
@@ -248,6 +248,10 @@ export const useSplitter = <T extends HTMLElement = HTMLElement>({
         }
       };
 
+      const ariaValueNow = ((separatorPosition - min) / (max - min)) * 100;
+      const ariaValueMin = isFinite(ariaValueNow) ? 0 : min;
+      const ariaValueMax = isFinite(ariaValueNow) ? 100 : max;
+
       return {
         role: role === null ? undefined : role,
         onMouseDown: composeEventHandlers(onMouseDown, handleMouseDown),
@@ -255,9 +259,9 @@ export const useSplitter = <T extends HTMLElement = HTMLElement>({
         onKeyDown: composeEventHandlers(onKeyDown, handleKeyDown),
         onClick: composeEventHandlers(onClick, handleClick),
         'aria-controls': primaryPaneId,
-        'aria-valuenow': separatorPosition,
-        'aria-valuemin': min,
-        'aria-valuemax': max,
+        'aria-valuenow': isFinite(ariaValueNow) ? ariaValueNow : separatorPosition,
+        'aria-valuemin': ariaValueMin,
+        'aria-valuemax': ariaValueMax,
         'aria-orientation': orientation,
         'data-garden-container-id': 'containers.splitter.separator',
         'data-garden-container-version': PACKAGE_VERSION,

--- a/packages/splitter/src/useSplitter.ts
+++ b/packages/splitter/src/useSplitter.ts
@@ -66,6 +66,7 @@ export const useSplitter = <T extends HTMLElement = HTMLElement>({
     bottom: 0
   });
   const separatorPosition = isControlled ? valueNow : state;
+  const [lastPosition, setLastPosition] = useState(separatorPosition);
   const doc = environment || document;
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -187,10 +188,15 @@ export const useSplitter = <T extends HTMLElement = HTMLElement>({
       const handleKeyDown = (event: React.KeyboardEvent) => {
         if (event.key === KEYS.ENTER) {
           if (separatorPosition === min) {
-            setSeparatorPosition(max);
+            setSeparatorPosition(lastPosition === min ? max : lastPosition);
           } else {
+            setLastPosition(separatorPosition);
             setSeparatorPosition(min);
           }
+        } else if (event.key === KEYS.HOME) {
+          setSeparatorPosition(min);
+        } else if (event.key === KEYS.END) {
+          setSeparatorPosition(max);
         } else if (!isFixed) {
           if (event.key === KEYS.RIGHT && orientation === 'vertical') {
             let position;
@@ -224,14 +230,17 @@ export const useSplitter = <T extends HTMLElement = HTMLElement>({
         }
       };
 
-      const handleClick = () => {
+      const handleClick = (event: MouseEvent) => {
         if (isFixed) {
           if (separatorPosition > min) {
             setSeparatorPosition(min);
           }
+
           if (separatorPosition < max) {
             setSeparatorPosition(max);
           }
+        } else if (event.detail === 2 /* double click */) {
+          handleKeyDown({ key: KEYS.ENTER } as React.KeyboardEvent);
         }
       };
 
@@ -257,6 +266,7 @@ export const useSplitter = <T extends HTMLElement = HTMLElement>({
       isFixed,
       isLeading,
       keyboardStep,
+      lastPosition,
       max,
       min,
       move,

--- a/packages/splitter/src/useSplitter.ts
+++ b/packages/splitter/src/useSplitter.ts
@@ -82,15 +82,17 @@ export const useSplitter = <T extends HTMLElement = HTMLElement>({
 
   const setRangedSeparatorPosition = useCallback(
     (nextDimension: number) => {
-      if (nextDimension >= max) {
-        setSeparatorPosition(max);
-      } else if (nextDimension <= min) {
-        setSeparatorPosition(min);
-      } else {
-        setSeparatorPosition(nextDimension);
+      if (separatorRef.current) {
+        if (nextDimension >= max) {
+          setSeparatorPosition(max);
+        } else if (nextDimension <= min) {
+          setSeparatorPosition(min);
+        } else {
+          setSeparatorPosition(nextDimension);
+        }
       }
     },
-    [max, min, setSeparatorPosition]
+    [max, min, separatorRef, setSeparatorPosition]
   );
 
   const move = useCallback(

--- a/packages/splitter/src/useSplitter.ts
+++ b/packages/splitter/src/useSplitter.ts
@@ -196,6 +196,7 @@ export const useSplitter = <T extends HTMLElement = HTMLElement>({
             setSeparatorPosition(min);
           }
         } else if (event.key === KEYS.HOME) {
+          separatorPosition !== min && setLastPosition(separatorPosition);
           setSeparatorPosition(min);
         } else if (event.key === KEYS.END) {
           setSeparatorPosition(max);

--- a/packages/splitter/src/useSplitter.ts
+++ b/packages/splitter/src/useSplitter.ts
@@ -208,6 +208,7 @@ export const useSplitter = <T extends HTMLElement = HTMLElement>({
             }
 
             setRangedSeparatorPosition(position);
+            event.preventDefault(); // prevent scroll
           } else if (event.key === KEYS.LEFT && orientation === 'vertical') {
             let position;
 
@@ -218,14 +219,17 @@ export const useSplitter = <T extends HTMLElement = HTMLElement>({
             }
 
             setRangedSeparatorPosition(position);
+            event.preventDefault(); // prevent scroll
           } else if (event.key === KEYS.UP && orientation === 'horizontal') {
             setRangedSeparatorPosition(
               separatorPosition + (isLeading ? keyboardStep : -keyboardStep)
             );
+            event.preventDefault(); // prevent scroll
           } else if (event.key === KEYS.DOWN && orientation === 'horizontal') {
             setRangedSeparatorPosition(
               separatorPosition + (isLeading ? -keyboardStep : keyboardStep)
             );
+            event.preventDefault(); // prevent scroll
           }
         }
       };


### PR DESCRIPTION
## Description

Update the current `useSplitter` hook to use [WAI-ARIA specified](https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/) actions and values:
- `<Enter>` "restores the splitter to its previous position" (not from `min` to `max`)
- typical `aria-valuemin` and `aria-valuemax` are normalized to values between 0 and 100 (see https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/#wai-aria-roles-states-and-properties-27)

## Detail

Additional fixes/enhancements include:
- prevent default browser scroll on cursor keys
- a mouse double-click action maps to `<Enter>`

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
