### PR TITLE
chore(deps): remove babel runtime from deps and improve build pipeline

### DIFF
--- a/packages/.template/package.json
+++ b/packages/.template/package.json
@@ -19,9 +19,6 @@
   },
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
-  "dependencies": {
-    "@babel/runtime": "^7.8.4"
-  },
   "peerDependencies": {
     "prop-types": "^15.6.1",
     "react": ">=16.8.0",

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -20,7 +20,6 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@babel/runtime": "^7.8.4",
     "@zendeskgarden/container-utilities": "^1.0.7",
     "react-uid": "^2.2.0"
   },

--- a/packages/accordion/yarn.lock
+++ b/packages/accordion/yarn.lock
@@ -2,24 +2,12 @@
 # yarn lockfile v1
 
 
-"@babel/runtime@^7.8.4":
-  version "7.22.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.6.tgz#57d64b9ae3cff1d67eb067ae117dac087f5bd438"
-  integrity sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==
-  dependencies:
-    regenerator-runtime "^0.13.11"
-
 react-uid@^2.2.0:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/react-uid/-/react-uid-2.3.3.tgz#6a485ccc868555997f3506c6db97a3e735d97adf"
   integrity sha512-iNpDovcb9qBpBTo8iUgqRSQOS8GV3bWoNaTaUptHkXtAooXSo0OWe7vN6TqqB8x3x0bNBbQx96kkmSltQ5h9kQ==
   dependencies:
     tslib "^2.0.0"
-
-regenerator-runtime@^0.13.11:
-  version "0.13.11"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
-  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 tslib@^2.0.0:
   version "2.5.3"

--- a/packages/breadcrumb/package.json
+++ b/packages/breadcrumb/package.json
@@ -19,9 +19,6 @@
   },
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
-  "dependencies": {
-    "@babel/runtime": "^7.8.4"
-  },
   "peerDependencies": {
     "prop-types": "^15.6.1",
     "react": ">=16.8.0",

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -20,7 +20,6 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@babel/runtime": "^7.8.4",
     "@zendeskgarden/container-field": "^3.0.6",
     "@zendeskgarden/container-utilities": "^1.0.7",
     "downshift": "^7.6.0"

--- a/packages/combobox/yarn.lock
+++ b/packages/combobox/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@babel/runtime@^7.14.8", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.14.8":
   version "7.22.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.6.tgz#57d64b9ae3cff1d67eb067ae117dac087f5bd438"
   integrity sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==

--- a/packages/field/package.json
+++ b/packages/field/package.json
@@ -20,7 +20,6 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@babel/runtime": "^7.8.4",
     "@zendeskgarden/container-utilities": "^1.0.7"
   },
   "peerDependencies": {

--- a/packages/focusjail/.size-snapshot.json
+++ b/packages/focusjail/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 4131,
-    "minified": 2106,
-    "gzipped": 916
+    "bundled": 3864,
+    "minified": 1963,
+    "gzipped": 860
   },
   "index.esm.js": {
-    "bundled": 4053,
-    "minified": 2030,
-    "gzipped": 910,
+    "bundled": 3783,
+    "minified": 1889,
+    "gzipped": 855,
     "treeshaked": {
       "rollup": {
-        "code": 158,
-        "import_statements": 100
+        "code": 192,
+        "import_statements": 134
       },
       "webpack": {
-        "code": 2001
+        "code": 1950
       }
     }
   }

--- a/packages/focusjail/package.json
+++ b/packages/focusjail/package.json
@@ -20,7 +20,6 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@babel/runtime": "^7.8.4",
     "@zendeskgarden/container-utilities": "^1.0.7",
     "dom-helpers": "^5.1.0",
     "tabbable": "^6.0.0"

--- a/packages/focusjail/yarn.lock
+++ b/packages/focusjail/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.8.7":
   version "7.22.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.6.tgz#57d64b9ae3cff1d67eb067ae117dac087f5bd438"
   integrity sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==

--- a/packages/focusvisible/package.json
+++ b/packages/focusvisible/package.json
@@ -19,9 +19,6 @@
   },
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
-  "dependencies": {
-    "@babel/runtime": "^7.8.4"
-  },
   "peerDependencies": {
     "prop-types": "^15.6.1",
     "react": ">=16.8.0",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -20,7 +20,6 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@babel/runtime": "^7.8.4",
     "@zendeskgarden/container-utilities": "^1.0.7"
   },
   "peerDependencies": {

--- a/packages/keyboardfocus/package.json
+++ b/packages/keyboardfocus/package.json
@@ -20,7 +20,6 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@babel/runtime": "^7.8.4",
     "@zendeskgarden/container-utilities": "^1.0.7"
   },
   "peerDependencies": {

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -20,7 +20,6 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@babel/runtime": "^7.8.4",
     "@zendeskgarden/container-focusjail": "^2.0.7",
     "@zendeskgarden/container-utilities": "^1.0.7"
   },

--- a/packages/schedule/package.json
+++ b/packages/schedule/package.json
@@ -19,9 +19,6 @@
   },
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
-  "dependencies": {
-    "@babel/runtime": "^7.8.4"
-  },
   "peerDependencies": {
     "prop-types": "^15.6.1",
     "react": ">=16.8.0",

--- a/packages/scrollregion/package.json
+++ b/packages/scrollregion/package.json
@@ -20,7 +20,6 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@babel/runtime": "^7.8.4",
     "lodash.debounce": "^4.0.8",
     "prop-types": "^15.7.2"
   },

