### PR TITLE
fix(combobox): ensure listbox collapse on non-editable combobox blur

### DIFF
--- a/packages/combobox/.size-snapshot.json
+++ b/packages/combobox/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 24361,
-    "minified": 13109,
-    "gzipped": 3792
+    "bundled": 24428,
+    "minified": 13161,
+    "gzipped": 3795
   },
   "index.esm.js": {
-    "bundled": 23445,
-    "minified": 12194,
-    "gzipped": 3779,
+    "bundled": 23493,
+    "minified": 12227,
+    "gzipped": 3783,
     "treeshaked": {
       "rollup": {
         "code": 1296,
         "import_statements": 177
       },
       "webpack": {
-        "code": 12088
+        "code": 12127
       }
     }
   }

--- a/packages/combobox/src/ComboboxContainer.spec.tsx
+++ b/packages/combobox/src/ComboboxContainer.spec.tsx
@@ -986,6 +986,21 @@ describe('ComboboxContainer', () => {
       expect(input).toHaveAttribute('aria-expanded', 'false');
     });
 
+    it('handles listbox collapse on non-editable multiselectable blur', async () => {
+      const { getByTestId } = render(
+        <TestCombobox layout="Garden" options={[]} isEditable={false} isMultiselectable />
+      );
+      const trigger = getByTestId('trigger');
+
+      await user.click(trigger);
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+      await user.keyboard('{Tab}');
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+
     it('handles listbox collapse on unrelated focus', async () => {
       const { getByTestId } = render(<TestCombobox layout="Garden" options={[]} />);
       const input = getByTestId('input');

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -383,13 +383,13 @@ export const useCombobox = <
         ...other
       } as IDownshiftTriggerProps);
 
-      if (isEditable && triggerContainsInput) {
-        const handleBlur = (event: React.FocusEvent) => {
-          if (event.relatedTarget === null || !event.currentTarget?.contains(event.relatedTarget)) {
-            closeListbox();
-          }
-        };
+      const handleBlur = (event: React.FocusEvent) => {
+        if (event.relatedTarget === null || !event.currentTarget?.contains(event.relatedTarget)) {
+          closeListbox();
+        }
+      };
 
+      if (isEditable && triggerContainsInput) {
         const handleClick = (event: MouseEvent) => {
           if (disabled) {
             event.preventDefault();
@@ -469,6 +469,7 @@ export const useCombobox = <
           'aria-disabled': disabled || undefined,
           disabled: undefined,
           role: 'combobox',
+          onBlur: composeEventHandlers(onBlur, handleBlur),
           onKeyDown: composeEventHandlers(onKeyDown, onDownshiftKeyDown, handleKeyDown),
           tabIndex: disabled ? -1 : 0
         };


### PR DESCRIPTION
## Description

The current combobox "sticks" expanded when tabbing out for `isMultiselectable={true}` and `isEditable={false}`. This fix ensures that the listbox collapses when the non-editable combobox is blurred.

## Detail

The problem can currently be seen here: https://zendeskgarden.github.io/react-containers/?path=/story/packages-combobox--uncontrolled&args=isEditable:false;isMultiselectable:true

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
