### PR TITLE
fix(combobox): handle select-only collapse listbox on space/enter

### DIFF
--- a/packages/combobox/.size-snapshot.json
+++ b/packages/combobox/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 25990,
-    "minified": 14055,
-    "gzipped": 3987
+    "bundled": 26606,
+    "minified": 14322,
+    "gzipped": 4032
   },
   "index.esm.js": {
-    "bundled": 24979,
-    "minified": 13045,
-    "gzipped": 3967,
+    "bundled": 25519,
+    "minified": 13236,
+    "gzipped": 4012,
     "treeshaked": {
       "rollup": {
         "code": 1296,
         "import_statements": 177
       },
       "webpack": {
-        "code": 12979
+        "code": 13181
       }
     }
   }

--- a/packages/combobox/src/ComboboxContainer.spec.tsx
+++ b/packages/combobox/src/ComboboxContainer.spec.tsx
@@ -604,7 +604,7 @@ describe('ComboboxContainer', () => {
 
           expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
-          await user.keyboard('{Escape}');
+          await user.keyboard('{Enter}');
 
           expect(trigger).toHaveAttribute('aria-expanded', 'false');
         });


### PR DESCRIPTION
## Description

For select-only (`isEditable={false}`) combobox:
- Adds `preventDefault` to avoid page scroll when pressing keyboard `space`
- Attaches same ☝️ behavior to tags for `isMultiselectable`
- Adds selection on `enter`/`space`

## Detail

Reference https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/#kbd_label

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
