### PR TITLE
fix(combobox): prevent multiselectable from retaining focus on tag removal

### DIFF
--- a/packages/combobox/.size-snapshot.json
+++ b/packages/combobox/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 25845,
-    "minified": 13975,
-    "gzipped": 3972
+    "bundled": 25990,
+    "minified": 14055,
+    "gzipped": 3985
   },
   "index.esm.js": {
-    "bundled": 24842,
-    "minified": 12973,
-    "gzipped": 3951,
+    "bundled": 24979,
+    "minified": 13045,
+    "gzipped": 3966,
     "treeshaked": {
       "rollup": {
         "code": 1296,
         "import_statements": 177
       },
       "webpack": {
-        "code": 12907
+        "code": 12979
       }
     }
   }

--- a/packages/combobox/src/ComboboxContainer.spec.tsx
+++ b/packages/combobox/src/ComboboxContainer.spec.tsx
@@ -555,6 +555,11 @@ describe('ComboboxContainer', () => {
           await user.keyboard('{Delete}');
 
           expect(listboxOptions[3]).toHaveAttribute('aria-selected', 'false');
+          expect(input).toHaveFocus();
+
+          await user.keyboard('{Tab}');
+
+          expect(input).not.toHaveFocus();
         });
       });
 

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -409,6 +409,11 @@ export const useCombobox = <
       } else {
         triggerRef.current?.focus();
       }
+
+      previousStateRef.current = {
+        ...previousStateRef.current,
+        type: useDownshift.stateChangeTypes.InputFocus
+      };
     }
   });
 


### PR DESCRIPTION
## Description

Fixes an issue where the input retains focus under the following circumstances:
1) user removes a tag
2) and then attempts to navigate away from the component

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
