### PR TITLE
fix(combobox): remove problematic tag focus handling

### DIFF
--- a/packages/combobox/.size-snapshot.json
+++ b/packages/combobox/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 26606,
-    "minified": 14322,
-    "gzipped": 4032
+    "bundled": 26329,
+    "minified": 14211,
+    "gzipped": 4003
   },
   "index.esm.js": {
-    "bundled": 25519,
-    "minified": 13236,
-    "gzipped": 4012,
+    "bundled": 25261,
+    "minified": 13144,
+    "gzipped": 3981,
     "treeshaked": {
       "rollup": {
         "code": 1296,
         "import_statements": 177
       },
       "webpack": {
-        "code": 13181
+        "code": 13081
       }
     }
   }

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -665,18 +665,12 @@ export const useCombobox = <
   );
 
   const getTagProps = useCallback<IUseComboboxReturnValue['getTagProps']>(
-    ({ option, onClick, onFocus, onKeyDown, ...other }) => {
+    ({ option, onClick, onKeyDown, ...other }) => {
       // Prevent tag click from affecting expansion.
       const handleClick = (event: MouseEvent) =>
         event.target instanceof Element &&
         triggerRef.current?.contains(event.target) &&
         event.stopPropagation();
-
-      const handleFocus = () => {
-        if (_isExpanded) {
-          setActiveIndex(values.findIndex(value => value === option.value));
-        }
-      };
 
       const handleKeyDown = (event: KeyboardEvent) => {
         if (event.key === KEYS.BACKSPACE || event.key === KEYS.DELETE) {
@@ -714,21 +708,11 @@ export const useCombobox = <
         'data-garden-container-id': 'containers.combobox.tag',
         'data-garden-container-version': PACKAGE_VERSION,
         onClick: composeEventHandlers(onClick, handleClick),
-        onFocus: composeEventHandlers(onFocus, handleFocus),
         onKeyDown: composeEventHandlers(onKeyDown, handleKeyDown),
         ...other
       };
     },
-    [
-      triggerRef,
-      setDownshiftSelection,
-      getDownshiftInputProps,
-      isEditable,
-      _isExpanded,
-      values,
-      setActiveIndex,
-      inputRef
-    ]
+    [triggerRef, setDownshiftSelection, getDownshiftInputProps, isEditable, inputRef]
   );
 
   const getListboxProps = useCallback<IUseComboboxReturnValue['getListboxProps']>(


### PR DESCRIPTION
## Description

The connective tissue between focused tag and expanded listbox active index proves to be problematic due to underlying Downshift `setHighlightedIndex` state management. In the `Combobox` HOC, the re-render is causing an unexpected loss of component focus. Since this functionality is neither  a usability or accessibility concern, we are removing it here in prep for a corresponding fix in `react-components`.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
