### PR TITLE
fix(combobox): prevent Downshift from overriding controlled `activeIndex`

### DIFF
--- a/packages/combobox/.size-snapshot.json
+++ b/packages/combobox/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 24428,
-    "minified": 13161,
-    "gzipped": 3795
+    "bundled": 24507,
+    "minified": 13196,
+    "gzipped": 3808
   },
   "index.esm.js": {
-    "bundled": 23493,
-    "minified": 12227,
-    "gzipped": 3783,
+    "bundled": 23572,
+    "minified": 12262,
+    "gzipped": 3796,
     "treeshaked": {
       "rollup": {
         "code": 1296,
         "import_statements": 177
       },
       "webpack": {
-        "code": 12127
+        "code": 12162
       }
     }
   }

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -164,6 +164,9 @@ export const useCombobox = <
           if (previousStateRef.current?.altKey) {
             // Prevent option activation for autocomplete selection override.
             changes.highlightedIndex = -1;
+          } else if (previousStateRef.current?.isOpen) {
+            // Prevent Downshift from overriding controlled `highlightedIndex`.
+            return state;
           }
 
           break;


### PR DESCRIPTION
## Description

This update fixes for controlled component re-renders that reset `activeIndex` to the currently selected option. Needed to unblock `<Combobox>` HOC.