### PR TITLE
fix(utilities): remove unused prop-types peerDep from container-utilities

### DIFF
--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -24,7 +24,6 @@
     "@reach/auto-id": "^0.18.0"
   },
   "peerDependencies": {
-    "prop-types": "^15.6.1",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   },


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(selection):
     add keydown event to handle rtl". the title informs the semantic
     version bump if this PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

This removes `prop-types` from `peerDependencies` in `react-containers`. It isn't being used within `react-containers` and causes a warning to be displayed if you install the package and don't have `prop-types` installed in your `package.json`.

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :guardsman: includes new unit tests
- [ ] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [ ] :memo: tested in Chrome, Firefox, Safari, and Edge
