### PR TITLE
fix!(combobox): update option value to be `string | object` rather than `any`; remove `isAutocomplete=true` default

### DIFF
--- a/packages/combobox/.size-snapshot.json
+++ b/packages/combobox/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 24395,
-    "minified": 13136,
-    "gzipped": 3801
+    "bundled": 24361,
+    "minified": 13109,
+    "gzipped": 3792
   },
   "index.esm.js": {
-    "bundled": 23479,
-    "minified": 12221,
-    "gzipped": 3787,
+    "bundled": 23445,
+    "minified": 12194,
+    "gzipped": 3779,
     "treeshaked": {
       "rollup": {
         "code": 1296,
         "import_statements": 177
       },
       "webpack": {
-        "code": 12115
+        "code": 12088
       }
     }
   }

--- a/packages/combobox/.size-snapshot.json
+++ b/packages/combobox/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 24001,
-    "minified": 12915,
-    "gzipped": 3725
+    "bundled": 24395,
+    "minified": 13136,
+    "gzipped": 3801
   },
   "index.esm.js": {
-    "bundled": 23085,
-    "minified": 12000,
-    "gzipped": 3712,
+    "bundled": 23479,
+    "minified": 12221,
+    "gzipped": 3787,
     "treeshaked": {
       "rollup": {
         "code": 1296,
         "import_statements": 177
       },
       "webpack": {
-        "code": 11935
+        "code": 12115
       }
     }
   }

--- a/packages/combobox/demo/combobox.stories.mdx
+++ b/packages/combobox/demo/combobox.stories.mdx
@@ -10,7 +10,6 @@ import { OPTIONS } from './stories/data';
   args={{
     as: 'hook',
     layout: 'Garden',
-    isAutocomplete: true,
     isEditable: true,
     options: OPTIONS
   }}

--- a/packages/combobox/demo/stories/ComboboxStory.tsx
+++ b/packages/combobox/demo/stories/ComboboxStory.tsx
@@ -19,6 +19,9 @@ import {
 } from '@zendeskgarden/container-combobox';
 import { useGrid } from '@zendeskgarden/container-grid';
 
+const toString = (option: IOption) =>
+  option.label || (typeof option.value === 'string' ? option.value : JSON.stringify(option.value));
+
 interface IOptionProps extends LiHTMLAttributes<HTMLLIElement> {
   option: IOption;
   isGrouped?: boolean;
@@ -41,7 +44,7 @@ const Option = ({ option, isGrouped, activeValue, selection, getOptionProps }: I
     {(Array.isArray(selection)
       ? selection.find(value => value.value === option.value) !== undefined
       : selection && selection.value === option.value) && '✓ '}
-    {option.label || option.value}
+    {toString(option)}
   </li>
 );
 
@@ -81,7 +84,7 @@ const Tags = ({ selection, getTagProps }: ITagsProps) => {
               return (
                 <td key={index} role={role} className="inline">
                   <button className="mr-1 px-1" disabled={option.disabled} {...props} type="button">
-                    {option.label || option.value}
+                    {toString(option)}
                   </button>
                 </td>
               );
@@ -278,9 +281,9 @@ export const ComboboxStory: Story<IArgs> = ({ as, ...props }) => {
           }
         });
 
-        const regex = new RegExp(value.replace(/\\/gu, '\\\\'), 'gui');
+        const regex = new RegExp(value.replace(/[.*+?^${}()|[\]\\]/giu, '\\$&'), 'gui');
 
-        setOptions(_options.filter(option => (option.label || option.value).match(regex)));
+        setOptions(_options.filter(option => toString(option).match(regex)));
       }
     }
   };

--- a/packages/combobox/src/ComboboxContainer.spec.tsx
+++ b/packages/combobox/src/ComboboxContainer.spec.tsx
@@ -819,7 +819,7 @@ describe('ComboboxContainer', () => {
                 selectionValue={['test-1', 'test-2']}
               />
             );
-          }).toThrow('to be a string');
+          }).toThrow('not to be an array');
 
           console.error = consoleError;
         });

