### PR TITLE
fix(tabs): minimize re-rendering of container by memoization

### DIFF
--- a/packages/tabs/.size-snapshot.json
+++ b/packages/tabs/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 3219,
-    "minified": 1851,
-    "gzipped": 800
+    "bundled": 3488,
+    "minified": 1986,
+    "gzipped": 852
   },
   "index.esm.js": {
-    "bundled": 3119,
-    "minified": 1758,
-    "gzipped": 780,
+    "bundled": 3377,
+    "minified": 1881,
+    "gzipped": 839,
     "treeshaked": {
       "rollup": {
         "code": 238,
         "import_statements": 126
       },
       "webpack": {
-        "code": 1878
+        "code": 2012
       }
     }
   }


### PR DESCRIPTION
## Description

Optimizes the `useTabs` hook for more performant consumption.

## Detail

By memoizing callbacks and the return value of `useTabs` container, this will reduce re-rendering (and recomputing) of consuming components on every render. The use of `useCallback` and `useMemo` will persist object references until it is necessary to update.

## Checklist

- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :wheelchair: ~tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
