### PR TITLE
chore(renovate): add postUpdateOptions to config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "extends": ["config:base"],
   "rebaseStalePrs": true,
   "schedule": ["on Monday every 9 weeks of the year starting on the 3rd week"],
+  "postUpdateOptions": ["yarnDedupeHighest"],
   "packageRules": [
     {
       "matchFiles": ["package.json"],


### PR DESCRIPTION
## Description

Re-adding postUpdateOptions to renovate configuration to de-dupe dependencies with yarn.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :wheelchair: ~tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
