### PR TITLE
feat(selection)!: updates container-selection to support react strict mode

### DIFF
--- a/packages/selection/.size-snapshot.json
+++ b/packages/selection/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 8158,
-    "minified": 3539,
-    "gzipped": 1318
+    "bundled": 8181,
+    "minified": 3554,
+    "gzipped": 1328
   },
   "index.esm.js": {
-    "bundled": 7887,
-    "minified": 3271,
-    "gzipped": 1298,
+    "bundled": 7910,
+    "minified": 3286,
+    "gzipped": 1307,
     "treeshaked": {
       "rollup": {
         "code": 190,
         "import_statements": 83
       },
       "webpack": {
-        "code": 3339
+        "code": 3354
       }
     }
   }

--- a/packages/selection/demo/selection.stories.mdx
+++ b/packages/selection/demo/selection.stories.mdx
@@ -2,6 +2,7 @@ import { Meta, ArgsTable, Canvas, Story, Markdown } from '@storybook/addon-docs'
 import { useArgs } from '@storybook/client-api';
 import { SelectionContainer } from '@zendeskgarden/container-selection';
 import { SelectionStory } from './stories/SelectionStory';
+import { ITEMS } from './stories/data';
 import README from '../README.md';
 
 <Meta
@@ -9,12 +10,12 @@ import README from '../README.md';
   component={SelectionContainer}
   args={{
     as: 'hook',
-    items: 3,
+    items: ITEMS,
     direction: 'horizontal'
   }}
   argTypes={{
     as: { options: ['container', 'hook'], control: 'radio', table: { category: 'Story' } },
-    items: { control: { type: 'range', min: 1, max: 5 }, table: { category: 'Story' } }
+    items: { table: { category: 'Story' } }
   }}
 />
 
@@ -30,9 +31,14 @@ import README from '../README.md';
   <Story
     name="Uncontrolled"
     args={{
-      defaultFocusedIndex: 0
+      defaultFocusedItem: 'item-1'
     }}
-    argTypes={{ selectedItem: { control: false }, focusedItem: { control: false } }}
+    argTypes={{
+      selectedItem: { control: false },
+      focusedItem: { control: false },
+      defaultFocusedItem: { control: { type: 'text' } },
+      defaultSelectedItem: { control: { type: 'text' } }
+    }}
   >
     {args => <SelectionStory {...args} />}
   </Story>
@@ -44,9 +50,14 @@ import README from '../README.md';
   <Story
     name="Controlled"
     args={{
-      selectedItem: '0'
+      selectedItem: 'item-3'
     }}