--- a/packages/scrollregion/yarn.lock
+++ b/packages/scrollregion/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-"@babel/runtime@^7.8.4":
-  version "7.22.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.6.tgz#57d64b9ae3cff1d67eb067ae117dac087f5bd438"
-  integrity sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==
-  dependencies:
-    regenerator-runtime "^0.13.11"
-
 "@types/lodash.debounce@4.0.7":
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/@types/lodash.debounce/-/lodash.debounce-4.0.7.tgz#0285879defb7cdb156ae633cecd62d5680eded9f"
@@ -56,8 +49,3 @@ react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
-regenerator-runtime@^0.13.11:
-  version "0.13.11"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
-  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==

--- a/packages/selection/package.json
+++ b/packages/selection/package.json
@@ -20,7 +20,6 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@babel/runtime": "^7.8.4",
     "@zendeskgarden/container-utilities": "^1.0.7"
   },
   "peerDependencies": {

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -20,7 +20,6 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@babel/runtime": "^7.8.4",
     "lodash.debounce": "^4.0.8"
   },
   "peerDependencies": {

--- a/packages/slider/yarn.lock
+++ b/packages/slider/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-"@babel/runtime@^7.8.4":
-  version "7.22.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.6.tgz#57d64b9ae3cff1d67eb067ae117dac087f5bd438"
-  integrity sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==
-  dependencies:
-    regenerator-runtime "^0.13.11"
-
 "@types/lodash.debounce@4.0.7":
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/@types/lodash.debounce/-/lodash.debounce-4.0.7.tgz#0285879defb7cdb156ae633cecd62d5680eded9f"
@@ -25,8 +18,3 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
-
-regenerator-runtime@^0.13.11:
-  version "0.13.11"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
-  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==

--- a/packages/splitter/package.json
+++ b/packages/splitter/package.json
@@ -20,7 +20,6 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@babel/runtime": "^7.8.4",
     "@zendeskgarden/container-utilities": "^1.0.7"
   },
   "peerDependencies": {

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -20,7 +20,6 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@babel/runtime": "^7.8.4",
     "@zendeskgarden/container-selection": "^3.0.1",
     "@zendeskgarden/container-utilities": "^1.0.7"
   },

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -20,7 +20,6 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@babel/runtime": "^7.8.4",
     "@zendeskgarden/container-utilities": "^1.0.7",
     "react-uid": "^2.2.0"
   },

--- a/packages/tooltip/yarn.lock
+++ b/packages/tooltip/yarn.lock
@@ -2,24 +2,12 @@
 # yarn lockfile v1
 
 
-"@babel/runtime@^7.8.4":
-  version "7.22.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.6.tgz#57d64b9ae3cff1d67eb067ae117dac087f5bd438"
-  integrity sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==
-  dependencies:
-    regenerator-runtime "^0.13.11"
-
 react-uid@^2.2.0:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/react-uid/-/react-uid-2.3.3.tgz#6a485ccc868555997f3506c6db97a3e735d97adf"
   integrity sha512-iNpDovcb9qBpBTo8iUgqRSQOS8GV3bWoNaTaUptHkXtAooXSo0OWe7vN6TqqB8x3x0bNBbQx96kkmSltQ5h9kQ==
   dependencies:
     tslib "^2.0.0"
-
-regenerator-runtime@^0.13.11:
-  version "0.13.11"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
-  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 tslib@^2.0.0:
   version "2.5.3"

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -20,7 +20,6 @@
   "sideEffects": false,
   "types": "dist/typings/index.d.ts",
   "dependencies": {
-    "@babel/runtime": "^7.8.4",
     "@reach/auto-id": "^0.18.0"
   },
   "peerDependencies": {

--- a/packages/utilities/yarn.lock
+++ b/packages/utilities/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-"@babel/runtime@^7.8.4":
-  version "7.22.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.6.tgz#57d64b9ae3cff1d67eb067ae117dac087f5bd438"
-  integrity sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==
-  dependencies:
-    regenerator-runtime "^0.13.11"
-
 "@reach/auto-id@^0.18.0":
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.18.0.tgz#4b97085cd1cf1360a9bedc6e9c78e97824014f0d"
@@ -20,8 +13,3 @@
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.18.0.tgz#4f3cebe093dd436eeaff633809bf0f68f4f9d2ee"
   integrity sha512-KdVMdpTgDyK8FzdKO9SCpiibuy/kbv3pwgfXshTI6tEcQT1OOwj7BAksnzGC0rPz0UholwC+AgkqEl3EJX3M1A==
-
-regenerator-runtime@^0.13.11:
-  version "0.13.11"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
-  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -27,22 +27,17 @@ const externalPackages = [
   'react',
   'react-dom',
   'prop-types',
-  'react-uid',
   ...Object.keys(pkg.dependencies || {})
-];
-
-if (!externalPackages.includes('@babel/runtime')) {
-  throw new Error(`Package "${pkg.name}" must include the "@babel/runtime" dependency.`);
-}
+].map(external => new RegExp(`^${external}/?.*`, 'u'));
 
 export default [
   {
     input: pkg['zendeskgarden:src'],
     /**
-     * Only mark common dependencies as externals.
-     * These are not included in the bundlesize.
+     * Filter out dependencies that consumers
+     * will bundle during build time
      */
-    external: id => externalPackages.includes(id),
+    external: id => externalPackages.filter(regexp => regexp.test(id)).length > 0,
     acornInjectPlugins: [jsx()],
     plugins: [
       /**


### PR DESCRIPTION
## Description

Improves the build pipeline and removes `@babel/runtime` from the `dependencies` for packages.

## Detail

- Removes the hard wired requirement for `@babel/runtime` and the dependency from `packages`.
- Improves the external dependency filtering.
- Removes the hard coded `react-uid` from externals in `rollup.config.js` since it is supplied from package `dependencies`.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :wheelchair: ~tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