--- a/packages/combobox/src/ComboboxContainer.spec.tsx
+++ b/packages/combobox/src/ComboboxContainer.spec.tsx
@@ -88,7 +88,7 @@ describe('ComboboxContainer', () => {
                 {Array.isArray(selection) &&
                   selection.map(option => (
                     <button
-                      key={option.value}
+                      key={option.value as string}
                       data-test-id={tagTestId}
                       disabled={option.disabled}
                       {...getTagProps({ 'aria-label': 'tag', option })}
@@ -107,7 +107,7 @@ describe('ComboboxContainer', () => {
                 {Array.isArray(selection) &&
                   selection.map(option => (
                     <button
-                      key={option.value}
+                      key={option.value as string}
                       data-test-id={tagTestId}
                       disabled={option.disabled}
                       {...getTagProps({ 'aria-label': 'tag', option })}
@@ -137,7 +137,7 @@ describe('ComboboxContainer', () => {
                     >
                       {option.options.map((groupOption, groupIndex) => (
                         <li
-                          key={groupOption.value || groupIndex}
+                          key={(groupOption.value as string) || groupIndex}
                           data-test-id={`${optionTestIdPrefix}-${index + 1}.${groupIndex + 1}`}
                           {...getOptionProps({ option: groupOption })}
                         >
@@ -148,7 +148,7 @@ describe('ComboboxContainer', () => {
                   </li>
                 ) : (
                   <li
-                    key={option.value || index}
+                    key={(option.value as string) || index}
                     data-test-id={`${optionTestIdPrefix}-${index + 1}`}
                     {...getOptionProps({ option })}
                   >

--- a/packages/combobox/src/ComboboxContainer.tsx
+++ b/packages/combobox/src/ComboboxContainer.tsx
@@ -43,6 +43,5 @@ ComboboxContainer.propTypes = {
 };
 
 ComboboxContainer.defaultProps = {
-  isAutocomplete: true,
   isEditable: true
 };

--- a/packages/combobox/src/types.ts
+++ b/packages/combobox/src/types.ts
@@ -8,7 +8,7 @@
 import { IUseFieldReturnValue } from '@zendeskgarden/container-field';
 import { HTMLProps, ReactNode, RefObject } from 'react';
 
-export type OptionValue = any;
+export type OptionValue = string | object;
 
 interface ISelectedOption {
   value: OptionValue;

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -19,7 +19,7 @@ import {
   UseComboboxStateChangeTypes as IDownshiftStateChangeType
 } from 'downshift';
 import { IOption, IUseComboboxProps, IUseComboboxReturnValue, OptionValue } from './types';
-import { toType } from './utils';
+import { toLabel, toType } from './utils';
 
 export const useCombobox = <
   T extends HTMLElement = HTMLElement,
@@ -63,7 +63,7 @@ export const useCombobox = <
   const [matchValue, setMatchValue] = useState('');
   const matchTimeoutRef = useRef<number>();
   const previousStateRef = useRef<IPreviousState>();
-  const labels: Record<OptionValue, string> = useMemo(() => ({}), []);
+  const labels: Record<string, string> = useMemo(() => ({}), []);
   const selectedValues: OptionValue[] = useMemo(() => [], []);
   const disabledValues: OptionValue[] = useMemo(() => [], []);
   const values = useMemo(() => {
@@ -87,7 +87,9 @@ export const useCombobox = <
         selectedValues.push(option.value);
       }
 
-      labels[option.value] = option.label || option.value;
+      const key = typeof option.value === 'string' ? option.value : JSON.stringify(option.value);
+
+      labels[key] = option.label || key;
     };
 
     options.forEach(option => {
@@ -101,7 +103,7 @@ export const useCombobox = <
     return retVal;
   }, [options, disabledValues, selectedValues, labels]);
   const initialSelectionValue = isMultiselectable ? selectedValues : selectedValues[0];
-  const initialInputValue = isMultiselectable ? '' : labels[initialSelectionValue];
+  const initialInputValue = isMultiselectable ? '' : toLabel(labels, initialSelectionValue);
   const _defaultActiveIndex = useMemo(() => {
     if (defaultActiveIndex === undefined) {
       return isAutocomplete && isEditable ? 0 : undefined;
@@ -126,7 +128,7 @@ export const useCombobox = <
         'Error: expected multiselectable useCombobox `selectionValue` to be an array.'
       );
     } else if (!isMultiselectable && Array.isArray(selectionValue)) {
-      throw new Error('Error: expected useCombobox `selectionValue` to be a string.');
+      throw new Error('Error: expected useCombobox `selectionValue` not to be an array.');
     }
   }
 
@@ -254,7 +256,7 @@ export const useCombobox = <
       return changes;
     };
 
-  const transformValue = (value: OptionValue | null) => (value ? labels[value] : '');
+  const transformValue = (value: OptionValue | null) => (value ? toLabel(labels, value) : '');
 
   /** Hooks */
 
@@ -451,7 +453,7 @@ export const useCombobox = <
               const valueIndex = (index + offset) % values.length;
               const value = values[valueIndex];
 
-              if (labels[value].toLowerCase().startsWith(_matchValue.toLowerCase())) {
+              if (toLabel(labels, value).toLowerCase().startsWith(_matchValue.toLowerCase())) {
                 setActiveIndex(valueIndex);
                 break;
               }
@@ -680,9 +682,13 @@ export const useCombobox = <
         ...other
       };
 
-      const ariaSelected = Array.isArray(_selectionValue)
-        ? _selectionValue?.includes(option?.value)
-        : _selectionValue === option?.value;
+      let ariaSelected = false;
+
+      if (option?.value !== undefined) {
+        ariaSelected = Array.isArray(_selectionValue)
+          ? _selectionValue?.includes(option?.value)
+          : _selectionValue === option?.value;
+      }
 
       if (option === undefined || option.disabled) {
         // Prevent downshift listbox mouse leave event.
@@ -713,7 +719,7 @@ export const useCombobox = <
         // Clear selection
         setDownshiftSelection(null);
       } else {
-        const removeValue = typeof value === 'object' ? value.value : value;
+        const removeValue = typeof value === 'object' && 'value' in value ? value.value : value;
 
         if (Array.isArray(_selectionValue) && _selectionValue.includes(removeValue)) {
           setDownshiftSelection(removeValue);
@@ -740,7 +746,7 @@ export const useCombobox = <
     } else if (_selectionValue) {
       return {
         value: _selectionValue,
-        label: labels[_selectionValue],
+        label: toLabel(labels, _selectionValue),
         disabled: disabledValues.includes(_selectionValue)
       };
     }

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -677,7 +677,6 @@ export const useCombobox = <
         'data-garden-container-id': 'containers.combobox.option',
         'data-garden-container-version': PACKAGE_VERSION,
         role,
-        'aria-disabled': option?.disabled,
         onMouseDown,
         ...other
       };
@@ -695,6 +694,7 @@ export const useCombobox = <
         const handleMouseDown = (event: MouseEvent) => event.preventDefault();
 
         return {
+          'aria-disabled': true,
           'aria-selected': ariaSelected,
           ...optionProps,
           onMouseDown: composeEventHandlers(onMouseDown, handleMouseDown)

--- a/packages/combobox/src/utils.ts
+++ b/packages/combobox/src/utils.ts
@@ -46,6 +46,14 @@ export const toType = (downshiftType: string) => {
   return typeMap[downshiftType] || downshiftType;
 };
 
+/**
+ * Convert the given option value to a label.
+ *
+ * @param labels A stored record of label key value pairs.
+ * @param value The value to convert to a valid key.
+ *
+ * @returns A label from the `labels` record based on the given value.
+ */
 export const toLabel = (labels: Record<string, string>, value: OptionValue) => {
   if (value === undefined) {
     return '';

--- a/packages/combobox/src/utils.ts
+++ b/packages/combobox/src/utils.ts
@@ -7,6 +7,7 @@
 
 import { KEYS } from '@zendeskgarden/container-utilities';
 import { useCombobox as useDownshift } from 'downshift';
+import { OptionValue } from './types';
 
 /** Map Downshift to Garden state change types */
 const typeMap: Record<string, string> = {
@@ -43,4 +44,14 @@ const typeMap: Record<string, string> = {
  */
 export const toType = (downshiftType: string) => {
   return typeMap[downshiftType] || downshiftType;
+};
+
+export const toLabel = (labels: Record<string, string>, value: OptionValue) => {
+  if (value === undefined) {
+    return '';
+  }
+
+  const key = typeof value === 'string' ? value : JSON.stringify(value);
+
+  return labels[key];
 };


### PR DESCRIPTION
- [x] **BREAKING CHANGE?**

## Description

The current `any` type is allowing the combobox to key on null-ish values such as `undefined` or `null`. Neither Downshift or Garden's useCombobox are geared to handle null-ish option values for selection, etc. This PR restricts the type, but still allows for complex `object` values. Allowing `number` was considered, but not applied due to the false-y case for `0` and the fact that numbers can easily be converted to strings by the consumer before providing them to the hook.

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
