### PR TITLE
fix!(combobox): update environment to be of type `Window` rather than `Document`

### DIFF
--- a/packages/combobox/.size-snapshot.json
+++ b/packages/combobox/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 23988,
-    "minified": 12919,
-    "gzipped": 3736
+    "bundled": 23964,
+    "minified": 12897,
+    "gzipped": 3724
   },
   "index.esm.js": {
-    "bundled": 23072,
-    "minified": 12004,
-    "gzipped": 3722,
+    "bundled": 23048,
+    "minified": 11982,
+    "gzipped": 3710,
     "treeshaked": {
       "rollup": {
         "code": 1296,
         "import_statements": 177
       },
       "webpack": {
-        "code": 11939
+        "code": 11917
       }
     }
   }

--- a/packages/combobox/.size-snapshot.json
+++ b/packages/combobox/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 24009,
-    "minified": 12922,
-    "gzipped": 3724
+    "bundled": 23960,
+    "minified": 12901,
+    "gzipped": 3718
   },
   "index.esm.js": {
-    "bundled": 23093,
-    "minified": 12007,
-    "gzipped": 3711,
+    "bundled": 23044,
+    "minified": 11986,
+    "gzipped": 3705,
     "treeshaked": {
       "rollup": {
         "code": 1296,
         "import_statements": 177
       },
       "webpack": {
-        "code": 11942
+        "code": 11921
       }
     }
   }

--- a/packages/combobox/.size-snapshot.json
+++ b/packages/combobox/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 23960,
-    "minified": 12901,
-    "gzipped": 3718
+    "bundled": 24001,
+    "minified": 12915,
+    "gzipped": 3724
   },
   "index.esm.js": {
-    "bundled": 23044,
-    "minified": 11986,
-    "gzipped": 3705,
+    "bundled": 23085,
+    "minified": 12000,
+    "gzipped": 3711,
     "treeshaked": {
       "rollup": {
         "code": 1296,
         "import_statements": 177
       },
       "webpack": {
-        "code": 11921
+        "code": 11935
       }
     }
   }

--- a/packages/combobox/.size-snapshot.json
+++ b/packages/combobox/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 23964,
-    "minified": 12897,
+    "bundled": 24009,
+    "minified": 12922,
     "gzipped": 3724
   },
   "index.esm.js": {
-    "bundled": 23048,
-    "minified": 11982,
-    "gzipped": 3710,
+    "bundled": 23093,
+    "minified": 12007,
+    "gzipped": 3711,
     "treeshaked": {
       "rollup": {
         "code": 1296,
         "import_statements": 177
       },
       "webpack": {
-        "code": 11917
+        "code": 11942
       }
     }
   }

