### PR TITLE
fix!(field): refactored interface types for enhanced accessibility

### DIFF
--- a/packages/field/.size-snapshot.json
+++ b/packages/field/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 2202,
-    "minified": 1103,
-    "gzipped": 524
+    "bundled": 2943,
+    "minified": 1637,
+    "gzipped": 626
   },
   "index.esm.js": {
-    "bundled": 2149,
-    "minified": 1056,
-    "gzipped": 509,
+    "bundled": 2854,
+    "minified": 1553,
+    "gzipped": 615,
     "treeshaked": {
       "rollup": {
-        "code": 81,
-        "import_statements": 58
+        "code": 120,
+        "import_statements": 83
       },
       "webpack": {
-        "code": 362
+        "code": 405
       }
     }
   }

--- a/packages/field/demo/field.stories.mdx
+++ b/packages/field/demo/field.stories.mdx
@@ -13,11 +13,9 @@ import { FieldStory } from './stories/FieldStory';
 <Canvas>
   <Story
     name="Field"
-    args={{ as: 'hook', isDescribed: true, hasMessage: true }}
+    args={{ as: 'hook', hasHint: true, hasMessage: true }}
     argTypes={{
-      as: { options: ['container', 'hook'], control: 'radio', table: { category: 'Story' } },
-      isDescribed: { table: { category: 'Story' } },
-      hasMessage: { table: { category: 'Story' } }
+      as: { options: ['container', 'hook'], control: 'radio', table: { category: 'Story' } }
     }}
   >
     {args => <FieldStory {...args} />}

--- a/packages/field/demo/stories/FieldStory.tsx
+++ b/packages/field/demo/stories/FieldStory.tsx
@@ -10,13 +10,14 @@ import { Story } from '@storybook/react';
 import {
   FieldContainer,
   IFieldContainerProps,
-  IUseFieldPropGetters,
+  IUseFieldProps,
+  IUseFieldReturnValue,
   useField
 } from '@zendeskgarden/container-field';
 
