### PR TITLE
fix!(grid): refactored interface types for enhanced accessibility and provide missing ID generation

### DIFF
--- a/packages/grid/.size-snapshot.json
+++ b/packages/grid/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "index.cjs.js": {
-    "bundled": 7968,
-    "minified": 3285,
-    "gzipped": 1304
+    "bundled": 8078,
+    "minified": 3305,
+    "gzipped": 1316
   },
   "index.esm.js": {
-    "bundled": 7658,
-    "minified": 2976,
-    "gzipped": 1288,
+    "bundled": 7768,
+    "minified": 2996,
+    "gzipped": 1299,
     "treeshaked": {
       "rollup": {
         "code": 230,

--- a/packages/grid/.size-snapshot.json
+++ b/packages/grid/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "index.cjs.js": {
-    "bundled": 7525,
-    "minified": 3002,
-    "gzipped": 1227
+    "bundled": 7968,
+    "minified": 3285,
+    "gzipped": 1304
   },
   "index.esm.js": {
-    "bundled": 7221,
-    "minified": 2699,
-    "gzipped": 1213,
+    "bundled": 7658,
+    "minified": 2976,
+    "gzipped": 1288,
     "treeshaked": {
       "rollup": {
         "code": 230,

--- a/packages/grid/.size-snapshot.json
+++ b/packages/grid/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "index.cjs.js": {
-    "bundled": 6880,
-    "minified": 2856,
-    "gzipped": 1157
+    "bundled": 7525,
+    "minified": 3002,
+    "gzipped": 1227
   },
   "index.esm.js": {
-    "bundled": 6571,
-    "minified": 2549,
-    "gzipped": 1139,
+    "bundled": 7221,
+    "minified": 2699,
+    "gzipped": 1213,
     "treeshaked": {
       "rollup": {
         "code": 230,

--- a/packages/grid/.size-snapshot.json
+++ b/packages/grid/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 7434,
-    "minified": 3244,
-    "gzipped": 1555
+    "bundled": 6880,
+    "minified": 2856,
+    "gzipped": 1157
   },
   "index.esm.js": {
-    "bundled": 7384,
-    "minified": 3199,
-    "gzipped": 1543,
+    "bundled": 6571,
+    "minified": 2549,
+    "gzipped": 1139,
     "treeshaked": {
       "rollup": {
-        "code": 451,
-        "import_statements": 40
+        "code": 230,
+        "import_statements": 98
       },
       "webpack": {
-        "code": 743
+        "code": 546
       }
     }
   }

--- a/packages/grid/demo/grid.stories.mdx
+++ b/packages/grid/demo/grid.stories.mdx
@@ -7,7 +7,7 @@ import { MATRIX } from './stories/data';
 <Meta
   title="Packages/Grid"
   component={GridContainer}
-  args={{ as: 'hook', layout: 'button', matrix: MATRIX }}
+  args={{ as: 'hook', layout: 'button', matrix: MATRIX, 'aria-label': 'Grid' }}
   argTypes={{
     as: { options: ['container', 'hook'], control: 'radio', table: { category: 'Story' } },
     layout: { options: ['button', 'radio', 'text'], control: 'radio', table: { category: 'Story' } }

--- a/packages/grid/demo/stories/GridStory.tsx
+++ b/packages/grid/demo/stories/GridStory.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { FocusEventHandler } from 'react';
+import React, { FocusEventHandler, HTMLProps } from 'react';
 import { Story } from '@storybook/react';
 import {
   GridContainer,
@@ -17,10 +17,18 @@ import {
 
 interface IComponent extends IUseGridProps, IUseGridReturnValue {
   layout: IArgs['layout'];
+  'aria-label': IArgs['aria-label'];
 }
 
-const Component = ({ rtl, matrix, layout, getGridCellProps }: IComponent) => (
-  <table role="grid" style={{ direction: rtl ? 'rtl' : 'ltr' }}>
+const Component = ({
+  rtl,
+  matrix,
+  layout,
+  'aria-label': ariaLabel,
+  getGridProps,
+  getGridCellProps
+}: IComponent) => (
+  <table style={{ direction: rtl ? 'rtl' : 'ltr' }} {...getGridProps({ 'aria-label': ariaLabel })}>
     <tbody>
       {matrix.map((row, rowIndex) => (
         <tr key={rowIndex}>
@@ -109,32 +117,34 @@ const Component = ({ rtl, matrix, layout, getGridCellProps }: IComponent) => (
 
 interface IProps extends IGridContainerProps {
   layout: IArgs['layout'];
+  'aria-label': IArgs['aria-label'];
 }
 
-const Container = (props: IProps) => (
+const Container = ({ 'aria-label': ariaLabel, ...props }: IProps) => (
   <GridContainer {...props}>
-    {containerProps => <Component {...containerProps} {...props} />}
+    {containerProps => <Component aria-label={ariaLabel} {...containerProps} {...props} />}
   </GridContainer>
 );
 
-const Hook = (props: IProps) => {
+const Hook = ({ 'aria-label': ariaLabel, ...props }: IProps) => {
   const hookProps = useGrid(props);
 
-  return <Component {...hookProps} {...props} />;
+  return <Component aria-label={ariaLabel} {...hookProps} {...props} />;
 };
 
 interface IArgs extends IGridContainerProps {
   as: 'hook' | 'container';
   layout: 'button' | 'radio' | 'text';
+  'aria-label': NonNullable<HTMLProps<HTMLDivElement>['aria-label']>;
 }
 
-export const GridStory: Story<IArgs> = ({ as, ...props }) => {
+export const GridStory: Story<IArgs> = ({ as, 'aria-label': ariaLabel, ...props }) => {
   switch (as) {
     case 'container':
-      return <Container {...props} />;
+      return <Container aria-label={ariaLabel} {...props} />;
 
     case 'hook':
     default:
-      return <Hook {...props} />;
+      return <Hook aria-label={ariaLabel} {...props} />;
   }
 };

--- a/packages/grid/demo/stories/GridStory.tsx
+++ b/packages/grid/demo/stories/GridStory.tsx
@@ -22,20 +22,29 @@ interface IComponent extends IUseGridProps, IUseGridReturnValue {
 const Component = ({ rtl, matrix, layout, getGridCellProps }: IComponent) => (
   <table role="grid" style={{ direction: rtl ? 'rtl' : 'ltr' }}>
     <tbody>
-      {matrix.map((row, rowIdx) => (
-        <tr key={rowIdx}>
-          {row.map((column, colIdx) => {
-            const { role, ...props } = getGridCellProps({ rowIdx, colIdx });
-
+      {matrix.map((row, rowIndex) => (
+        <tr key={rowIndex}>
+          {row.map((column, colIndex) => {
             switch (layout) {
-              case 'text':
+              case 'text': {
+                const { role, ...props } = getGridCellProps<HTMLTableCellElement>({
+                  rowIndex,
+                  colIndex
+                });
+
                 return (
-                  <td key={colIdx} className="w-5 h-5 text-center" role={role} {...props}>
-                    {matrix[rowIdx][colIdx]}
+                  <td key={colIndex} className="w-5 h-5 text-center" role={role} {...props}>
+                    {matrix[rowIndex][colIndex]}
                   </td>
                 );
+              }
 
               case 'radio': {
+                const { role, ...props } = getGridCellProps<HTMLInputElement>({
+                  rowIndex,
+                  colIndex
+                });
+
                 const handleBlur: FocusEventHandler<HTMLInputElement> = event => {
                   /**
                    * When the grid loses focus, reset the roving tab index to
@@ -60,9 +69,9 @@ const Component = ({ rtl, matrix, layout, getGridCellProps }: IComponent) => (
                 };
 
                 return (
-                  <td key={colIdx} role={role}>
+                  <td key={colIndex} role={role}>
                     <label>
-                      <span className="sr-only">{matrix[rowIdx][colIdx]}</span>
+                      <span className="sr-only">{matrix[rowIndex][colIndex]}</span>
                       <input
                         className="w-5 h-5"
                         name="demo"
@@ -76,14 +85,20 @@ const Component = ({ rtl, matrix, layout, getGridCellProps }: IComponent) => (
               }
 
               case 'button':
-              default:
+              default: {
+                const { role, ...props } = getGridCellProps<HTMLButtonElement>({
+                  rowIndex,
+                  colIndex
+                });
+
                 return (
-                  <td key={colIdx} role={role}>
-                    <button className="h-7 w-7" type="button" {...props}>
-                      {matrix[rowIdx][colIdx]}
+                  <td key={colIndex} role={role}>
+                    <button className="h-7 w-7" {...props} type="button">
+                      {matrix[rowIndex][colIndex]}
                     </button>
                   </td>
                 );
+              }
             }
           })}
         </tr>

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -20,7 +20,8 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@babel/runtime": "^7.8.4"
+    "@babel/runtime": "^7.8.4",
+    "@zendeskgarden/container-utilities": "^1.0.1"
   },
   "peerDependencies": {
     "prop-types": "^15.6.1",

--- a/packages/grid/src/GridContainer.spec.tsx
+++ b/packages/grid/src/GridContainer.spec.tsx
@@ -381,6 +381,40 @@ describe('useGrid', () => {
       expect(onChange).toHaveBeenCalledTimes(7);
       expect(onChange).toHaveBeenCalledWith(0, 0);
     });
+
+    test('handles matrix mutation', async () => {
+      const onChange = jest.fn();
+      let matrix = [
+        ['1', '2', '3'],
+        ['4', '5', '6'],
+        ['7', '8', '9']
+      ];
+
+      const { rerender } = render(<Example matrix={matrix} onChange={onChange} />);
+
+      await user.click(gridCell('9'));
+      expect(gridCell('9')).toHaveFocus();
+
+      matrix = [
+        ['1', '2'],
+        ['3', '4']
+      ];
+
+      rerender(<Example matrix={matrix} onChange={onChange} />);
+      expect(onChange).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledWith(1, 1);
+      expect(gridCell('4')).toHaveAttribute('tabIndex', '0');
+
+      await user.click(gridCell('4'));
+      expect(gridCell('4')).toHaveFocus();
+
+      matrix = [['1', '2']];
+
+      rerender(<Example matrix={matrix} onChange={onChange} />);
+      expect(onChange).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledWith(0, 1);
+      expect(gridCell('2')).toHaveAttribute('tabIndex', '0');
+    });
   });
 
   describe('controlled usages', () => {

--- a/packages/grid/src/GridContainer.spec.tsx
+++ b/packages/grid/src/GridContainer.spec.tsx
@@ -25,8 +25,8 @@ describe('useGrid', () => {
 
   const Example = ({ rtl, matrix, onFocus, onClick, ...props }: IExample) => (
     <GridContainer rtl={rtl} matrix={matrix} idPrefix={idPrefix} {...props}>
-      {({ getGridCellProps }: IUseGridReturnValue) => (
-        <table role="grid">
+      {({ getGridProps, getGridCellProps }: IUseGridReturnValue) => (
+        <table {...getGridProps({ 'aria-label': 'test' })}>
           <tbody>
             {matrix.map((row, rowIndex: number) => (
               <tr key={row[0] as string}>
@@ -52,6 +52,15 @@ describe('useGrid', () => {
       )}
     </GridContainer>
   );
+
+  test('renders grid as expected', () => {
+    const { getByRole } = render(<Example matrix={[[]]} />);
+
+    const table = getByRole('grid');
+
+    expect(table.nodeName).toBe('TABLE');
+    expect(table).toHaveAttribute('aria-label', 'test');
+  });
 
   test('composes gridcell onClick handler', async () => {
     const onClick = jest.fn();

--- a/packages/grid/src/GridContainer.spec.tsx
+++ b/packages/grid/src/GridContainer.spec.tsx
@@ -28,17 +28,18 @@ describe('useGrid', () => {
       {({ getGridCellProps }: IUseGridReturnValue) => (
         <table role="grid">
           <tbody>
-            {matrix.map((row: string[], rowIdx: number) => (
-              <tr key={row[0]}>
-                {row.map((rowItem: string, colIdx: number) => (
-                  <td role="presentation" key={rowItem}>
+            {matrix.map((row, rowIndex: number) => (
+              <tr key={row[0] as string}>
+                {row.map((rowItem, colIndex: number) => (
+                  <td role="presentation" key={rowItem as string}>
                     <button
                       {...getGridCellProps({
-                        colIdx,
-                        rowIdx,
+                        colIndex,
+                        rowIndex,
                         onFocus,
                         onClick
                       })}
+                      type="button"
                     >
                       {rowItem}
                     </button>

--- a/packages/grid/src/GridContainer.spec.tsx
+++ b/packages/grid/src/GridContainer.spec.tsx
@@ -423,6 +423,11 @@ describe('useGrid', () => {
       expect(onChange).toHaveBeenCalled();
       expect(onChange).toHaveBeenCalledWith(0, 1);
       expect(gridCell('2')).toHaveAttribute('tabIndex', '0');
+
+      matrix = [[]];
+      rerender(<Example matrix={matrix} onChange={onChange} />);
+      expect(onChange).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledWith(0, 0);
     });
   });
 

--- a/packages/grid/src/GridContainer.tsx
+++ b/packages/grid/src/GridContainer.tsx
@@ -7,20 +7,14 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useGrid, IUseGridProps, IUseGridReturnValue } from './useGrid';
+import { useGrid } from './useGrid';
+import { IGridContainerProps } from './types';
 
-export interface IGridContainerProps extends IUseGridProps {
-  /** A render prop function which receives grid a prop getter */
-  render?: (options: IUseGridReturnValue) => React.ReactNode;
-  /** A children render prop function which receives a grid prop getter */
-  children?: (options: IUseGridReturnValue) => React.ReactNode;
-}
-
-export const GridContainer: React.FC<IGridContainerProps> = props => {
-  const { children, render = children, ...options } = props;
-
-  return <>{render!(useGrid(options)) as React.ReactElement}</>;
-};
+export const GridContainer: React.FC<IGridContainerProps> = ({
+  children,
+  render = children,
+  ...options
+}) => <>{render!(useGrid(options))}</>;
 
 GridContainer.propTypes = {
   children: PropTypes.func,

--- a/packages/grid/src/index.ts
+++ b/packages/grid/src/index.ts
@@ -7,8 +7,8 @@
 
 /* Hooks */
 export { useGrid } from './useGrid';
-export type { IUseGridProps, IUseGridReturnValue } from './useGrid';
 
 /* Render-props */
 export { GridContainer } from './GridContainer';
-export type { IGridContainerProps } from './GridContainer';
+
+export type { IUseGridProps, IUseGridReturnValue, IGridContainerProps } from './types';

--- a/packages/grid/src/types.ts
+++ b/packages/grid/src/types.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { HTMLProps, ReactNode } from 'react';
+
+export interface IUseGridProps {
+  /** Sets the two-dimension array to render the grid */
+  matrix: any[][];
+  /** Determines if navigation uses right-to-left direction */
+  rtl?: boolean;
+  /** Enables wrapped keyboard navigation  */
+  wrap?: boolean;
+  /** Prefixes IDs for the grid and cells  */
+  idPrefix?: string;
+  /** Sets the focused row index in a controlled grid */
+  rowIndex?: number;
+  /** Sets the focused column index in a controlled grid */
+  colIndex?: number;
+  /** Sets the default focused row index in a uncontrolled grid */
+  defaultRowIndex?: number;
+  /** Sets the default focused column index in a uncontrolled grid */
+  defaultColIndex?: number;
+  /** Handles grid change event */
+  onChange?: (rowIndex: number, colIndex: number) => void;
+  /** Sets the environment where the grid is rendered */
+  environment?: Document;
+}
+
+export interface IUseGridReturnValue {
+  getGridCellProps: <T extends Element>(
+    props?: Omit<HTMLProps<T>, 'role'> & {
+      role?: 'gridcell' | null;
+    }
+  ) => HTMLProps<T>;
+}
+
+export interface IGridContainerProps extends IUseGridProps {
+  /**
+   * Provides grid render prop functions
+   *
+   * @param {function} [options.getGridCellProps] Grid cell props getter
+   */
+  render?: (options: { getGridCellProps: IUseGridReturnValue['getGridCellProps'] }) => ReactNode;
+  /** @ignore */
+  children?: (options: IUseGridReturnValue) => ReactNode;
+}

--- a/packages/grid/src/types.ts
+++ b/packages/grid/src/types.ts
@@ -31,6 +31,12 @@ export interface IUseGridProps {
 }
 
 export interface IUseGridReturnValue {
+  getGridProps: <T extends Element>(
+    props: Omit<HTMLProps<T>, 'role' | 'aria-label'> & {
+      role?: 'grid' | null;
+      'aria-label': NonNullable<HTMLProps<T>['aria-label']>;
+    }
+  ) => HTMLProps<T>;
   getGridCellProps: <T extends Element>(
     props?: Omit<HTMLProps<T>, 'role'> & {
       role?: 'gridcell' | null;
@@ -44,9 +50,13 @@ export interface IGridContainerProps extends IUseGridProps {
   /**
    * Provides grid render prop functions
    *
+   * @param {function} [options.getGridProps] Grid props getter
    * @param {function} [options.getGridCellProps] Grid cell props getter
    */
-  render?: (options: { getGridCellProps: IUseGridReturnValue['getGridCellProps'] }) => ReactNode;
+  render?: (options: {
+    getGridProps: IUseGridReturnValue['getGridProps'];
+    getGridCellProps: IUseGridReturnValue['getGridCellProps'];
+  }) => ReactNode;
   /** @ignore */
   children?: (options: IUseGridReturnValue) => ReactNode;
 }

--- a/packages/grid/src/types.ts
+++ b/packages/grid/src/types.ts
@@ -9,7 +9,7 @@ import { HTMLProps, ReactNode } from 'react';
 
 export interface IUseGridProps {
   /** Sets the two-dimension array to render the grid */
-  matrix: any[][];
+  matrix: unknown[][];
   /** Determines if navigation uses right-to-left direction */
   rtl?: boolean;
   /** Enables wrapped keyboard navigation  */
@@ -34,6 +34,8 @@ export interface IUseGridReturnValue {
   getGridCellProps: <T extends Element>(
     props?: Omit<HTMLProps<T>, 'role'> & {
       role?: 'gridcell' | null;
+      rowIndex: number;
+      colIndex: number;
     }
   ) => HTMLProps<T>;
 }

--- a/packages/grid/src/useGrid.ts
+++ b/packages/grid/src/useGrid.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { useState, KeyboardEventHandler, useCallback, useMemo } from 'react';
+import { useState, KeyboardEventHandler, useCallback, useMemo, useEffect } from 'react';
 import { composeEventHandlers, KEYS, useId } from '@zendeskgarden/container-utilities';
 import { IUseGridProps, IUseGridReturnValue } from './types';
 import { getCellDown, getCellLeft, getCellRight, getCellUp, getId } from './utils';
@@ -39,6 +39,26 @@ export function useGrid({
     controlledColIndex !== undefined;
   const rowIndex = isControlled ? controlledRowIndex : uncontrolledRowIndex;
   const colIndex = isControlled ? controlledColIndex : uncontrolledColIndex;
+
+  useEffect(() => {
+    // Handle dynamic matrix mutation by ensuring roving tab index is valid.
+    const rowCount = matrix.length;
+    const colCount = matrix[0].length;
+    const isRowIndexInvalid = rowIndex >= rowCount;
+    const isColIndexInvalid = colIndex >= colCount;
+
+    if (isRowIndexInvalid || isColIndexInvalid) {
+      const _rowIndex = isRowIndexInvalid ? rowCount - 1 : rowIndex;
+      const _colIndex = isColIndexInvalid ? colCount - 1 : colIndex;
+
+      if (!isControlled) {
+        setUncontrolledRowIndex(_rowIndex);
+        setUncontrolledColIndex(_colIndex);
+      }
+
+      onChange(_rowIndex, _colIndex);
+    }
+  }, [matrix, rowIndex, colIndex, isControlled, setUncontrolledColIndex, onChange]);
 
   const getGridCellProps: IUseGridReturnValue['getGridCellProps'] = useCallback(
     (

--- a/packages/grid/src/useGrid.ts
+++ b/packages/grid/src/useGrid.ts
@@ -60,6 +60,16 @@ export function useGrid({
     }
   }, [matrix, rowIndex, colIndex, isControlled, setUncontrolledColIndex, onChange]);
 
+  const getGridProps: IUseGridReturnValue['getGridProps'] = useCallback(
+    ({ role = 'grid', ...other }) => ({
+      'data-garden-container-id': 'containers.grid',
+      'data-garden-container-version': PACKAGE_VERSION,
+      role: role === null ? undefined : role,
+      ...other
+    }),
+    []
+  );
+
   const getGridCellProps: IUseGridReturnValue['getGridCellProps'] = useCallback(
     (
       {
@@ -134,6 +144,8 @@ export function useGrid({
       };
 
       return {
+        'data-garden-container-id': 'containers.grid.cell',
+        'data-garden-container-version': PACKAGE_VERSION,
         id: getId(prefix!, _rowIndex, _colIndex),
         role: role === null ? undefined : role,
         tabIndex: rowIndex === _rowIndex && colIndex === _colIndex ? 0 : -1,
@@ -147,8 +159,9 @@ export function useGrid({
 
   return useMemo<IUseGridReturnValue>(
     () => ({
+      getGridProps,
       getGridCellProps
     }),
-    [getGridCellProps]
+    [getGridProps, getGridCellProps]
   );
 }

--- a/packages/grid/src/useGrid.ts
+++ b/packages/grid/src/useGrid.ts
@@ -48,8 +48,16 @@ export function useGrid({
     const isColIndexInvalid = colIndex >= colCount;
 
     if (isRowIndexInvalid || isColIndexInvalid) {
-      const _rowIndex = isRowIndexInvalid ? rowCount - 1 : rowIndex;
-      const _colIndex = isColIndexInvalid ? colCount - 1 : colIndex;
+      let _rowIndex = rowIndex;
+      let _colIndex = colIndex;
+
+      if (isRowIndexInvalid) {
+        _rowIndex = rowCount > 0 ? rowCount - 1 : 0;
+      }
+
+      if (isColIndexInvalid) {
+        _colIndex = colCount > 0 ? colCount - 1 : 0;
+      }
 
       if (!isControlled) {
         setUncontrolledRowIndex(_rowIndex);

--- a/packages/grid/src/useGrid.ts
+++ b/packages/grid/src/useGrid.ts
@@ -5,42 +5,11 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { useState, HTMLProps, HTMLAttributes, KeyboardEventHandler } from 'react';
+import { useState, KeyboardEventHandler } from 'react';
 import { composeEventHandlers, KEYS } from '@zendeskgarden/container-utilities';
+import { IUseGridProps, IUseGridReturnValue } from './types';
 
 const GRID_KEYS = [KEYS.LEFT, KEYS.RIGHT, KEYS.UP, KEYS.DOWN, KEYS.HOME, KEYS.END];
-
-export interface IUseGridProps {
-  /** Determines if navigation uses right-to-left direction */
-  rtl?: boolean;
-  /** Enables wrapped keyboard navigation  */
-  wrap?: boolean;
-  /** Sets the two-dimension array to render the grid */
-  matrix: any[][];
-  /** Prefixes IDs for the grid and cells  */
-  idPrefix?: string;
-  /** Sets the focused row index in a controlled grid */
-  rowIndex?: number;
-  /** Sets the focused column index in a controlled grid */
-  colIndex?: number;
-  /** Sets the default focused row index in a uncontrolled grid */
-  defaultRowIndex?: number;
-  /** Sets the default focused column index in a uncontrolled grid */
-  defaultColIndex?: number;
-  /** Handles grid change event */
-  onChange?: (rowIndex: number, colIndex: number) => void;
-  /** The environment where the grid is rendered */
-  environment?: Document;
-}
-
-interface IGetGridCellProps extends HTMLProps<any> {
-  rowIdx: number;
-  colIdx: number;
-}
-
-export interface IUseGridReturnValue {
-  getGridCellProps: (options: IGetGridCellProps) => HTMLAttributes<any>;
-}
 
 export function useGrid({
   rtl,
@@ -48,12 +17,13 @@ export function useGrid({
   matrix,
   idPrefix,
   onChange,
-  environment = document,
+  environment,
   rowIndex: controlledRowIndex,
   colIndex: controlledColIndex,
   defaultRowIndex,
   defaultColIndex
 }: IUseGridProps): IUseGridReturnValue {
+  const doc = environment || document;
   const [uncontrolledRowIndex, setUncontrolledRowIndex] = useState(
     defaultRowIndex !== null && defaultRowIndex !== undefined ? defaultRowIndex : 0
   );
@@ -187,7 +157,7 @@ export function useGrid({
 
       if (row !== rowIndex || col !== colIndex) {
         const id = `${idPrefix}-${row}-${col}`;
-        const element = environment.getElementById(id);
+        const element = doc.getElementById(id);
 
         element?.focus();
       }

--- a/packages/grid/src/utils.ts
+++ b/packages/grid/src/utils.ts
@@ -1,0 +1,113 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { IUseGridProps } from './types';
+
+export const getCellDown = (
+  matrix: IUseGridProps['matrix'],
+  rowIndex: number,
+  colIndex: number,
+  wrap?: boolean
+) => {
+  let retVal: number[] = [];
+  const rowCount = matrix.length;
+  const colCount = matrix[0].length;
+  const lastRowLength = matrix[rowCount - 1].length;
+  const isLastCellFocused =
+    rowIndex === rowCount - (colCount > lastRowLength ? 2 : 1) && colIndex === colCount - 1;
+
+  if (!isLastCellFocused) {
+    if (rowIndex === rowCount - (colIndex >= lastRowLength ? 2 : 1) /* last row is focused */) {
+      if (wrap) {
+        retVal = [0, colIndex + 1]; // top cell of next col
+      }
+    } else {
+      retVal = [rowIndex + 1, colIndex]; // cell below
+    }
+  }
+
+  return retVal;
+};
+
+export const getCellLeft = (
+  matrix: IUseGridProps['matrix'],
+  rowIndex: number,
+  colIndex: number,
+  wrap?: boolean
+) => {
+  let retVal: number[] = [];
+  const colCount = matrix[0].length;
+  const isFirstCellFocused = rowIndex === 0 && colIndex === 0;
+
+  if (!isFirstCellFocused) {
+    if (colIndex === 0 /* first col is focused */) {
+      if (wrap) {
+        retVal = [rowIndex - 1, colCount - 1]; // last cell of previous row
+      }
+    } else {
+      retVal = [rowIndex, colIndex - 1]; // previous cell
+    }
+  }
+
+  return retVal;
+};
+
+export const getCellRight = (
+  matrix: IUseGridProps['matrix'],
+  rowIndex: number,
+  colIndex: number,
+  wrap?: boolean
+) => {
+  let retVal: number[] = [];
+  const rowCount = matrix.length;
+  const colCount = matrix[0].length;
+  const lastRowIndex = rowCount - 1;
+  const lastColIndex = matrix[lastRowIndex].length - 1;
+  const isLastCellFocused = rowIndex === lastRowIndex && colIndex === lastColIndex;
+
+  if (!isLastCellFocused) {
+    if (colIndex === colCount - 1 /* last col is focused */) {
+      if (wrap) {
+        retVal = [rowIndex + 1, 0]; // first cell of next row
+      }
+    } else {
+      retVal = [rowIndex, colIndex + 1]; // next cell
+    }
+  }
+
+  return retVal;
+};
+
+export const getCellUp = (
+  matrix: IUseGridProps['matrix'],
+  rowIndex: number,
+  colIndex: number,
+  wrap?: boolean
+) => {
+  let retVal: number[] = [];
+  const rowCount = matrix.length;
+  const isFirstCellFocused = rowIndex === 0 && colIndex === 0;
+
+  if (!isFirstCellFocused) {
+    if (rowIndex === 0 /* first row is focused */) {
+      if (wrap) {
+        const lastRowLength = matrix[rowCount - 1].length;
+        const col = colIndex - 1;
+        const row = rowCount - (col >= lastRowLength ? 2 : 1);
+
+        retVal = [row, col]; // bottom cell of previous col
+      }
+    } else {
+      retVal = [rowIndex - 1, colIndex]; // cell above
+    }
+  }
+
+  return retVal;
+};
+
+export const getId = (idPrefix: string, rowIndex: number, colIndex: number) =>
+  `${idPrefix}--R${rowIndex + 1}C${colIndex + 1}`;


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

includes:
- consistent `rowIndex` & `colIndex` naming for `getGridCellProps`
- narrowed `HTMLProps` typing with `Element` extension generics

## Description

Similar to #516, this PR refactors `grid` interface types for consistency and prepares the hook for inclusion in `useCombobox` branch work. Adds critical missing `useId` generation as the current hook would only support one active, default grid on the page due to ID collision. Also fixes SSR-unsafe `environment` instantiation.

## Detail

Opportunistic updates:
- added `getGridProps` to help enforce ARIA labeling
- handle matrix mutation by ensuring `tabIndex` remains valid
- `useCallback` and `useMemo` patterns applied

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :guardsman: ~includes new unit tests~
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
