### PR TITLE
fix(combobox): prevent page scroll on input focus

### DIFF
--- a/packages/combobox/.size-snapshot.json
+++ b/packages/combobox/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 25811,
-    "minified": 13958,
-    "gzipped": 3957
+    "bundled": 25845,
+    "minified": 13975,
+    "gzipped": 3972
   },
   "index.esm.js": {
-    "bundled": 24808,
-    "minified": 12956,
-    "gzipped": 3939,
+    "bundled": 24842,
+    "minified": 12973,
+    "gzipped": 3951,
     "treeshaked": {
       "rollup": {
         "code": 1296,
         "import_statements": 177
       },
       "webpack": {
-        "code": 12890
+        "code": 12907
       }
     }
   }

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -415,7 +415,7 @@ export const useCombobox = <
   useEffect(() => {
     if (isEditable && inputRef.current === win.document.activeElement) {
       // Scroll input into view on focus.
-      inputRef.current?.scrollIntoView && inputRef.current?.scrollIntoView();
+      inputRef.current?.scrollIntoView && inputRef.current?.scrollIntoView({ block: 'nearest' });
     }
   }, [inputRef, isEditable, win.document.activeElement]);
 


### PR DESCRIPTION
## Description

The `{ block: 'start' }` default for [scrollIntoView](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) causes a page to scroll whenever a combobox is focused. The updated `{ block: 'nearest' }` brings the input into view (if it is scrolled due to multiselectable tags, for example) without scrolling the page.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :guardsman: ~includes new unit tests~
- [ ] :wheelchair: ~tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance~
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
