### PR TITLE
fix(splitter): update `isFixed` to leverage enter key handling

### DIFF
--- a/packages/splitter/.size-snapshot.json
+++ b/packages/splitter/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 10632,
-    "minified": 4848,
-    "gzipped": 1804
+    "bundled": 10377,
+    "minified": 4816,
+    "gzipped": 1782
   },
   "index.esm.js": {
-    "bundled": 9679,
-    "minified": 4016,
-    "gzipped": 1684,
+    "bundled": 9424,
+    "minified": 3984,
+    "gzipped": 1667,
     "treeshaked": {
       "rollup": {
         "code": 259,
         "import_statements": 83
       },
       "webpack": {
-        "code": 4828
+        "code": 4796
       }
     }
   }

--- a/packages/splitter/demo/splitter.stories.mdx
+++ b/packages/splitter/demo/splitter.stories.mdx
@@ -38,7 +38,7 @@ import { SplitterStory } from './stories/SplitterStory';
 <Canvas>
   <Story
     name="Controlled"
-    args={{ valueNow: 200 }}
+    args={{ valueNow: 300 }}
     argTypes={{ defaultValueNow: { control: false } }}
   >
     {({ ...args }) => {

--- a/packages/splitter/demo/stories/SplitterStory.tsx
+++ b/packages/splitter/demo/stories/SplitterStory.tsx
@@ -62,7 +62,7 @@ const Component = forwardRef<HTMLDivElement, IComponentProps>(
         </div>
       </div>
       <div
-        className={classNames('flex', 'flex-none', {
+        className={classNames('flex', 'flex-none', 'select-none', {
           'cursor-pointer': isFixed,
           'cursor-col-resize': !isFixed && orientation === 'vertical',
           'cursor-row-resize': !isFixed && orientation === 'horizontal',

--- a/packages/splitter/src/SplitterContainer.spec.tsx
+++ b/packages/splitter/src/SplitterContainer.spec.tsx
@@ -289,10 +289,10 @@ describe('SplitterContainer', () => {
       describe('fixed', () => {
         type MouseDownMatrix = [IUseSplitterProps['orientation'], number, number];
         it.each<MouseDownMatrix>([
-          ['vertical', 20, 100],
+          ['vertical', 20, 0],
           ['vertical', 0, 100],
           ['vertical', 100, 0],
-          ['horizontal', 20, 100],
+          ['horizontal', 20, 0],
           ['horizontal', 0, 100],
           ['horizontal', 100, 0]
         ])('should move %s splitter using mouse down from %i to %i', (orientation, start, end) => {
@@ -359,10 +359,10 @@ describe('SplitterContainer', () => {
       describe('fixed', () => {
         type TouchMatrix = [IUseSplitterProps['orientation'], number, number];
         it.each<TouchMatrix>([
-          ['vertical', 20, 100],
+          ['vertical', 20, 0],
           ['vertical', 0, 100],
           ['vertical', 100, 0],
-          ['horizontal', 20, 100],
+          ['horizontal', 20, 0],
           ['horizontal', 0, 100],
           ['horizontal', 100, 0]
         ])('should move %s splitter using touch from %i to %i', (orientation, start, end) => {

--- a/packages/splitter/src/useSplitter.ts
+++ b/packages/splitter/src/useSplitter.ts
@@ -82,17 +82,15 @@ export const useSplitter = <T extends HTMLElement = HTMLElement>({
 
   const setRangedSeparatorPosition = useCallback(
     (nextDimension: number) => {
-      if (separatorRef.current) {
-        if (nextDimension >= max) {
-          setSeparatorPosition(max);
-        } else if (nextDimension <= min) {
-          setSeparatorPosition(min);
-        } else {
-          setSeparatorPosition(nextDimension);
-        }
+      if (nextDimension >= max) {
+        setSeparatorPosition(max);
+      } else if (nextDimension <= min) {
+        setSeparatorPosition(min);
+      } else {
+        setSeparatorPosition(nextDimension);
       }
     },
-    [max, min, separatorRef, setSeparatorPosition]
+    [max, min, setSeparatorPosition]
   );
 
   const move = useCallback(
@@ -238,15 +236,7 @@ export const useSplitter = <T extends HTMLElement = HTMLElement>({
       };
 
       const handleClick = (event: MouseEvent) => {
-        if (isFixed) {
-          if (separatorPosition > min) {
-            setSeparatorPosition(min);
-          }
-
-          if (separatorPosition < max) {
-            setSeparatorPosition(max);
-          }
-        } else if (event.detail === 2 /* double click */) {
+        if (isFixed || event.detail === 2 /* double click */) {
           handleKeyDown({ key: KEYS.ENTER } as React.KeyboardEvent);
         }
       };


### PR DESCRIPTION
## Description

Allow `isFixed` splitter to leverage `lastPosition` state handling.

## Detail

Also, unwinds a controlled component re-render bug introduced by #487.

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
