### PR TITLE
fix(combobox): handle controlled actions

### DIFF
--- a/packages/combobox/.size-snapshot.json
+++ b/packages/combobox/.size-snapshot.json
@@ -1,11 +1,11 @@
 {
   "index.cjs.js": {
-    "bundled": 24507,
+    "bundled": 24505,
     "minified": 13196,
-    "gzipped": 3808
+    "gzipped": 3810
   },
   "index.esm.js": {
-    "bundled": 23572,
+    "bundled": 23570,
     "minified": 12262,
     "gzipped": 3796,
     "treeshaked": {

--- a/packages/combobox/.size-snapshot.json
+++ b/packages/combobox/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 24505,
-    "minified": 13196,
-    "gzipped": 3810
+    "bundled": 25580,
+    "minified": 13856,
+    "gzipped": 3921
   },
   "index.esm.js": {
-    "bundled": 23570,
-    "minified": 12262,
-    "gzipped": 3796,
+    "bundled": 24583,
+    "minified": 12860,
+    "gzipped": 3904,
     "treeshaked": {
       "rollup": {
         "code": 1296,
         "import_statements": 177
       },
       "webpack": {
-        "code": 12162
+        "code": 12788
       }
     }
   }

--- a/packages/combobox/.size-snapshot.json
+++ b/packages/combobox/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 25578,
-    "minified": 13856,
-    "gzipped": 3921
+    "bundled": 26541,
+    "minified": 14252,
+    "gzipped": 4057
   },
   "index.esm.js": {
-    "bundled": 24581,
-    "minified": 12860,
-    "gzipped": 3904,
+    "bundled": 25526,
+    "minified": 13238,
+    "gzipped": 4039,
     "treeshaked": {
       "rollup": {
         "code": 1296,
         "import_statements": 177
       },
       "webpack": {
-        "code": 12788
+        "code": 13175
       }
     }
   }

--- a/packages/combobox/.size-snapshot.json
+++ b/packages/combobox/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 26541,
-    "minified": 14252,
-    "gzipped": 4057
+    "bundled": 25818,
+    "minified": 13961,
+    "gzipped": 3961
   },
   "index.esm.js": {
-    "bundled": 25526,
-    "minified": 13238,
-    "gzipped": 4039,
+    "bundled": 24815,
+    "minified": 12959,
+    "gzipped": 3942,
     "treeshaked": {
       "rollup": {
         "code": 1296,
         "import_statements": 177
       },
       "webpack": {
-        "code": 13175
+        "code": 12893
       }
     }
   }

--- a/packages/combobox/.size-snapshot.json
+++ b/packages/combobox/.size-snapshot.json
@@ -1,11 +1,11 @@
 {
   "index.cjs.js": {
-    "bundled": 25580,
+    "bundled": 25578,
     "minified": 13856,
     "gzipped": 3921
   },
   "index.esm.js": {
-    "bundled": 24583,
+    "bundled": 24581,
     "minified": 12860,
     "gzipped": 3904,
     "treeshaked": {

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -23,7 +23,7 @@
     "@babel/runtime": "^7.8.4",
     "@zendeskgarden/container-field": "^3.0.4",
     "@zendeskgarden/container-utilities": "^1.0.5",
-    "downshift": "^7.2.0"
+    "downshift": "^7.6.0"
   },
   "peerDependencies": {
     "prop-types": "^15.6.1",

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -209,10 +209,12 @@ export const useCombobox = <
         case useDownshift.stateChangeTypes.InputKeyDownEnter:
         case useDownshift.stateChangeTypes.FunctionSelectItem:
         case useDownshift.stateChangeTypes.ItemClick:
+          // Prevent selection from altering active index.
+          changes.highlightedIndex = state.highlightedIndex;
+
           if (isMultiselectable) {
             // A multiselectable combobox remains expanded on selection.
             changes.isOpen = state.isOpen;
-            changes.highlightedIndex = state.highlightedIndex;
             changes.inputValue = '';
           }
 

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -212,10 +212,12 @@ export const useCombobox = <
         case useDownshift.stateChangeTypes.InputKeyDownEnter:
         case useDownshift.stateChangeTypes.FunctionSelectItem:
         case useDownshift.stateChangeTypes.ItemClick:
+          // Prevent selection from altering active index.
+          changes.highlightedIndex = state.highlightedIndex;
+
           if (isMultiselectable) {
             // A multiselectable combobox remains expanded on selection.
             changes.isOpen = state.isOpen;
-            changes.highlightedIndex = state.highlightedIndex;
             changes.inputValue = '';
           }
 

--- a/packages/combobox/yarn.lock
+++ b/packages/combobox/yarn.lock
@@ -9,12 +9,40 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@reach/auto-id@^0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.18.0.tgz#4b97085cd1cf1360a9bedc6e9c78e97824014f0d"
+  integrity sha512-XwY1IwhM7mkHZFghhjiqjQ6dstbOdpbFLdggeke75u8/8icT8uEHLbovFUgzKjy9qPvYwZIB87rLiR8WdtOXCg==
+  dependencies:
+    "@reach/utils" "0.18.0"
+
+"@reach/utils@0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.18.0.tgz#4f3cebe093dd436eeaff633809bf0f68f4f9d2ee"
+  integrity sha512-KdVMdpTgDyK8FzdKO9SCpiibuy/kbv3pwgfXshTI6tEcQT1OOwj7BAksnzGC0rPz0UholwC+AgkqEl3EJX3M1A==
+
+"@zendeskgarden/container-field@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-field/-/container-field-3.0.4.tgz#620f7e04bad4dd0b97c62a9fc08111cb82cf41d0"
+  integrity sha512-mits6DF6Ndh0qp9EX9d1hZdl+DEqx2332V9WVAc3V247UfTrNAmnjv7bE1Z8PWJkzsHti9XKxt4+mfX0IdtkWA==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@zendeskgarden/container-utilities" "^1.0.5"
+
+"@zendeskgarden/container-utilities@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-1.0.5.tgz#f787e2d75471bbf684d5b1b0c0daabe6e23a0b18"
+  integrity sha512-9BEpLnAwSsDq4QgnGWhK/O/Fj+Q9daNGaSNNxqSfhkWj8h7HQDM4vU4gtu/mDEgDO8ubDE9Qeu+zytN/pdWqpQ==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@reach/auto-id" "^0.18.0"
+
 compute-scroll-into-view@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-2.0.4.tgz#2b444b2b9e4724819d2531efacb7ac094155fdf6"
   integrity sha512-y/ZA3BGnxoM/QHHQ2Uy49CLtnWPbt4tTPpEEZiEmmiWBFKjej7nEyH8Ryz54jH0MLXflUYA3Er2zUxPSJu5R+g==
 
-downshift@^7.2.0:
+downshift@^7.6.0:
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/downshift/-/downshift-7.6.0.tgz#de04fb2962bd6c4ea94589c797c91f34aa9816f3"
   integrity sha512-VSoTVynTAsabou/hbZ6HJHUVhtBiVOjQoBsCPcQq5eAROIGP+9XKMp9asAKQ3cEcUP4oe0fFdD2pziUjhFY33Q==


### PR DESCRIPTION
## Description

- prevent selection from altering active index
- handle controlled actions
- add disabled option ID
- scroll input into view on focus

This change fixes a flash of `aria-activedescendant` that occurs as the HOC listbox is animating collapsed and ensures controlled `onChange` handlers are called for Downshift actions (which rolls back #540).