--- a/packages/combobox/src/ComboboxContainer.spec.tsx
+++ b/packages/combobox/src/ComboboxContainer.spec.tsx
@@ -193,7 +193,6 @@ describe('ComboboxContainer', () => {
 
         expect(label).toHaveAttribute('for', input.getAttribute('id'));
         expect(trigger).toHaveAttribute('aria-controls', listboxId);
-        expect(trigger).toHaveAttribute('aria-expanded', 'false');
         expect(input).toHaveAttribute('role', 'combobox');
         expect(input).toHaveAttribute('aria-activedescendant');
         expect(input).toHaveAttribute('aria-autocomplete', 'list');
@@ -967,12 +966,12 @@ describe('ComboboxContainer', () => {
       await user.click(trigger);
 
       expect(input).toHaveFocus();
-      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(input).toHaveAttribute('aria-expanded', 'true');
 
       await user.click(trigger);
 
       expect(input).not.toHaveFocus();
-      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(input).toHaveAttribute('aria-expanded', 'false');
     });
 
     it('handles listbox collapse on input blur', async () => {
@@ -984,17 +983,18 @@ describe('ComboboxContainer', () => {
       await user.keyboard('{Tab}');
 
       expect(input).not.toHaveFocus();
-      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(input).toHaveAttribute('aria-expanded', 'false');
     });
 
     it('handles listbox collapse on unrelated focus', async () => {
       const { getByTestId } = render(<TestCombobox layout="Garden" options={[]} />);
+      const input = getByTestId('input');
       const trigger = getByTestId('trigger');
 
       await user.click(trigger);
       await user.click(document.body);
 
-      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(input).toHaveAttribute('aria-expanded', 'false');
     });
 
     it('handles disabled trigger click', async () => {
@@ -1005,7 +1005,7 @@ describe('ComboboxContainer', () => {
       await user.click(trigger);
 
       expect(input).not.toHaveFocus();
-      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(input).toHaveAttribute('aria-expanded', 'false');
     });
 
     it('handles trigger click without autocomplete', async () => {
@@ -1029,17 +1029,18 @@ describe('ComboboxContainer', () => {
           options={[{ value: 'test', selected: true }]}
         />
       );
+      const input = getByTestId('input');
       const trigger = getByTestId('trigger');
       const tag = getByTestId('tag');
 
       await user.click(trigger);
 
-      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(input).toHaveAttribute('aria-expanded', 'true');
 
       await user.keyboard('{Shift>}{Tab}{/Shift}');
 
       expect(tag).toHaveFocus();
-      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(input).toHaveAttribute('aria-expanded', 'true');
     });
 
     it('prevents tag propagation to trigger', async () => {

--- a/packages/combobox/src/types.ts
+++ b/packages/combobox/src/types.ts
@@ -84,7 +84,7 @@ export interface IUseComboboxProps<T = HTMLElement, L = HTMLElement> {
     activeIndex?: number;
   }) => void;
   /** Sets the environment where the combobox is rendered */
-  environment?: Document;
+  environment?: Window;
 }
 
 export interface IUseComboboxReturnValue {

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -401,7 +401,8 @@ export const useCombobox = ({
           onClick: composeEventHandlers(onClick, handleClick),
           /* Knock out ARIA for non-autocomplete Garden layout trigger */
           'aria-controls': isAutocomplete ? triggerProps['aria-controls'] : undefined,
-          'aria-expanded': isAutocomplete ? triggerProps['aria-expanded'] : undefined,
+          /* Knock out ARIA for Garden layout trigger */
+          'aria-expanded': undefined,
           /* Handle disabled for Garden layout */
           'aria-disabled': disabled || undefined,
           disabled: undefined

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -21,7 +21,10 @@ import {
 import { IOption, IUseComboboxProps, IUseComboboxReturnValue, OptionValue } from './types';
 import { toType } from './utils';
 
-export const useCombobox = ({
+export const useCombobox = <
+  T extends HTMLElement = HTMLElement,
+  L extends HTMLElement = HTMLElement
+>({
   idPrefix,
   triggerRef,
   inputRef,
@@ -43,7 +46,7 @@ export const useCombobox = ({
   initialActiveIndex,
   onChange = () => undefined,
   environment
-}: IUseComboboxProps): IUseComboboxReturnValue => {
+}: IUseComboboxProps<T, L>): IUseComboboxReturnValue => {
   const win = environment || window;
 
   /*

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -367,16 +367,10 @@ export const useCombobox = ({
 
   const getTriggerProps = useCallback<IUseComboboxReturnValue['getTriggerProps']>(
     ({ onBlur, onClick, onKeyDown, ...other } = {}) => {
-      const handleBlur = (event: React.FocusEvent) => {
-        if (event.relatedTarget === null || !event.currentTarget?.contains(event.relatedTarget)) {
-          closeListbox();
-        }
-      };
-
       const triggerProps = getDownshiftTriggerProps({
         'data-garden-container-id': 'containers.combobox',
         'data-garden-container-version': PACKAGE_VERSION,
-        onBlur: composeEventHandlers(onBlur, handleBlur),
+        onBlur,
         onClick,
         onKeyDown,
         ref: triggerRef,
@@ -385,6 +379,12 @@ export const useCombobox = ({
       } as IDownshiftTriggerProps);
 
       if (isEditable && triggerContainsInput) {
+        const handleBlur = (event: React.FocusEvent) => {
+          if (event.relatedTarget === null || !event.currentTarget?.contains(event.relatedTarget)) {
+            closeListbox();
+          }
+        };
+
         const handleClick = (event: MouseEvent) => {
           if (disabled) {
             event.preventDefault();
@@ -397,6 +397,7 @@ export const useCombobox = ({
 
         return {
           ...triggerProps,
+          onBlur: composeEventHandlers(onBlur, handleBlur),
           onClick: composeEventHandlers(onClick, handleClick),
           /* Knock out ARIA for non-autocomplete Garden layout trigger */
           'aria-controls': isAutocomplete ? triggerProps['aria-controls'] : undefined,
@@ -671,6 +672,7 @@ export const useCombobox = ({
         'data-garden-container-version': PACKAGE_VERSION,
         role,
         'aria-disabled': option?.disabled,
+        onMouseDown,
         ...other
       };
 

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -44,7 +44,7 @@ export const useCombobox = ({
   onChange = () => undefined,
   environment
 }: IUseComboboxProps): IUseComboboxReturnValue => {
-  const doc = environment || document;
+  const win = environment || window;
 
   /*
    * State
@@ -287,7 +287,7 @@ export const useCombobox = ({
     initialHighlightedIndex: initialActiveIndex,
     onStateChange: handleDownshiftStateChange,
     stateReducer,
-    environment: doc.defaultView || window
+    environment: win
   });
 
   const {

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -680,19 +680,20 @@ export const useCombobox = <
         ...other
       };
 
+      const ariaSelected = Array.isArray(_selectionValue)
+        ? _selectionValue?.includes(option?.value)
+        : _selectionValue === option?.value;
+
       if (option === undefined || option.disabled) {
         // Prevent downshift listbox mouse leave event.
         const handleMouseDown = (event: MouseEvent) => event.preventDefault();
 
         return {
+          'aria-selected': ariaSelected,
           ...optionProps,
           onMouseDown: composeEventHandlers(onMouseDown, handleMouseDown)
         };
       }
-
-      const ariaSelected = Array.isArray(_selectionValue)
-        ? _selectionValue?.includes(option.value)
-        : _selectionValue === option.value;
 
       return getDownshiftOptionProps({
         item: option.value,


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Consumers need access to environment as `window` rather than `document` in order to render Downshift in environments such as shadow DOM. In addition:

- restores a blur event handler (bug introduced in 1791d0c) that is intended for Garden-only (vs. Downshift) layouts
- removes invalid `aria-expanded` from a Garden layout trigger (contains input)
- passes ref type generics through `useCombobox`
- allows disabled options to be `aria-selected`

## Detail

Unlike the current combobox seen in https://zendeskgarden.github.io/react-containers/?path=/story/packages-combobox--uncontrolled&args=layout:Downshift, this PR's storybook deployment can successfully expand Downshift trigger layout via mouse.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