-    argTypes={{ defaultFocusedIndex: { control: false }, defaultSelectedIndex: { control: false } }}
+    argTypes={{
+      selectedItem: { control: { type: 'text' } },
+      focusedItem: { control: { type: 'text' } },
+      defaultFocusedItem: { control: false },
+      defaultSelectedItem: { control: false }
+    }}
   >
     {args => {
       const updateArgs = useArgs()[1];

--- a/packages/selection/demo/stories/SelectionStory.tsx
+++ b/packages/selection/demo/stories/SelectionStory.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { createRef, RefObject } from 'react';
+import React from 'react';
 import { Story } from '@storybook/react';
 import classNames from 'classnames';
 import {
@@ -19,7 +19,7 @@ import {
 interface IComponentProps extends IUseSelectionReturnValue<string> {
   direction: IUseSelectionProps<any>['direction'];
   rtl: IUseSelectionProps<any>['rtl'];
-  items: RefObject<HTMLLIElement>[];
+  items: string[];
 }
 
 const Component = ({
@@ -40,7 +40,7 @@ const Component = ({
   >
     {items.map((item, index) => (
       <li
-        key={index}
+        key={item}
         className={classNames(
           'flex',
           'justify-center',
@@ -56,46 +56,51 @@ const Component = ({
             [`mt-${index * 4}`]: direction === 'both'
           }
         )}
-        {...getItemProps({ item: index.toString(), focusRef: item })}
+        {...getItemProps({ item })}
       >
-        {index.toString() === selectedItem && <span className="text-lg">✓</span>}
+        {item === selectedItem && <span className="text-lg">✓</span>}
       </li>
     ))}
   </ul>
 );
 
 interface IProps extends IUseSelectionProps<string> {
-  itemRefs: RefObject<HTMLLIElement>[];
+  items: string[];
 }
 
-const Container = ({ itemRefs, ...props }: IProps) => (
+const Container = ({ ...props }: IProps) => (
   <SelectionContainer {...props}>
     {containerProps => (
-      <Component items={itemRefs} direction={props.direction} rtl={props.rtl} {...containerProps} />
+      <Component
+        items={props.items}
+        direction={props.direction}
+        rtl={props.rtl}
+        {...containerProps}
+      />
     )}
   </SelectionContainer>
 );
 
-const Hook = ({ itemRefs, ...props }: IProps) => {
-  const hookProps = useSelection(props);
+const Hook = ({ ...props }: IProps) => {
+  const hookProps = useSelection({ ...props });
 
-  return <Component items={itemRefs} direction={props.direction} rtl={props.rtl} {...hookProps} />;
+  return (
+    <Component items={props.items} direction={props.direction} rtl={props.rtl} {...hookProps} />
+  );
 };
 
-interface IArgs extends ISelectionContainerProps<any> {
+interface IArgs extends ISelectionContainerProps<string> {
   as: 'hook' | 'container';
-  items: number;
+  items: string[];
 }
 
-export const SelectionStory: Story<IArgs> = ({ as, items, ...props }: IArgs) => {
-  const itemRefs = Array.from({ length: items }, () => createRef<HTMLLIElement>());
-
+export const SelectionStory: Story<IArgs> = ({ as, ...props }: IArgs) => {
   switch (as) {
     case 'container':
-      return <Container itemRefs={itemRefs} {...props} />;
+      return <Container {...props} />;
 
     case 'hook':
     default:
-      return <Hook itemRefs={itemRefs} {...props} />;
+      return <Hook {...props} />;
   }
 };

--- a/packages/selection/demo/stories/data.ts
+++ b/packages/selection/demo/stories/data.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+export const ITEMS: string[] = ['item-1', 'item-2', 'item-3', 'item-4', 'item-5'];

--- a/packages/selection/package.json
+++ b/packages/selection/package.json
@@ -21,7 +21,8 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@babel/runtime": "^7.8.4",
-    "@zendeskgarden/container-utilities": "^1.0.6"
+    "@zendeskgarden/container-utilities": "^1.0.6",
+    "react-merge-refs": "^2.0.2"
   },
   "peerDependencies": {
     "prop-types": "^15.6.1",

--- a/packages/selection/src/SelectionContainer.tsx
+++ b/packages/selection/src/SelectionContainer.tsx
@@ -17,17 +17,17 @@ export const SelectionContainer: React.FC<ISelectionContainerProps<any>> = ({
 }) => <>{render!(useSelection(options))}</>;
 
 SelectionContainer.defaultProps = {
-  direction: 'horizontal',
-  defaultFocusedIndex: 0
+  direction: 'horizontal'
 };
 
 SelectionContainer.propTypes = {
   children: PropTypes.func,
   render: PropTypes.func,
+  items: PropTypes.arrayOf(PropTypes.string).isRequired,
   rtl: PropTypes.bool,
   direction: PropTypes.oneOf(['horizontal', 'vertical', 'both']),
-  defaultFocusedIndex: PropTypes.number,
-  defaultSelectedIndex: PropTypes.number,
+  defaultFocusedItem: PropTypes.string,
+  defaultSelectedItem: PropTypes.string,
   focusedItem: PropTypes.any,
   selectedItem: PropTypes.any,
   onSelect: PropTypes.func,

--- a/packages/selection/src/types.ts
+++ b/packages/selection/src/types.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { HTMLProps, ReactNode, MutableRefObject } from 'react';
+import { HTMLProps, ReactNode, RefObject } from 'react';
 
 export interface IUseSelectionProps<Item> {
   /** The array of IDs used for managing selection */
@@ -47,7 +47,7 @@ export interface IUseSelectionReturnValue<Item> {
   getItemProps: <T extends Element>(
     props: Omit<HTMLProps<T>, 'role'> & {
       item: Item;
-      focusRef?: MutableRefObject<T>;
+      focusRef?: RefObject<T>;
       refKey?: string;
       role?: 'option' | null;
       selectedAriaKey?: any;

--- a/packages/selection/src/types.ts
+++ b/packages/selection/src/types.ts
@@ -5,15 +5,17 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { HTMLProps, ReactNode, RefObject } from 'react';
+import { HTMLProps, ReactNode, MutableRefObject } from 'react';
 
 export interface IUseSelectionProps<Item> {
+  /** The array of IDs used for managing selection */
+  items: Item[];
   /** Determines the orientation of the selection */
   direction?: 'horizontal' | 'vertical' | 'both';
   /** Sets the initial focused item */
-  defaultFocusedIndex?: number;
+  defaultFocusedItem?: Item;
   /** Sets the initial selected item */
-  defaultSelectedIndex?: number;
+  defaultSelectedItem?: Item;
   /** Determines right-to-left layout */
   rtl?: boolean;
   /** Sets controlled item selection */
@@ -45,7 +47,7 @@ export interface IUseSelectionReturnValue<Item> {
   getItemProps: <T extends Element>(
     props: Omit<HTMLProps<T>, 'role'> & {
       item: Item;
-      focusRef: RefObject<T>;
+      focusRef?: MutableRefObject<T>;
       refKey?: string;
       role?: 'option' | null;
       selectedAriaKey?: any;

--- a/packages/selection/yarn.lock
+++ b/packages/selection/yarn.lock
@@ -9,6 +9,11 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+react-merge-refs@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-2.0.2.tgz#73f576111124897dec4ea56035a97e199e8cb377"
+  integrity sha512-V5BGTwGa2r+/t0A/BZMS6L7VPXY0CU8xtAhkT3XUoI1WJJhhtvulvoiZkJ5Jt9YAW23m4xFWmhQ+C5HwjtTFhQ==
+
 regenerator-runtime@^0.13.11:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"

--- a/packages/tabs/demo/stories/TabsStory.tsx
+++ b/packages/tabs/demo/stories/TabsStory.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { createRef, RefObject } from 'react';
+import React from 'react';
 import { Story } from '@storybook/react';
 import {
   ITabsContainerProps,
@@ -16,108 +16,123 @@ import {
 } from '@zendeskgarden/container-tabs';
 import classNames from 'classnames';
 
+interface TabItemProps {
+  item: string;
+  getTabProps: IUseTabsReturnValue<string>['getTabProps'];
+  selectedItem: IUseTabsReturnValue<string>['selectedItem'];
+  orientation: IUseTabsProps<string>['orientation'];
+  rtl?: IUseTabsProps<string>['rtl'];
+}
+
+const TabItem = ({ item, getTabProps, selectedItem, orientation, rtl }: TabItemProps) => (
+  <li
+    key={item}
+    {...getTabProps({ item })}
+    className={classNames(
+      'border-3',
+      'border-solid',
+      'border-transparent',
+      'cursor-pointer',
+      'px-2',
+      'py-1',
+      {
+        'border-b-blue-600': selectedItem === item && orientation !== 'vertical',
+        'border-r-blue-600': selectedItem === item && orientation === 'vertical' && !rtl,
+        'border-l-blue-600': selectedItem === item && orientation === 'vertical' && rtl
+      }
+    )}
+  >
+    {item}
+  </li>
+);
+
 interface IComponentProps extends IUseTabsReturnValue<string> {
-  tabs: RefObject<HTMLLIElement>[];
+  items: IUseTabsProps<string>['items'];
   orientation: IUseTabsProps<any>['orientation'];
   rtl: IUseTabsProps<any>['rtl'];
 }
 
 const Component = ({
-  tabs,
+  items,
   getTabListProps,
   getTabPanelProps,
   getTabProps,
   selectedItem,
   orientation,
   rtl
-}: IComponentProps) => (
-  <div
-    className={classNames({
-      flex: orientation === 'vertical',
-      'flex-row-reverse': orientation === 'vertical' && rtl
-    })}
-  >
-    <ul
-      {...getTabListProps()}
-      className={classNames('border-solid', 'border-transparent', 'flex', {
-        'flex-col': orientation === 'vertical',
-        'border-b-grey-600': orientation !== 'vertical',
-        'flex-row-reverse': orientation !== 'vertical' && rtl,
-        'border-r-grey-600': orientation === 'vertical' && !rtl,
-        'border-l-grey-600': orientation === 'vertical' && rtl
+}: IComponentProps) => {
+  return (
+    <div
+      className={classNames({
+        flex: orientation === 'vertical',
+        'flex-row-reverse': orientation === 'vertical' && rtl
       })}
     >
-      {tabs.map((tab, index) => (
-        <li
-          key={index}
-          {...getTabProps({ index, item: index.toString(), focusRef: tab })}
-          className={classNames(
-            'border-3',
-            'border-solid',
-            'border-transparent',
-            'cursor-pointer',
-            'px-2',
-            'py-1',
-            {
-              'border-b-blue-600': selectedItem === index.toString() && orientation !== 'vertical',
-              'border-r-blue-600':
-                selectedItem === index.toString() && orientation === 'vertical' && !rtl,
-              'border-l-blue-600':
-                selectedItem === index.toString() && orientation === 'vertical' && rtl
-            }
-          )}
-        >{`Tab ${index + 1}`}</li>
+      <ul
+        {...getTabListProps()}
+        className={classNames('border-solid', 'border-transparent', 'flex', {
+          'flex-col': orientation === 'vertical',
+          'border-b-grey-600': orientation !== 'vertical',
+          'flex-row-reverse': orientation !== 'vertical' && rtl,
+          'border-r-grey-600': orientation === 'vertical' && !rtl,
+          'border-l-grey-600': orientation === 'vertical' && rtl
+        })}
+      >
+        {items.map(item => (
+          <TabItem
+            key={item}
+            item={item}
+            getTabProps={getTabProps}
+            selectedItem={selectedItem}
+            orientation={orientation}
+            rtl={rtl}
+          />
+        ))}
+      </ul>
+      {items.map(item => (
+        <div key={item} {...getTabPanelProps({ item })} className="p-2">
+          {item}
+        </div>
       ))}
-    </ul>
-    {tabs.map((_, index) => (
-      <div
-        key={index}
-        {...getTabPanelProps({ index, item: index.toString() })}
-        className="p-2"
-      >{`Panel ${index + 1}`}</div>
-    ))}
-  </div>
-);
+    </div>
+  );
+};
 
 interface IProps extends IUseTabsProps<string> {
-  tabRefs: RefObject<HTMLLIElement>[];
+  items: IUseTabsProps<string>['items'];
 }
 
-const Container = ({ tabRefs, ...props }: IProps) => (
-  <TabsContainer {...props}>
-    {containerProps => (
-      <Component
-        tabs={tabRefs}
-        orientation={props.orientation}
-        rtl={props.rtl}
-        {...containerProps}
-      />
-    )}
-  </TabsContainer>
-);
-
-const Hook = ({ tabRefs, ...props }: IProps) => {
-  const hookProps = useTabs(props);
+const Container = (props: IProps) => {
+  const { rtl, orientation, items } = props;
 
   return (
-    <Component tabs={tabRefs} orientation={props.orientation} rtl={props.rtl} {...hookProps} />
+    <TabsContainer {...props}>
+      {containerProps => (
+        <Component items={items} orientation={orientation} rtl={rtl} {...containerProps} />
+      )}
+    </TabsContainer>
   );
+};
+
+const Hook = (props: IProps) => {
+  const { items, orientation, rtl } = props;
+  const hookProps = useTabs(props);
+
+  return <Component items={items} orientation={orientation} rtl={rtl} {...hookProps} />;
 };
 
 interface IArgs extends ITabsContainerProps<string> {
   as: 'hook' | 'container';
-  tabs: number;
+  items: IUseTabsProps<string>['items'];
 }
 
-export const TabsStory: Story<IArgs> = ({ as, tabs, ...props }: IArgs) => {
-  const tabRefs = Array.from({ length: tabs }, () => createRef<HTMLLIElement>());
-
+export const TabsStory: Story<IArgs> = ({ as, ...props }: IArgs) => {
   switch (as) {
     case 'container':
-      return <Container tabRefs={tabRefs} {...props} />;
+      return <Container {...props} />;
 
     case 'hook':
     default:
-      return <Hook tabRefs={tabRefs} {...props} />;
+      return <Hook {...props} />;
   }
 };

--- a/packages/tabs/demo/stories/data.ts
+++ b/packages/tabs/demo/stories/data.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+export const ITEMS: string[] = ['tab-1', 'tab-2', 'tab-3', 'tab-4', 'tab-5'];

--- a/packages/tabs/demo/tabs.stories.mdx
+++ b/packages/tabs/demo/tabs.stories.mdx
@@ -2,6 +2,7 @@ import { Meta, ArgsTable, Canvas, Story, Markdown } from '@storybook/addon-docs'
 import { useArgs } from '@storybook/client-api';
 import { TabsContainer } from '@zendeskgarden/container-tabs';
 import { TabsStory } from './stories/TabsStory';
+import { ITEMS } from './stories/data';
 import README from '../README.md';
 
 <Meta
@@ -9,11 +10,12 @@ import README from '../README.md';
   component={TabsContainer}
   args={{
     as: 'hook',
-    tabs: 3
+    tabs: 3,
+    items: ITEMS
   }}
   argTypes={{
     as: { options: ['container', 'hook'], control: 'radio', table: { category: 'Story' } },
-    tabs: { control: { type: 'range', min: 1, max: 5 }, table: { category: 'Story' } }
+    tabs: { table: { category: 'Story' } }
   }}
 />
 
@@ -28,9 +30,7 @@ import README from '../README.md';
 <Canvas>
   <Story
     name="Uncontrolled"
-    args={{
-      defaultSelectedIndex: 0
-    }}
+    args={{ defaultSelectedItem: ITEMS[0] }}
     argTypes={{ selectedItem: { control: false } }}
   >
     {args => <TabsStory {...args} />}
@@ -42,10 +42,8 @@ import README from '../README.md';
 <Canvas>
   <Story
     name="Controlled"
-    args={{
-      selectedItem: '0'
-    }}
-    argTypes={{ defaultSelectedIndex: { control: false } }}
+    args={{ selectedItem: ITEMS[0] }}
+    argTypes={{ defaultSelectedItem: { control: false } }}
   >
     {args => {
       const updateArgs = useArgs()[1];

--- a/packages/tabs/src/types.ts
+++ b/packages/tabs/src/types.ts
@@ -9,6 +9,8 @@ import { IUseSelectionProps, IUseSelectionReturnValue } from '@zendeskgarden/con
 import { HTMLProps, ReactNode, RefObject } from 'react';
 
 export interface IUseTabsProps<Item> extends Omit<IUseSelectionProps<Item>, 'direction'> {
+  /** The array of IDs used for managing selection */
+  items: Item[];
   /** Determines the orientation of the tabs */
   orientation?: 'horizontal' | 'vertical';
   /** Prefixes IDs for tab elements */
@@ -24,16 +26,14 @@ export interface IUseTabsReturnValue<Item>
   ) => HTMLProps<T>;
   getTabProps: <T extends Element>(
     props: Omit<HTMLProps<T>, 'role'> & {
-      index: number;
       item: Item;
-      focusRef: RefObject<T>;
+      focusRef?: RefObject<T>;
       refKey?: string;
       role?: 'tab' | null;
     }
   ) => HTMLProps<T>;
   getTabPanelProps: <T extends Element>(
     props: Omit<HTMLProps<T>, 'role'> & {
-      index: number;
       item: Item;
       role?: 'tabpanel' | null;
     }

--- a/packages/tabs/src/useTabs.ts
+++ b/packages/tabs/src/useTabs.ts
@@ -10,16 +10,18 @@ import { useSelection } from '@zendeskgarden/container-selection';
 import { IUseTabsProps, IUseTabsReturnValue } from './types';
 
 export const useTabs = <Item>({
+  items,
   orientation = 'horizontal',
   idPrefix,
   ...options
-}: IUseTabsProps<Item> = {}): IUseTabsReturnValue<Item> => {
+}: IUseTabsProps<Item>): IUseTabsReturnValue<Item> => {
   const prefix = useId(idPrefix);
   const PANEL_ID = `${prefix}__panel`;
   const TAB_ID = `${prefix}__tab`;
   const { selectedItem, focusedItem, getContainerProps, getItemProps } = useSelection<Item>({
+    items,
     direction: orientation,
-    defaultSelectedIndex: 0,
+    defaultSelectedItem: items[0],
     ...options
   });
 
@@ -36,25 +38,24 @@ export const useTabs = <Item>({
 
   const getTabProps: IUseTabsReturnValue<Item>['getTabProps'] = ({
     role = 'tab',
-    index,
+    item,
     ...other
   }) => ({
-    ...getItemProps(other),
+    ...getItemProps({ item, ...other }),
     role: role === null ? undefined : role,
-    id: `${TAB_ID}:${index}`,
-    'aria-controls': `${PANEL_ID}:${index}`
+    id: `${TAB_ID}:${item}`,
+    'aria-controls': `${PANEL_ID}:${item}`
   });
 
   const getTabPanelProps: IUseTabsReturnValue<Item>['getTabPanelProps'] = ({
     role = 'tabpanel',
-    index,
     item,
     ...other
   }) => ({
     role: role === null ? undefined : role,
-    id: `${PANEL_ID}:${index}`,
+    id: `${PANEL_ID}:${item}`,
     hidden: item !== selectedItem,
-    'aria-labelledby': `${TAB_ID}:${index}`,
+    'aria-labelledby': `${TAB_ID}:${item}`,
     ...other
   });
 


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Updates `container-selection` (and subsequently `container-tabs`) to not rely on indices when gathering and using selection items.

⚠️ This is a breaking change due to API necessary changes.

## Detail

This fix is motivated by the need to support React Strict Mode. In this case, React remounts multiple times in development mode to weed out impure render effects. More info [here](https://react.dev/reference/react/StrictMode).

For `container-selection`, instead of building a list of `items` and `refs` from `useSelection`'s `getItemProps` prop getter, all `items` are required as an argument to `useSelection` (or `SelectionContainer`) directly.

### Downstream effects

As mentioned, `container-tabs` has been updated to consume the new API. These containers also rely on `container-selection`, but they can be deprecated since their behavior is undesirable:

- `buttongroup`
- `treeview`
- `pagination`

Subsequent components will be updated (or removed) in a future major version (likely `v9`).

## Checklist

- [ ] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :guardsman: includes new unit tests
- [ ] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [ ] :memo: tested in Chrome, Firefox, Safari, and Edge