-interface IComponentProps extends IUseFieldPropGetters {
-  isDescribed: boolean;
-  hasMessage: boolean;
+interface IComponentProps extends IUseFieldReturnValue {
+  hasHint?: boolean;
+  hasMessage?: boolean;
 }
 
 const Component = ({
@@ -24,46 +25,32 @@ const Component = ({
   getHintProps,
   getInputProps,
   getMessageProps,
-  isDescribed,
+  hasHint,
   hasMessage
 }: IComponentProps) => (
   /* eslint-disable jsx-a11y/label-has-associated-control */
   <>
     <label {...getLabelProps()}>Label</label>
-    {isDescribed && <div {...getHintProps()}>Hint</div>}
-    <input {...getInputProps({}, { isDescribed, hasMessage })} />
-    {hasMessage && (
-      <div role="alert" {...getMessageProps()}>
-        Message
-      </div>
-    )}
+    {hasHint && <div {...getHintProps()}>Hint</div>}
+    <input {...getInputProps()} />
+    {hasMessage && <div {...getMessageProps()}>Message</div>}
   </>
 );
 
-interface IProps {
-  id?: NonNullable<IFieldContainerProps['id']>;
-  isDescribed: boolean;
-  hasMessage: boolean;
-}
-
-const Container = ({ id, isDescribed, hasMessage }: IProps) => (
-  <FieldContainer id={id}>
-    {containerProps => (
-      <Component isDescribed={isDescribed} hasMessage={hasMessage} {...containerProps} />
-    )}
+const Container = ({ hasHint, hasMessage, ...props }: IFieldContainerProps) => (
+  <FieldContainer hasHint={hasHint} hasMessage={hasMessage} {...props}>
+    {containerProps => <Component {...containerProps} hasHint={hasHint} hasMessage={hasMessage} />}
   </FieldContainer>
 );
 
-const Hook = ({ id, isDescribed, hasMessage }: IProps) => {
-  const hookProps = useField(id);
+const Hook = ({ hasHint, hasMessage, ...props }: IUseFieldProps) => {
+  const hookProps = useField({ hasHint, hasMessage, ...props });
 
-  return <Component isDescribed={isDescribed} hasMessage={hasMessage} {...hookProps} />;
+  return <Component {...hookProps} hasHint={hasHint} hasMessage={hasMessage} />;
 };
 
 interface IArgs extends IFieldContainerProps {
   as: 'hook' | 'container';
-  isDescribed: boolean;
-  hasMessage: boolean;
 }
 
 export const FieldStory: Story<IArgs> = ({ as, ...props }) => {

--- a/packages/field/package.json
+++ b/packages/field/package.json
@@ -21,7 +21,7 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@babel/runtime": "^7.8.4",
-    "react-uid": "^2.2.0"
+    "@zendeskgarden/container-utilities": "^1.0.1"
   },
   "peerDependencies": {
     "prop-types": "^15.6.1",

--- a/packages/field/src/FieldContainer.spec.tsx
+++ b/packages/field/src/FieldContainer.spec.tsx
@@ -14,13 +14,19 @@ describe('FieldContainer', () => {
   const CONTAINER_ID = 'test';
 
   const BasicExample = () => (
-    <FieldContainer id={CONTAINER_ID}>
+    <FieldContainer idPrefix={CONTAINER_ID}>
       {({ getLabelProps, getInputProps, getHintProps, getMessageProps }) => (
         <div>
-          <label {...getLabelProps({ 'data-test-id': 'label' })}>Label</label>
-          <div {...getHintProps({ 'data-test-id': 'hint' })}>Hint</div>
-          <input {...getInputProps({ 'data-test-id': 'input' })} />
-          <div {...getMessageProps({ 'data-test-id': 'message' })}>Message</div>
+          <label data-test-id="label" {...getLabelProps()}>
+            Label
+          </label>
+          <div data-test-id="hint" {...getHintProps()}>
+            Hint
+          </div>
+          <input data-test-id="input" {...getInputProps()} />
+          <div data-test-id="message" {...getMessageProps()}>
+            Message
+          </div>
         </div>
       )}
     </FieldContainer>
@@ -48,14 +54,14 @@ describe('FieldContainer', () => {
 
     it.each([
       ['options', true, true],
-      ['isDescribed', true, false],
+      ['hasHint', true, false],
       ['hasMessage', false, true]
-    ])(`includes aria-describedby if %s is provided`, (_, isDescribed, hasMessage) => {
+    ])(`includes aria-describedby if %s is provided`, (_, hasHint, hasMessage) => {
       const { getByTestId } = render(
-        <FieldContainer id={CONTAINER_ID}>
+        <FieldContainer idPrefix={CONTAINER_ID} hasHint={hasHint} hasMessage={hasMessage}>
           {({ getInputProps }) => (
             <div>
-              <input {...getInputProps({ 'data-test-id': 'input' }, { isDescribed, hasMessage })} />
+              <input data-test-id="input" {...getInputProps()} />
             </div>
           )}
         </FieldContainer>
@@ -63,7 +69,7 @@ describe('FieldContainer', () => {
 
       expect(getByTestId('input')).toHaveAttribute(
         'aria-describedby',
-        [isDescribed ? `${CONTAINER_ID}--hint` : '', hasMessage ? `${CONTAINER_ID}--message` : '']
+        [hasHint ? `${CONTAINER_ID}--hint` : '', hasMessage ? `${CONTAINER_ID}--message` : '']
           .join(' ')
           .trim()
       );

--- a/packages/field/src/FieldContainer.tsx
+++ b/packages/field/src/FieldContainer.tsx
@@ -7,20 +7,21 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import { IFieldContainerProps } from './types';
 import { useField } from './useField';
+import { IFieldContainerProps } from './types';
 
-export const FieldContainer: React.FunctionComponent<IFieldContainerProps> = ({
+export const FieldContainer: React.FC<IFieldContainerProps> = ({
   children,
   render = children,
-  id
+  ...options
 }) => {
-  return <>{render!(useField(id)) as React.ReactElement}</>;
+  return <>{render!(useField(options))}</>;
 };
 
 FieldContainer.propTypes = {
   children: PropTypes.func,
   render: PropTypes.func,
-  id: PropTypes.string
+  idPrefix: PropTypes.string,
+  hasHint: PropTypes.bool,
+  hasMessage: PropTypes.bool
 };

--- a/packages/field/src/index.ts
+++ b/packages/field/src/index.ts
@@ -11,4 +11,4 @@ export { useField } from './useField';
 /* Render-props */
 export { FieldContainer } from './FieldContainer';
 
-export type { IUseFieldPropGetters, IFieldContainerProps } from './types';
+export type { IFieldContainerProps, IUseFieldProps, IUseFieldReturnValue } from './types';

--- a/packages/field/src/types.ts
+++ b/packages/field/src/types.ts
@@ -31,10 +31,10 @@ export interface IFieldContainerProps extends IUseFieldProps {
   /**
    * Provides field render prop functions
    *
-   * @param {function} [options.getLabelProps] Backdrop props getter
-   * @param {function} [options.getHintProps] Modal dialog props getter
-   * @param {function} [options.getInputProps] Modal close button props getter
-   * @param {function} [options.getMessageProps] Modal title props getter
+   * @param {function} [options.getLabelProps] Field label props getter
+   * @param {function} [options.getHintProps] Field hint props getter
+   * @param {function} [options.getInputProps] Field input props getter
+   * @param {function} [options.getMessageProps] Field message getter
    */
   render?: (options: {
     getLabelProps: IUseFieldReturnValue['getLabelProps'];

--- a/packages/field/src/types.ts
+++ b/packages/field/src/types.ts
@@ -7,21 +7,41 @@
 
 import { HTMLProps, ReactNode } from 'react';
 
-export interface IUseFieldPropGetters {
-  getHintProps: <T>(options?: T & HTMLProps<any>) => T & HTMLProps<any>;
-  getMessageProps: <T>(options?: T & HTMLProps<any>) => T & HTMLProps<any>;
-  getLabelProps: <T>(options?: T & HTMLProps<any>) => T & HTMLProps<any>;
-  getInputProps: <T>(
-    options?: T & HTMLProps<any>,
-    isDescribedOptions?: { isDescribed?: boolean; hasMessage?: boolean }
-  ) => T & HTMLProps<any>;
+export interface IUseFieldProps {
+  /** Prefixes IDs for field elements */
+  idPrefix?: string;
+  /** Indicates the field has a hint */
+  hasHint?: boolean;
+  /** Indicates the field has a message */
+  hasMessage?: boolean;
 }
 
-export interface IFieldContainerProps {
-  /** A render prop function which receives field prop getters */
-  render?: (options: IUseFieldPropGetters) => ReactNode;
-  /** A children render prop function which receives field prop getters */
-  children?: (options: IUseFieldPropGetters) => ReactNode;
-  /** An identifer for the field input elements */
-  id?: string;
+export interface IUseFieldReturnValue {
+  getLabelProps: <T extends Element>(props?: HTMLProps<T>) => HTMLProps<T>;
+  getHintProps: <T extends Element>(props?: HTMLProps<T>) => HTMLProps<T>;
+  getInputProps: <T extends Element>(props?: HTMLProps<T>) => HTMLProps<T>;
+  getMessageProps: <T extends Element>(
+    props?: Omit<HTMLProps<T>, 'role'> & {
+      role?: 'alert' | null;
+    }
+  ) => HTMLProps<T>;
+}
+
+export interface IFieldContainerProps extends IUseFieldProps {
+  /**
+   * Provides field render prop functions
+   *
+   * @param {function} [options.getLabelProps] Backdrop props getter
+   * @param {function} [options.getHintProps] Modal dialog props getter
+   * @param {function} [options.getInputProps] Modal close button props getter
+   * @param {function} [options.getMessageProps] Modal title props getter
+   */
+  render?: (options: {
+    getLabelProps: IUseFieldReturnValue['getLabelProps'];
+    getHintProps: IUseFieldReturnValue['getHintProps'];
+    getInputProps: IUseFieldReturnValue['getInputProps'];
+    getMessageProps: IUseFieldReturnValue['getMessageProps'];
+  }) => ReactNode;
+  /** @ignore */
+  children?: (options: IUseFieldReturnValue) => ReactNode;
 }

--- a/packages/field/src/useField.ts
+++ b/packages/field/src/useField.ts
@@ -58,7 +58,7 @@ export const useField = ({
         'data-garden-container-version': PACKAGE_VERSION,
         id,
         'aria-labelledby': labelId,
-        'aria-describedby': describedBy ? describedBy.join(' ') : undefined,
+        'aria-describedby': describedBy.length > 0 ? describedBy.join(' ') : undefined,
         ...other
       };
     },

--- a/packages/field/src/useField.ts
+++ b/packages/field/src/useField.ts
@@ -5,64 +5,84 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { useMemo } from 'react';
-import { useUIDSeed } from 'react-uid';
+import { useCallback, useMemo } from 'react';
+import { useId } from '@zendeskgarden/container-utilities';
+import { IUseFieldProps, IUseFieldReturnValue } from './types';
 
-import { IUseFieldPropGetters } from './types';
-
-export function useField(idPrefix?: string): IUseFieldPropGetters {
-  const seed = useUIDSeed();
-  const prefix = useMemo(() => idPrefix || seed(`field_${PACKAGE_VERSION}`), [idPrefix, seed]);
+export const useField = ({
+  idPrefix,
+  hasHint,
+  hasMessage
+}: IUseFieldProps): IUseFieldReturnValue => {
+  const prefix = useId(idPrefix);
   const inputId = `${prefix}--input`;
   const labelId = `${prefix}--label`;
   const hintId = `${prefix}--hint`;
   const messageId = `${prefix}--message`;
 
-  const getLabelProps = ({ id = labelId, htmlFor = inputId, ...other } = {}) => {
-    return {
+  const getLabelProps = useCallback<IUseFieldReturnValue['getLabelProps']>(
+    ({ id = labelId, htmlFor = inputId, ...other } = {}) => ({
+      'data-garden-container-id': 'containers.field.label',
+      'data-garden-container-version': PACKAGE_VERSION,
       id,
       htmlFor,
-      'data-garden-container-id': 'containers.field',
+      ...other
+    }),
+    [labelId, inputId]
+  );
+
+  const getHintProps = useCallback<IUseFieldReturnValue['getInputProps']>(
+    ({ id = hintId, ...other } = {}) => ({
+      'data-garden-container-id': 'containers.field.hint',
       'data-garden-container-version': PACKAGE_VERSION,
-      ...other
-    } as any;
-  };
-
-  const getInputProps = (
-    { id = inputId, ...other } = {},
-    { isDescribed = false, hasMessage = false } = {}
-  ) => {
-    return {
-      id,
-      'aria-labelledby': labelId,
-      'aria-describedby':
-        isDescribed || hasMessage
-          ? ([] as string[])
-              .concat(isDescribed ? hintId : [], hasMessage ? messageId : [])
-              .join(' ')
-          : null,
-      ...other
-    } as any;
-  };
-
-  const getHintProps = ({ id = hintId, ...other } = {}) => {
-    return {
       id,
       ...other
-    } as any;
-  };
+    }),
+    [hintId]
+  );
 
-  const getMessageProps = ({ id = messageId, ...other } = {}) => {
-    return {
+  const getInputProps = useCallback<IUseFieldReturnValue['getInputProps']>(
+    ({ id = inputId, ...other } = {}) => {
+      const describedBy = [];
+
+      if (hasHint) {
+        describedBy.push(hintId);
+      }
+
+      if (hasMessage) {
+        describedBy.push(messageId);
+      }
+
+      return {
+        'data-garden-container-id': 'containers.field.input',
+        'data-garden-container-version': PACKAGE_VERSION,
+        id,
+        'aria-labelledby': labelId,
+        'aria-describedby': describedBy ? describedBy.join(' ') : undefined,
+        ...other
+      };
+    },
+    [inputId, labelId, hintId, messageId, hasHint, hasMessage]
+  );
+
+  const getMessageProps = useCallback<IUseFieldReturnValue['getMessageProps']>(
+    ({ id = messageId, role = 'alert', ...other } = {}) => ({
+      'data-garden-container-id': 'containers.field.message',
+      'data-garden-container-version': PACKAGE_VERSION,
+      role: role === null ? undefined : role,
       id,
       ...other
-    } as any;
-  };
+    }),
+    [messageId]
+  );
 
-  return {
-    getLabelProps,
-    getInputProps,
-    getHintProps,
-    getMessageProps
-  };
-}
+  return useMemo<IUseFieldReturnValue>(
+    () => ({
+      getLabelProps,
+      getHintProps,
+      getInputProps,
+      getMessageProps
+    }),
+    [getLabelProps, getHintProps, getInputProps, getMessageProps]
+  );
+};

--- a/packages/field/yarn.lock
+++ b/packages/field/yarn.lock
@@ -9,19 +9,41 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-react-uid@^2.2.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/react-uid/-/react-uid-2.3.1.tgz#22a75d4a948a4824b9b8078cbf864d55d91ca4be"
-  integrity sha512-6C5pwNYP1udgp5feQ9MTBZBKD4su9nhD2aYCFY1bB0Bpask8wYKYz0ZhAtAJ4lcmTDC5kY1ByGTQMFDHQW6p0w==
+"@reach/auto-id@^0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.17.0.tgz#60cce65eb7a0d6de605820727f00dfe2b03b5f17"
+  integrity sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==
   dependencies:
-    tslib "^1.10.0"
+    "@reach/utils" "0.17.0"
+    tslib "^2.3.0"
+
+"@reach/utils@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.17.0.tgz#3d1d2ec56d857f04fe092710d8faee2b2b121303"
+  integrity sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==
+  dependencies:
+    tiny-warning "^1.0.3"
+    tslib "^2.3.0"
+
+"@zendeskgarden/container-utilities@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-1.0.1.tgz#54f1ee1d86850d2484609a097526a91fe6444211"
+  integrity sha512-eEIgOqdbeRx+MYbjrgUTtJ80/O3DQegY/rvHafCb0Ar7xSxpWYRQ3L3QfGm7mWJWD1Vj5Q5zZWdmq+94Ur/yPA==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@reach/auto-id" "^0.17.0"
 
 regenerator-runtime@^0.13.4:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
 
-tslib@^1.10.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+tiny-warning@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
+tslib@^2.3.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

includes:

- root props for `useField` and `FieldContainer` are consistent: `{idPrefix, hasHint, hasMessage}`
- `[options.getInputProps]` no longer accepts 2nd `{isDescribed, hasMessage}` parameter (due to previous)

## Description

Following on from #461, this PR refactors `field` interface types for consistency. Please see the reference PR description as it applies here. **This PR is a dependency for the `useCombobox` branch work.**

## Detail

Opportunistic updates:

- `useUIDSeed()` -> `useId()`
- `data-garden-container-id` attributes (consistent with combobox)
- `useCallback` and `useMemo` patterns applied

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
