### PR TITLE
feat(accordion)!: add sections prop

### DIFF
--- a/packages/accordion/.size-snapshot.json
+++ b/packages/accordion/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 4786,
-    "minified": 2554,
-    "gzipped": 1070
+    "bundled": 4865,
+    "minified": 2581,
+    "gzipped": 1054
   },
   "index.esm.js": {
-    "bundled": 4662,
-    "minified": 2434,
-    "gzipped": 1052,
+    "bundled": 4724,
+    "minified": 2441,
+    "gzipped": 1047,
     "treeshaked": {
       "rollup": {
-        "code": 161,
-        "import_statements": 101
+        "code": 143,
+        "import_statements": 83
       },
       "webpack": {
-        "code": 2507
+        "code": 2530
       }
     }
   }

--- a/packages/accordion/.size-snapshot.json
+++ b/packages/accordion/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 4948,
-    "minified": 2628,
-    "gzipped": 1070
+    "bundled": 4499,
+    "minified": 2290,
+    "gzipped": 973
   },
   "index.esm.js": {
-    "bundled": 4807,
-    "minified": 2488,
-    "gzipped": 1064,
+    "bundled": 4358,
+    "minified": 2150,
+    "gzipped": 967,
     "treeshaked": {
       "rollup": {
         "code": 162,
         "import_statements": 83
       },
       "webpack": {
-        "code": 2571
+        "code": 2231
       }
     }
   }

--- a/packages/accordion/.size-snapshot.json
+++ b/packages/accordion/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 4865,
-    "minified": 2581,
-    "gzipped": 1054
+    "bundled": 4950,
+    "minified": 2616,
+    "gzipped": 1064
   },
   "index.esm.js": {
-    "bundled": 4724,
-    "minified": 2441,
-    "gzipped": 1047,
+    "bundled": 4809,
+    "minified": 2476,
+    "gzipped": 1058,
     "treeshaked": {
       "rollup": {
-        "code": 143,
+        "code": 162,
         "import_statements": 83
       },
       "webpack": {
-        "code": 2530
+        "code": 2559
       }
     }
   }

--- a/packages/accordion/.size-snapshot.json
+++ b/packages/accordion/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 4940,
-    "minified": 2622,
-    "gzipped": 1066
+    "bundled": 4948,
+    "minified": 2628,
+    "gzipped": 1070
   },
   "index.esm.js": {
-    "bundled": 4799,
-    "minified": 2482,
-    "gzipped": 1060,
+    "bundled": 4807,
+    "minified": 2488,
+    "gzipped": 1064,
     "treeshaked": {
       "rollup": {
         "code": 162,
         "import_statements": 83
       },
       "webpack": {
-        "code": 2565
+        "code": 2571
       }
     }
   }

--- a/packages/accordion/.size-snapshot.json
+++ b/packages/accordion/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 4499,
-    "minified": 2290,
-    "gzipped": 973
+    "bundled": 4504,
+    "minified": 2293,
+    "gzipped": 975
   },
   "index.esm.js": {
-    "bundled": 4358,
-    "minified": 2150,
-    "gzipped": 967,
+    "bundled": 4363,
+    "minified": 2153,
+    "gzipped": 969,
     "treeshaked": {
       "rollup": {
         "code": 162,
         "import_statements": 83
       },
       "webpack": {
-        "code": 2231
+        "code": 2234
       }
     }
   }

--- a/packages/accordion/.size-snapshot.json
+++ b/packages/accordion/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 4504,
-    "minified": 2293,
-    "gzipped": 975
+    "bundled": 4402,
+    "minified": 2227,
+    "gzipped": 961
   },
   "index.esm.js": {
-    "bundled": 4363,
-    "minified": 2153,
-    "gzipped": 969,
+    "bundled": 4261,
+    "minified": 2087,
+    "gzipped": 952,
     "treeshaked": {
       "rollup": {
         "code": 162,
         "import_statements": 83
       },
       "webpack": {
-        "code": 2234
+        "code": 2168
       }
     }
   }

--- a/packages/accordion/.size-snapshot.json
+++ b/packages/accordion/.size-snapshot.json
@@ -19,21 +19,21 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 4950,
-    "minified": 2616,
-    "gzipped": 1064
+    "bundled": 4940,
+    "minified": 2622,
+    "gzipped": 1066
   },
   "index.esm.js": {
-    "bundled": 4809,
-    "minified": 2476,
-    "gzipped": 1058,
+    "bundled": 4799,
+    "minified": 2482,
+    "gzipped": 1060,
     "treeshaked": {
       "rollup": {
         "code": 162,
         "import_statements": 83
       },
       "webpack": {
-        "code": 2559
+        "code": 2565
       }
     }
   }

--- a/packages/accordion/README.md
+++ b/packages/accordion/README.md
@@ -27,9 +27,10 @@ attributes for a group of sections.
 ```jsx
 import { useAccordion } from '@zendeskgarden/container-accordion';
 
-const Accordion = ({ expandable = true, collapsible = true } = {}) => {
+const Accordion = ({ sections = [0, 1, 2], expandable = true, collapsible = true } = {}) => {
   const { getHeaderProps, getTriggerProps, getPanelProps, expandedSections, disabledSections } =
     useAccordion({
+      sections,
       expandedSections: [0],
       expandable,
       collapsible
@@ -82,8 +83,8 @@ return <Accordion expandable={true} collapsible={true} />;
 ```jsx
 import { AccordionContainer } from '@zendeskgarden/container-accordion';
 
-const Accordion = ({ expandable = true, collapsible = true } = {}) => (
-  <AccordionContainer expandable={expandable} collapsible={collapsible}>
+const Accordion = ({ sections = [0, 1, 2], expandable = true, collapsible = true } = {}) => (
+  <AccordionContainer sections={sections} expandable={expandable} collapsible={collapsible}>
     {({ getHeaderProps, getTriggerProps, getPanelProps, expandedSections, disabledSections }) => (
       <>
         {sections.map((section, index) => {

--- a/packages/accordion/demo/accordion.stories.mdx
+++ b/packages/accordion/demo/accordion.stories.mdx
@@ -2,6 +2,7 @@ import { Meta, ArgsTable, Canvas, Story, Markdown } from '@storybook/addon-docs'
 import { useArgs } from '@storybook/client-api';
 import { AccordionContainer } from '@zendeskgarden/container-accordion';
 import { AccordionStory } from './stories/AccordionStory';
+import { SECTIONS } from './stories/data.ts';
 import README from '../README.md';
 
 <Meta
@@ -9,9 +10,7 @@ import README from '../README.md';
   component={AccordionContainer}
   args={{
     as: 'hook',
-    sections: Array(5)
-      .fill(undefined)
-      .map((s, i) => i)
+    sections: SECTIONS
   }}
   argTypes={{
     as: { options: ['container', 'hook'], control: 'radio', table: { category: 'Story' } }
@@ -43,7 +42,7 @@ import README from '../README.md';
 <Canvas>
   <Story
     name="Controlled"
-    args={{ expandedSections: [0] }}
+    args={{ expandedSections: [sections[0]] }}
     argTypes={{
       defaultExpandedSections: { control: false },
       collapsible: { control: false },
@@ -52,10 +51,10 @@ import README from '../README.md';
   >
     {args => {
       const updateArgs = useArgs()[1];
-      const handleChange = index => {
-        const expandedSections = args.expandedSections.includes(index)
-          ? args.expandedSections.filter(section => section !== index)
-          : [...args.expandedSections, index];
+      const handleChange = value => {
+        const expandedSections = args.expandedSections.includes(value)
+          ? args.expandedSections.filter(section => section !== value)
+          : [...args.expandedSections, value];
         updateArgs({ expandedSections });
       };
       return <AccordionStory {...args} onChange={handleChange} />;

--- a/packages/accordion/demo/accordion.stories.mdx
+++ b/packages/accordion/demo/accordion.stories.mdx
@@ -7,7 +7,12 @@ import README from '../README.md';
 <Meta
   title="Packages/Accordion"
   component={AccordionContainer}
-  args={{ as: 'hook', sections: [0, 1, 2, 3, 4] }}
+  args={{
+    as: 'hook',
+    sections: Array(5)
+      .fill(undefined)
+      .map((s, i) => i)
+  }}
   argTypes={{
     as: { options: ['container', 'hook'], control: 'radio', table: { category: 'Story' } }
   }}

--- a/packages/accordion/demo/accordion.stories.mdx
+++ b/packages/accordion/demo/accordion.stories.mdx
@@ -7,10 +7,9 @@ import README from '../README.md';
 <Meta
   title="Packages/Accordion"
   component={AccordionContainer}
-  args={{ as: 'hook', sections: 5 }}
+  args={{ as: 'hook', sections: [0, 1, 2, 3, 4] }}
   argTypes={{
-    as: { options: ['container', 'hook'], control: 'radio', table: { category: 'Story' } },
-    sections: { control: { type: 'range', min: 1, max: 9 }, table: { category: 'Story' } }
+    as: { options: ['container', 'hook'], control: 'radio', table: { category: 'Story' } }
   }}
 />
 

--- a/packages/accordion/demo/accordion.stories.mdx
+++ b/packages/accordion/demo/accordion.stories.mdx
@@ -42,7 +42,7 @@ import README from '../README.md';
 <Canvas>
   <Story
     name="Controlled"
-    args={{ expandedSections: [sections[0]] }}
+    args={{ expandedSections: SECTIONS.slice(0, 1) }}
     argTypes={{
       defaultExpandedSections: { control: false },
       collapsible: { control: false },

--- a/packages/accordion/demo/stories/AccordionStory.tsx
+++ b/packages/accordion/demo/stories/AccordionStory.tsx
@@ -16,7 +16,7 @@ import {
 } from '@zendeskgarden/container-accordion';
 
 interface IComponentProps extends IUseAccordionReturnValue {
-  sections: number[];
+  sections: IUseAccordionProps['sections'];
 }
 
 const Component = ({
@@ -28,7 +28,7 @@ const Component = ({
   getPanelProps
 }: IComponentProps) => (
   <div style={{ width: 300 }}>
-    {sections.map((section, index) => {
+    {sections!.map((section, index) => {
       const disabled = disabledSections.indexOf(index) !== -1;
       const hidden = expandedSections.indexOf(index) === -1;
 
@@ -65,38 +65,33 @@ const Component = ({
   </div>
 );
 
-interface IProps extends IUseAccordionProps {
-  sections: number[];
-}
-
-const Container = ({ sections, ...props }: IProps) => (
+const Container = (props: IAccordionContainerProps) => (
   <AccordionContainer {...props}>
-    {containerProps => <Component sections={sections} {...containerProps} />}
+    {/* eslint-disable-next-line react/destructuring-assignment */}
+    {containerProps => <Component sections={props.sections} {...containerProps} />}
   </AccordionContainer>
 );
 
-const Hook = ({ sections, ...props }: IProps) => {
+const Hook = (props: IUseAccordionProps) => {
   const hookProps = useAccordion(props);
 
-  return <Component sections={sections} {...hookProps} />;
+  // eslint-disable-next-line react/destructuring-assignment
+  return <Component sections={props.sections} {...hookProps} />;
 };
 
 interface IArgs extends IAccordionContainerProps {
   as: 'hook' | 'container';
-  sections: number;
 }
 
-export const AccordionStory: Story<IArgs> = ({ as, sections, ...props }: IArgs) => {
+export const AccordionStory: Story<IArgs> = ({ as, ...props }: IArgs) => {
   const Accordion = () => {
-    const _sections = Array.from({ length: sections }, (_, index) => index);
-
     switch (as) {
       case 'container':
-        return <Container sections={_sections} {...props} />;
+        return <Container {...props} />;
 
       case 'hook':
       default:
-        return <Hook sections={_sections} {...props} />;
+        return <Hook {...props} />;
     }
   };
 

--- a/packages/accordion/demo/stories/AccordionStory.tsx
+++ b/packages/accordion/demo/stories/AccordionStory.tsx
@@ -30,7 +30,7 @@ const Component = ({
   getPanelProps
 }: IComponentProps) => (
   <div style={{ width: 300 }}>
-    {sections!.map(value => {
+    {sections.map((value, index) => {
       const disabled = disabledSections.indexOf(value) !== -1;
       const hidden = expandedSections.indexOf(value) === -1;
 
@@ -41,13 +41,12 @@ const Component = ({
               {...getTriggerProps({
                 value,
                 role: null,
-                tabIndex: null,
                 disabled
               })}
               className="text-left w-full"
               type="button"
             >
-              {`Trigger ${value + 1}`}
+              {`Trigger ${index + 1}`}
             </button>
           </div>
           <section
@@ -57,7 +56,7 @@ const Component = ({
               hidden
             })}
           >
-            {`[Panel ${value + 1}] `}
+            {`[Panel ${index + 1}] `}
             Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon
             amaranth tatsoi tomatillo melon azuki bean garlic.
           </section>

--- a/packages/accordion/demo/stories/AccordionStory.tsx
+++ b/packages/accordion/demo/stories/AccordionStory.tsx
@@ -15,8 +15,10 @@ import {
   useAccordion
 } from '@zendeskgarden/container-accordion';
 
-interface IComponentProps extends IUseAccordionReturnValue {
-  sections: IUseAccordionProps['sections'];
+type ISectionValue = number;
+
+interface IComponentProps<T = ISectionValue> extends IUseAccordionReturnValue<T> {
+  sections: IUseAccordionProps<T>['sections'];
 }
 
 const Component = ({
@@ -28,16 +30,16 @@ const Component = ({
   getPanelProps
 }: IComponentProps) => (
   <div style={{ width: 300 }}>
-    {sections!.map((section, index) => {
-      const disabled = disabledSections.indexOf(index) !== -1;
-      const hidden = expandedSections.indexOf(index) === -1;
+    {sections!.map(value => {
+      const disabled = disabledSections.indexOf(value) !== -1;
+      const hidden = expandedSections.indexOf(value) === -1;
 
       return (
-        <div key={section}>
-          <div {...getHeaderProps({ ariaLevel: 2 })}>
+        <div key={value}>
+          <div {...getHeaderProps({ 'aria-level': 2 })}>
             <button
               {...getTriggerProps({
-                index,
+                value,
                 role: null,
                 tabIndex: null,
                 disabled
@@ -45,17 +47,17 @@ const Component = ({
               className="text-left w-full"
               type="button"
             >
-              {`Trigger ${index + 1}`}
+              {`Trigger ${value + 1}`}
             </button>
           </div>
           <section
             {...getPanelProps({
-              index,
+              value,
               role: null,
               hidden
             })}
           >
-            {`[Panel ${index + 1}] `}
+            {`[Panel ${value + 1}] `}
             Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon
             amaranth tatsoi tomatillo melon azuki bean garlic.
           </section>
@@ -65,21 +67,21 @@ const Component = ({
   </div>
 );
 
-const Container = (props: IAccordionContainerProps) => (
+const Container = (props: IAccordionContainerProps<ISectionValue>) => (
   <AccordionContainer {...props}>
     {/* eslint-disable-next-line react/destructuring-assignment */}
     {containerProps => <Component sections={props.sections} {...containerProps} />}
   </AccordionContainer>
 );
 
-const Hook = (props: IUseAccordionProps) => {
+const Hook = (props: IUseAccordionProps<ISectionValue>) => {
   const hookProps = useAccordion(props);
 
   // eslint-disable-next-line react/destructuring-assignment
   return <Component sections={props.sections} {...hookProps} />;
 };
 
-interface IArgs extends IAccordionContainerProps {
+interface IArgs extends IAccordionContainerProps<ISectionValue> {
   as: 'hook' | 'container';
 }
 

--- a/packages/accordion/demo/stories/data.ts
+++ b/packages/accordion/demo/stories/data.ts
@@ -5,6 +5,4 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-export const SECTIONS = Array(5)
-  .fill(undefined)
-  .map((_, i) => i);
+export const SECTIONS = ['section-1', 'section-2', 'section-3', 'section-4', 'section-5'];

--- a/packages/accordion/demo/stories/data.ts
+++ b/packages/accordion/demo/stories/data.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+export const SECTIONS = Array(5)
+  .fill(undefined)
+  .map((_, i) => i);

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -21,8 +21,7 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@babel/runtime": "^7.8.4",
-    "@zendeskgarden/container-utilities": "^1.0.8",
-    "react-uid": "^2.2.0"
+    "@zendeskgarden/container-utilities": "^1.0.8"
   },
   "peerDependencies": {
     "prop-types": "^15.6.1",

--- a/packages/accordion/src/AccordionContainer.spec.tsx
+++ b/packages/accordion/src/AccordionContainer.spec.tsx
@@ -43,31 +43,13 @@ describe('AccordionContainer', () => {
           {sections.map(section => {
             return (
               <div key={section}>
-                <div
-                  {...getHeaderProps({
-                    'aria-level': 1,
-                    // @ts-expect-error data-test-id for testing
-                    'data-test-id': 'header'
-                  })}
-                >
-                  <div
-                    {...getTriggerProps({
-                      value: section,
-                      // @ts-expect-error data-test-id for testing
-                      'data-test-id': 'trigger'
-                    })}
-                  >
+                <div data-test-id="header" {...getHeaderProps({ 'aria-level': 1 })}>
+                  <div data-test-id="trigger" {...getTriggerProps({ value: section })}>
                     Trigger
                   </div>
                 </div>
 
-                <div
-                  {...getPanelProps({
-                    value: section,
-                    // @ts-expect-error data-test-id for testing
-                    'data-test-id': 'panel'
-                  })}
-                >
+                <div data-test-id="panel" {...getPanelProps({ value: section })}>
                   Panel
                 </div>
               </div>

--- a/packages/accordion/src/AccordionContainer.spec.tsx
+++ b/packages/accordion/src/AccordionContainer.spec.tsx
@@ -464,7 +464,7 @@ describe('AccordionContainer', () => {
       const panels = getAllByTestId('panel');
 
       triggers.forEach((trigger, index) => {
-        expect(trigger).toHaveAttribute('aria-disabled', 'false');
+        expect(trigger).not.toHaveAttribute('aria-disabled');
         expect(trigger).toHaveAttribute('aria-expanded', 'false');
         expect(panels[index]).toHaveAttribute('aria-hidden', 'true');
       });
@@ -496,7 +496,7 @@ describe('AccordionContainer', () => {
       const trigger = triggers[1];
       const panel = panels[1];
 
-      expect(trigger).toHaveAttribute('aria-disabled', 'false');
+      expect(trigger).not.toHaveAttribute('aria-disabled');
       expect(trigger).toHaveAttribute('aria-expanded', 'false');
       expect(panel).toHaveAttribute('aria-hidden', 'true');
       await user.click(trigger); // expand!
@@ -527,7 +527,11 @@ describe('AccordionContainer', () => {
         const hidden = index === 0 ? 'false' : 'true';
 
         expect(trigger).toHaveAttribute('aria-expanded', expanded);
-        expect(trigger).toHaveAttribute('aria-disabled', expanded);
+        if (expanded === 'true') {
+          expect(trigger).toHaveAttribute('aria-disabled', expanded);
+        } else {
+          expect(trigger).not.toHaveAttribute('aria-disabled');
+        }
         expect(panels[index]).toHaveAttribute('aria-hidden', hidden);
       });
     });
@@ -543,10 +547,10 @@ describe('AccordionContainer', () => {
           const expanded = _index === index ? 'true' : 'false';
           const hidden = _index === index ? 'false' : 'true';
 
-          console.log(index, expanded, hidden);
-
           expect(_trigger).toHaveAttribute('aria-expanded', expanded);
-          expect(_trigger).toHaveAttribute('aria-disabled', expanded);
+          if (expanded === 'true' || index >= _index) {
+            expect(trigger).toHaveAttribute('aria-disabled', 'true');
+          }
           expect(panels[_index]).toHaveAttribute('aria-hidden', hidden);
         });
       }

--- a/packages/accordion/src/AccordionContainer.spec.tsx
+++ b/packages/accordion/src/AccordionContainer.spec.tsx
@@ -37,7 +37,7 @@ describe('AccordionContainer', () => {
   const CONTAINER_ID_PREFIX = 'test';
 
   const BasicExample = (props: IUseAccordionProps = {}) => (
-    <AccordionContainer idPrefix={CONTAINER_ID_PREFIX} {...props}>
+    <AccordionContainer idPrefix={CONTAINER_ID_PREFIX} sections={sections} {...props}>
       {({ getHeaderProps, getTriggerProps, getPanelProps }) => (
         <>
           {sections.map((section, index) => {
@@ -56,7 +56,7 @@ describe('AccordionContainer', () => {
   );
 
   const AdvancedExample = () => (
-    <AccordionContainer>
+    <AccordionContainer sections={sections}>
       {({ getHeaderProps, getTriggerProps, getPanelProps }) => (
         <>
           {sections.map((section, index) => {

--- a/packages/accordion/src/AccordionContainer.spec.tsx
+++ b/packages/accordion/src/AccordionContainer.spec.tsx
@@ -86,31 +86,30 @@ describe('AccordionContainer', () => {
             return (
               <div key={section}>
                 <h2
+                  data-test-id="header"
                   {...getHeaderProps({
                     role: null,
-                    'aria-level': null,
-                    // @ts-expect-error data-test-id for testing
-                    'data-test-id': 'header'
+                    // @ts-expect-error for testing purposes only
+                    'aria-level': null
                   })}
                 >
                   <button
+                    data-test-id="trigger"
                     {...(getTriggerProps({
                       value: section,
                       role: null,
-                      tabIndex: null,
-                      // @ts-expect-error data-test-id for testing
-                      'data-test-id': 'trigger'
+                      // setting to `null` when semantically implicit (button)
+                      tabIndex: null as any
                     }) as any)}
                   >
                     Trigger
                   </button>
                 </h2>
                 <section
+                  data-test-id="panel"
                   {...getPanelProps({
                     value: section,
-                    role: null,
-                    // @ts-expect-error data-test-id for testing
-                    'data-test-id': 'panel'
+                    role: null
                   })}
                 >
                   Panel
@@ -177,22 +176,6 @@ describe('AccordionContainer', () => {
       getAllByTestId('header').forEach(header => {
         expect(header).not.toHaveAttribute('aria-level');
       });
-    });
-
-    it('throws error if aria-level is not provided', () => {
-      const consoleError = console.error;
-
-      console.error = jest.fn();
-
-      expect(() => {
-        render(
-          <AccordionContainer sections={[]}>
-            {({ getHeaderProps }) => <div {...getHeaderProps()} />}
-          </AccordionContainer>
-        );
-      }).toThrow('aria-level');
-
-      console.error = consoleError;
     });
   });
 
@@ -294,22 +277,6 @@ describe('AccordionContainer', () => {
         expect(firstTrigger).toHaveAttribute('aria-expanded', 'false');
       });
     });
-
-    it('throws error if value is not provided', () => {
-      const consoleError = console.error;
-
-      console.error = jest.fn();
-
-      expect(() => {
-        render(
-          <AccordionContainer sections={[]}>
-            {({ getTriggerProps }) => <div {...getTriggerProps()} />}
-          </AccordionContainer>
-        );
-      }).toThrow('value');
-
-      console.error = consoleError;
-    });
   });
 
   describe('getPanelProps', () => {
@@ -395,22 +362,6 @@ describe('AccordionContainer', () => {
 
         expect(firstPanel).toHaveAttribute('aria-hidden', 'true');
       });
-    });
-
-    it('throws error if value is not provided', () => {
-      const consoleError = console.error;
-
-      console.error = jest.fn();
-
-      expect(() => {
-        render(
-          <AccordionContainer sections={[]}>
-            {({ getPanelProps }) => <div {...getPanelProps()} />}
-          </AccordionContainer>
-        );
-      }).toThrow('value');
-
-      console.error = consoleError;
     });
   });
 

--- a/packages/accordion/src/AccordionContainer.spec.tsx
+++ b/packages/accordion/src/AccordionContainer.spec.tsx
@@ -14,10 +14,15 @@ import { AccordionContainer, IUseAccordionReturnValue, IUseAccordionProps } from
 describe('AccordionContainer', () => {
   const user = userEvent.setup();
 
+  const sections = Array(3)
+    .fill(undefined)
+    .map((s, i) => i);
+  const CONTAINER_ID_PREFIX = 'test';
+
   it('renders with expected return values', () => {
     const { getByTestId, getByText } = render(
-      <AccordionContainer>
-        {({ expandedSections, disabledSections }: IUseAccordionReturnValue) => (
+      <AccordionContainer sections={sections}>
+        {({ expandedSections, disabledSections }: IUseAccordionReturnValue<number>) => (
           <div data-test-id="test" hidden={expandedSections.includes(0)}>
             <button disabled={disabledSections.length !== 0}>Trigger</button>
           </div>
@@ -31,22 +36,40 @@ describe('AccordionContainer', () => {
     expect(triggerButton).not.toHaveAttribute('disabled');
   });
 
-  const sections = Array(3)
-    .fill(undefined)
-    .map((s, i) => i);
-  const CONTAINER_ID_PREFIX = 'test';
-
-  const BasicExample = (props: IUseAccordionProps = {}) => (
+  const BasicExample = (props: Omit<IUseAccordionProps<number>, 'sections'> = {}) => (
     <AccordionContainer idPrefix={CONTAINER_ID_PREFIX} sections={sections} {...props}>
       {({ getHeaderProps, getTriggerProps, getPanelProps }) => (
         <>
-          {sections.map((section, index) => {
+          {sections.map(section => {
             return (
               <div key={section}>
-                <div {...getHeaderProps({ ariaLevel: 1, 'data-test-id': 'header' })}>
-                  <div {...getTriggerProps({ index, 'data-test-id': 'trigger' })}>Trigger</div>
+                <div
+                  {...getHeaderProps({
+                    'aria-level': 1,
+                    // @ts-expect-error data-test-id for testing
+                    'data-test-id': 'header'
+                  })}
+                >
+                  <div
+                    {...getTriggerProps({
+                      value: section,
+                      // @ts-expect-error data-test-id for testing
+                      'data-test-id': 'trigger'
+                    })}
+                  >
+                    Trigger
+                  </div>
                 </div>
-                <div {...getPanelProps({ index, 'data-test-id': 'panel' })}>Panel</div>
+
+                <div
+                  {...getPanelProps({
+                    value: section,
+                    // @ts-expect-error data-test-id for testing
+                    'data-test-id': 'panel'
+                  })}
+                >
+                  Panel
+                </div>
               </div>
             );
           })}
@@ -59,22 +82,37 @@ describe('AccordionContainer', () => {
     <AccordionContainer sections={sections}>
       {({ getHeaderProps, getTriggerProps, getPanelProps }) => (
         <>
-          {sections.map((section, index) => {
+          {sections.map(section => {
             return (
               <div key={section}>
-                <h2 {...getHeaderProps({ role: null, ariaLevel: null, 'data-test-id': 'header' })}>
+                <h2
+                  {...getHeaderProps({
+                    role: null,
+                    'aria-level': null,
+                    // @ts-expect-error data-test-id for testing
+                    'data-test-id': 'header'
+                  })}
+                >
                   <button
-                    {...getTriggerProps({
-                      index,
+                    {...(getTriggerProps({
+                      value: section,
                       role: null,
                       tabIndex: null,
+                      // @ts-expect-error data-test-id for testing
                       'data-test-id': 'trigger'
-                    })}
+                    }) as any)}
                   >
                     Trigger
                   </button>
                 </h2>
-                <section {...getPanelProps({ index, role: null, 'data-test-id': 'panel' })}>
+                <section
+                  {...getPanelProps({
+                    value: section,
+                    role: null,
+                    // @ts-expect-error data-test-id for testing
+                    'data-test-id': 'panel'
+                  })}
+                >
                   Panel
                 </section>
               </div>
@@ -141,18 +179,18 @@ describe('AccordionContainer', () => {
       });
     });
 
-    it('throws error if aria level is not provided', () => {
+    it('throws error if aria-level is not provided', () => {
       const consoleError = console.error;
 
       console.error = jest.fn();
 
       expect(() => {
         render(
-          <AccordionContainer>
+          <AccordionContainer sections={[]}>
             {({ getHeaderProps }) => <div {...getHeaderProps()} />}
           </AccordionContainer>
         );
-      }).toThrow('ariaLevel');
+      }).toThrow('aria-level');
 
       console.error = consoleError;
     });
@@ -257,18 +295,18 @@ describe('AccordionContainer', () => {
       });
     });
 
-    it('throws error if index is not provided', () => {
+    it('throws error if value is not provided', () => {
       const consoleError = console.error;
 
       console.error = jest.fn();
 
       expect(() => {
         render(
-          <AccordionContainer>
+          <AccordionContainer sections={[]}>
             {({ getTriggerProps }) => <div {...getTriggerProps()} />}
           </AccordionContainer>
         );
-      }).toThrow('index');
+      }).toThrow('value');
 
       console.error = consoleError;
     });
@@ -359,18 +397,18 @@ describe('AccordionContainer', () => {
       });
     });
 
-    it('throws error if index is not provided', () => {
+    it('throws error if value is not provided', () => {
       const consoleError = console.error;
 
       console.error = jest.fn();
 
       expect(() => {
         render(
-          <AccordionContainer>
+          <AccordionContainer sections={[]}>
             {({ getPanelProps }) => <div {...getPanelProps()} />}
           </AccordionContainer>
         );
-      }).toThrow('index');
+      }).toThrow('value');
 
       console.error = consoleError;
     });
@@ -504,6 +542,8 @@ describe('AccordionContainer', () => {
         triggers.forEach((_trigger, _index) => {
           const expanded = _index === index ? 'true' : 'false';
           const hidden = _index === index ? 'false' : 'true';
+
+          console.log(index, expanded, hidden);
 
           expect(_trigger).toHaveAttribute('aria-expanded', expanded);
           expect(_trigger).toHaveAttribute('aria-disabled', expanded);

--- a/packages/accordion/src/AccordionContainer.tsx
+++ b/packages/accordion/src/AccordionContainer.tsx
@@ -8,14 +8,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { useAccordion, IUseAccordionProps, IUseAccordionReturnValue } from './useAccordion';
-
-export interface IAccordionContainerProps extends IUseAccordionProps {
-  /** A render prop function which receives accordion state and prop getters */
-  render?: (options: IUseAccordionReturnValue) => React.ReactNode;
-  /** A children render prop function which receives accordion state and prop getters */
-  children?: (options: IUseAccordionReturnValue) => React.ReactNode;
-}
+import { useAccordion } from './useAccordion';
+import type { IAccordionContainerProps } from './types';
 
 export const AccordionContainer: React.FunctionComponent<IAccordionContainerProps> = props => {
   const { children, render = children, ...options } = props;

--- a/packages/accordion/src/AccordionContainer.tsx
+++ b/packages/accordion/src/AccordionContainer.tsx
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import { useAccordion } from './useAccordion';
 import type { IAccordionContainerProps } from './types';
 
-export const AccordionContainer: React.FunctionComponent<IAccordionContainerProps> = props => {
+export const AccordionContainer: React.FunctionComponent<IAccordionContainerProps<any>> = props => {
   const { children, render = children, ...options } = props;
 
   return <>{render!(useAccordion(options)) as React.ReactElement}</>;
@@ -25,6 +25,7 @@ AccordionContainer.defaultProps = {
 AccordionContainer.propTypes = {
   children: PropTypes.func,
   render: PropTypes.func,
+  sections: PropTypes.array.isRequired,
   expandedSections: PropTypes.array,
   defaultExpandedSections: PropTypes.array,
   expandable: PropTypes.bool,

--- a/packages/accordion/src/index.ts
+++ b/packages/accordion/src/index.ts
@@ -6,12 +6,14 @@
  */
 
 /* Hooks */
-export {
-  useAccordion,
-  IUseAccordionReturnValue,
-  IUseAccordionPropGetters,
-  IUseAccordionProps
-} from './useAccordion';
+export { useAccordion } from './useAccordion';
 
 /* Render-props */
-export { AccordionContainer, IAccordionContainerProps } from './AccordionContainer';
+export { AccordionContainer } from './AccordionContainer';
+
+export type {
+  IUseAccordionReturnValue,
+  IUseAccordionPropGetters,
+  IAccordionContainerProps,
+  IUseAccordionProps
+} from './types';

--- a/packages/accordion/src/index.ts
+++ b/packages/accordion/src/index.ts
@@ -13,7 +13,6 @@ export { AccordionContainer } from './AccordionContainer';
 
 export type {
   IUseAccordionReturnValue,
-  IUseAccordionPropGetters,
   IAccordionContainerProps,
   IUseAccordionProps
 } from './types';

--- a/packages/accordion/src/types.ts
+++ b/packages/accordion/src/types.ts
@@ -7,70 +7,66 @@
 
 import type { HTMLProps } from 'react';
 
-export interface IUseAccordionProps {
+export interface IUseAccordionProps<Value> {
   /** Prefixes IDs for the accordion trigger and panels  */
   idPrefix?: string;
   /** Defines the sections for the accordion */
-  sections?: number[];
+  sections: Value[];
   /** Sets the expanded sections in a controlled accordion */
-  expandedSections?: number[];
+  expandedSections?: Value[];
   /** Sets the default expanded sections in a uncontrolled accordion */
-  defaultExpandedSections?: number[];
+  defaultExpandedSections?: Value[];
   /** Handles accordion expansion changes */
-  onChange?: (expanded: number) => any;
+  onChange?: (expanded: Value) => any;
   /** Determines if multiple panels can be expanded at the same time in an uncontrolled accordion */
   expandable?: boolean;
   /** Determines if panels can be collapsed in an uncontrolled accordion */
   collapsible?: boolean;
 }
 
-export interface IHeaderProps extends HTMLProps<any> {
-  ariaLevel?: number | null;
-  role?: any;
+export interface IUseAccordionReturnValue<Value> {
+  expandedSections: Value[];
+  disabledSections: Value[];
+  getHeaderProps: <T extends Element>(
+    props?: Omit<HTMLProps<T>, 'role' | 'aria-level'> & {
+      role?: 'heading' | null;
+      'aria-level': string | number | null;
+    }
+  ) => HTMLProps<T>;
+  getTriggerProps: <T extends Element>(
+    props?: Omit<HTMLProps<T>, 'role' | 'tabIndex'> & {
+      role?: 'button' | null;
+      tabIndex?: any | null;
+      value?: Value;
+    }
+  ) => HTMLProps<T>;
+  getPanelProps: <T extends Element>(
+    props?: Omit<HTMLProps<T>, 'role'> & {
+      role?: 'region' | null;
+      value?: Value;
+    }
+  ) => HTMLProps<T>;
 }
-
-export interface ITriggerProps extends HTMLProps<any> {
-  index?: number;
-  role?: any;
-  tabIndex?: any;
-}
-
-export interface IPanelProps extends HTMLProps<any> {
-  index?: number;
-  role?: any;
-}
-
-export interface IUseAccordionPropGetters {
-  getHeaderProps: <T>(options?: T & IHeaderProps) => any;
-  getTriggerProps: <T>(options?: T & ITriggerProps) => any;
-  getPanelProps: <T>(options?: T & IPanelProps) => any;
-}
-
-export interface IUseAccordionReturnValue extends IUseAccordionPropGetters {
-  expandedSections: number[];
-  disabledSections: number[];
-}
-
-export interface IAccordionContainerProps extends IUseAccordionProps {
+export interface IAccordionContainerProps<Value> extends IUseAccordionProps<Value> {
   /**
    * Provides accordion render prop functions and state
    *
    * @param {function} [options.getHeaderProps] Header props getter
    * @param {function} [options.getTriggerProps] Trigger props getter
    * @param {function} [options.getPanelProps] Panel props getter
-   * @param {number[]} options.expandedSections Current expanded sections
-   * @param {number[]} options.disabledSections Current disabled sections
+   * @param {number[]|string[]} options.expandedSections Current expanded sections
+   * @param {number[]|string[]} options.disabledSections Current disabled sections
    */
   render?: (options: {
     /* prop getters */
-    getHeaderProps: <T>(options?: T & IHeaderProps) => any;
-    getTriggerProps: <T>(options?: T & ITriggerProps) => any;
-    getPanelProps: <T>(options?: T & IPanelProps) => any;
+    getHeaderProps: IUseAccordionReturnValue<Value>['getHeaderProps'];
+    getTriggerProps: IUseAccordionReturnValue<Value>['getTriggerProps'];
+    getPanelProps: IUseAccordionReturnValue<Value>['getPanelProps'];
     /* state */
-    expandedSections: number[];
-    disabledSections: number[];
+    expandedSections: IUseAccordionReturnValue<Value>['expandedSections'];
+    disabledSections: IUseAccordionReturnValue<Value>['disabledSections'];
   }) => React.ReactNode;
   /** @ignore */
   /** A children render prop function which receives accordion state and prop getters */
-  children?: (options: IUseAccordionReturnValue) => React.ReactNode;
+  children?: (options: IUseAccordionReturnValue<Value>) => React.ReactNode;
 }

--- a/packages/accordion/src/types.ts
+++ b/packages/accordion/src/types.ts
@@ -10,14 +10,14 @@ import type { HTMLProps } from 'react';
 export interface IUseAccordionProps<Value> {
   /** Prefixes IDs for the accordion trigger and panels  */
   idPrefix?: string;
-  /** Defines the sections for the accordion */
+  /** Provides an ordered list of unique section values */
   sections: Value[];
   /** Sets the expanded sections in a controlled accordion */
   expandedSections?: Value[];
   /** Sets the default expanded sections in a uncontrolled accordion */
   defaultExpandedSections?: Value[];
   /** Handles accordion expansion changes */
-  onChange?: (expanded: Value) => any;
+  onChange?: (expanded: Value) => void;
   /** Determines if multiple panels can be expanded at the same time in an uncontrolled accordion */
   expandable?: boolean;
   /** Determines if panels can be collapsed in an uncontrolled accordion */
@@ -30,20 +30,19 @@ export interface IUseAccordionReturnValue<Value> {
   getHeaderProps: <T extends Element>(
     props?: Omit<HTMLProps<T>, 'role' | 'aria-level'> & {
       role?: 'heading' | null;
-      'aria-level': string | number | null;
+      'aria-level': NonNullable<HTMLProps<T>['aria-level']>;
     }
   ) => HTMLProps<T>;
   getTriggerProps: <T extends Element>(
-    props?: Omit<HTMLProps<T>, 'role' | 'tabIndex'> & {
+    props?: Omit<HTMLProps<T>, 'role'> & {
       role?: 'button' | null;
-      tabIndex?: any | null;
-      value?: Value;
+      value: Value;
     }
   ) => HTMLProps<T>;
   getPanelProps: <T extends Element>(
     props?: Omit<HTMLProps<T>, 'role'> & {
       role?: 'region' | null;
-      value?: Value;
+      value: Value;
     }
   ) => HTMLProps<T>;
 }
@@ -54,8 +53,8 @@ export interface IAccordionContainerProps<Value> extends IUseAccordionProps<Valu
    * @param {function} [options.getHeaderProps] Header props getter
    * @param {function} [options.getTriggerProps] Trigger props getter
    * @param {function} [options.getPanelProps] Panel props getter
-   * @param {number[]|string[]} options.expandedSections Current expanded sections
-   * @param {number[]|string[]} options.disabledSections Current disabled sections
+   * @param {*[]} options.expandedSections Current expanded sections
+   * @param {*[]} options.disabledSections Current disabled sections
    */
   render?: (options: {
     /* prop getters */
@@ -67,6 +66,5 @@ export interface IAccordionContainerProps<Value> extends IUseAccordionProps<Valu
     disabledSections: IUseAccordionReturnValue<Value>['disabledSections'];
   }) => React.ReactNode;
   /** @ignore */
-  /** A children render prop function which receives accordion state and prop getters */
   children?: (options: IUseAccordionReturnValue<Value>) => React.ReactNode;
 }

--- a/packages/accordion/src/types.ts
+++ b/packages/accordion/src/types.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import type { HTMLProps } from 'react';
+
+export interface IUseAccordionProps {
+  /** Prefixes IDs for the accordion trigger and panels  */
+  idPrefix?: string;
+  /** Defines the sections for the accordion */
+  sections?: number[];
+  /** Sets the expanded sections in a controlled accordion */
+  expandedSections?: number[];
+  /** Sets the default expanded sections in a uncontrolled accordion */
+  defaultExpandedSections?: number[];
+  /** Handles accordion expansion changes */
+  onChange?: (expanded: number) => any;
+  /** Determines if multiple panels can be expanded at the same time in an uncontrolled accordion */
+  expandable?: boolean;
+  /** Determines if panels can be collapsed in an uncontrolled accordion */
+  collapsible?: boolean;
+}
+
+export interface IHeaderProps extends HTMLProps<any> {
+  ariaLevel?: number | null;
+  role?: any;
+}
+
+export interface ITriggerProps extends HTMLProps<any> {
+  index?: number;
+  role?: any;
+  tabIndex?: any;
+}
+
+export interface IPanelProps extends HTMLProps<any> {
+  index?: number;
+  role?: any;
+}
+
+export interface IUseAccordionPropGetters {
+  getHeaderProps: <T>(options?: T & IHeaderProps) => any;
+  getTriggerProps: <T>(options?: T & ITriggerProps) => any;
+  getPanelProps: <T>(options?: T & IPanelProps) => any;
+}
+
+export interface IUseAccordionReturnValue extends IUseAccordionPropGetters {
+  expandedSections: number[];
+  disabledSections: number[];
+}
+
+export interface IAccordionContainerProps extends IUseAccordionProps {
+  /**
+   * Provides accordion render prop functions and state
+   *
+   * @param {function} [options.getHeaderProps] Header props getter
+   * @param {function} [options.getTriggerProps] Trigger props getter
+   * @param {function} [options.getPanelProps] Panel props getter
+   * @param {number[]} options.expandedSections Current expanded sections
+   * @param {number[]} options.disabledSections Current disabled sections
+   */
+  render?: (options: {
+    /* prop getters */
+    getHeaderProps: <T>(options?: T & IHeaderProps) => any;
+    getTriggerProps: <T>(options?: T & ITriggerProps) => any;
+    getPanelProps: <T>(options?: T & IPanelProps) => any;
+    /* state */
+    expandedSections: number[];
+    disabledSections: number[];
+  }) => React.ReactNode;
+  /** @ignore */
+  /** A children render prop function which receives accordion state and prop getters */
+  children?: (options: IUseAccordionReturnValue) => React.ReactNode;
+}

--- a/packages/accordion/src/types.ts
+++ b/packages/accordion/src/types.ts
@@ -28,19 +28,19 @@ export interface IUseAccordionReturnValue<Value> {
   expandedSections: Value[];
   disabledSections: Value[];
   getHeaderProps: <T extends Element>(
-    props?: Omit<HTMLProps<T>, 'role' | 'aria-level'> & {
+    props: Omit<HTMLProps<T>, 'role' | 'aria-level'> & {
       role?: 'heading' | null;
       'aria-level': NonNullable<HTMLProps<T>['aria-level']>;
     }
   ) => HTMLProps<T>;
   getTriggerProps: <T extends Element>(
-    props?: Omit<HTMLProps<T>, 'role'> & {
+    props: Omit<HTMLProps<T>, 'role'> & {
       role?: 'button' | null;
       value: Value;
     }
   ) => HTMLProps<T>;
   getPanelProps: <T extends Element>(
-    props?: Omit<HTMLProps<T>, 'role'> & {
+    props: Omit<HTMLProps<T>, 'role'> & {
       role?: 'region' | null;
       value: Value;
     }

--- a/packages/accordion/src/useAccordion.ts
+++ b/packages/accordion/src/useAccordion.ts
@@ -70,7 +70,7 @@ export function useAccordion<Value>({
   );
 
   const getHeaderProps = useCallback(
-    ({ role = 'heading', 'aria-level': ariaLevel, ...props } = {}) => ({
+    ({ role = 'heading', 'aria-level': ariaLevel, ...props }) => ({
       role,
       'aria-level': ariaLevel,
       'data-garden-container-id': 'containers.accordion',
@@ -81,7 +81,7 @@ export function useAccordion<Value>({
   );
 
   const getTriggerProps = useCallback(
-    ({ value, role = 'button', tabIndex = 0, ...props } = {}) => ({
+    ({ value, role = 'button', tabIndex = 0, ...props }) => ({
       id: `${TRIGGER_ID}:${value}`,
       role,
       tabIndex,
@@ -101,7 +101,7 @@ export function useAccordion<Value>({
   );
 
   const getPanelProps = useCallback(
-    ({ value, role = 'region', ...props } = {}) => ({
+    ({ value, role = 'region', ...props }) => ({
       id: `${PANEL_ID}:${value}`,
       role,
       'aria-hidden': !internalExpandedState.includes(value),

--- a/packages/accordion/src/useAccordion.ts
+++ b/packages/accordion/src/useAccordion.ts
@@ -20,7 +20,7 @@ export function useAccordion<Value>({
   sections,
   expandedSections,
   defaultExpandedSections,
-  onChange,
+  onChange = () => undefined,
   expandable = true,
   collapsible = true
 }: IUseAccordionProps<Value>): IUseAccordionReturnValue<Value> {
@@ -58,9 +58,7 @@ export function useAccordion<Value>({
         }
       });
 
-      if (onChange) {
-        onChange(value);
-      }
+      onChange(value);
 
       if (isControlled === false) {
         setExpandedState(expanded);

--- a/packages/accordion/src/useAccordion.ts
+++ b/packages/accordion/src/useAccordion.ts
@@ -17,7 +17,7 @@ import { IUseAccordionProps, IUseAccordionReturnValue } from './types';
 
 export function useAccordion<Value>({
   idPrefix,
-  sections,
+  sections = [],
   expandedSections,
   defaultExpandedSections,
   onChange = () => undefined,

--- a/packages/accordion/src/useAccordion.ts
+++ b/packages/accordion/src/useAccordion.ts
@@ -101,7 +101,7 @@ export function useAccordion<Value>({
         role,
         tabIndex,
         'aria-controls': `${PANEL_ID}:${value}`,
-        'aria-disabled': disabledState.includes(value),
+        'aria-disabled': disabledState.includes(value) || null,
         'aria-expanded': internalExpandedState.includes(value),
         onClick: composeEventHandlers(props.onClick, () => toggle(value)),
         onKeyDown: composeEventHandlers(props.onKeyDown, (event: KeyboardEvent) => {

--- a/packages/accordion/src/useAccordion.ts
+++ b/packages/accordion/src/useAccordion.ts
@@ -30,7 +30,7 @@ export function useAccordion<Value>({
 
   const isControlled = expandedSections !== null && expandedSections !== undefined;
   const [expandedState, setExpandedState] = useState<Value[]>(
-    defaultExpandedSections || expandedSections || sections.slice(0, 1)
+    defaultExpandedSections || sections.slice(0, 1)
   );
   const [disabledState, setDisabledState] = useState(collapsible ? [] : expandedState);
   const internalExpandedState = getControlledValue(expandedSections, expandedState)!;
@@ -70,68 +70,44 @@ export function useAccordion<Value>({
   );
 
   const getHeaderProps = useCallback(
-    ({ role = 'heading', 'aria-level': ariaLevel, ...props } = {}) => {
-      if (ariaLevel === undefined) {
-        throw new Error(
-          'Accessibility Error: You must apply the `aria-level` prop to `getHeaderProps()`'
-        );
-      }
-
-      return {
-        role,
-        'aria-level': ariaLevel,
-        'data-garden-container-id': 'containers.accordion',
-        'data-garden-container-version': PACKAGE_VERSION,
-        ...props
-      };
-    },
+    ({ role = 'heading', 'aria-level': ariaLevel, ...props } = {}) => ({
+      role,
+      'aria-level': ariaLevel,
+      'data-garden-container-id': 'containers.accordion',
+      'data-garden-container-version': PACKAGE_VERSION,
+      ...props
+    }),
     []
   );
 
   const getTriggerProps = useCallback(
-    ({ value, role = 'button', tabIndex = 0, ...props } = {}) => {
-      if (value === undefined) {
-        throw new Error(
-          'Accessibility Error: You must provide an `value` option to `getTriggerProps()`'
-        );
-      }
-
-      return {
-        id: `${TRIGGER_ID}:${value}`,
-        role,
-        tabIndex,
-        'aria-controls': `${PANEL_ID}:${value}`,
-        'aria-disabled': disabledState.includes(value) || null,
-        'aria-expanded': internalExpandedState.includes(value),
-        onClick: composeEventHandlers(props.onClick, () => toggle(value)),
-        onKeyDown: composeEventHandlers(props.onKeyDown, (event: KeyboardEvent) => {
-          if (event.keyCode === KEY_CODES.SPACE || event.keyCode === KEY_CODES.ENTER) {
-            toggle(value);
-            event.preventDefault();
-          }
-        }),
-        ...props
-      };
-    },
+    ({ value, role = 'button', tabIndex = 0, ...props } = {}) => ({
+      id: `${TRIGGER_ID}:${value}`,
+      role,
+      tabIndex,
+      'aria-controls': `${PANEL_ID}:${value}`,
+      'aria-disabled': disabledState.includes(value) || null,
+      'aria-expanded': internalExpandedState.includes(value),
+      onClick: composeEventHandlers(props.onClick, () => toggle(value)),
+      onKeyDown: composeEventHandlers(props.onKeyDown, (event: KeyboardEvent) => {
+        if (event.keyCode === KEY_CODES.SPACE || event.keyCode === KEY_CODES.ENTER) {
+          toggle(value);
+          event.preventDefault();
+        }
+      }),
+      ...props
+    }),
     [PANEL_ID, TRIGGER_ID, internalExpandedState, disabledState, toggle]
   );
 
   const getPanelProps = useCallback(
-    ({ value, role = 'region', ...props } = {}) => {
-      if (value === undefined) {
-        throw new Error(
-          'Accessibility Error: You must provide an `value` option to `getPanelProps()`'
-        );
-      }
-
-      return {
-        id: `${PANEL_ID}:${value}`,
-        role,
-        'aria-hidden': !internalExpandedState.includes(value),
-        'aria-labelledby': `${TRIGGER_ID}:${value}`,
-        ...props
-      };
-    },
+    ({ value, role = 'region', ...props } = {}) => ({
+      id: `${PANEL_ID}:${value}`,
+      role,
+      'aria-hidden': !internalExpandedState.includes(value),
+      'aria-labelledby': `${TRIGGER_ID}:${value}`,
+      ...props
+    }),
     [PANEL_ID, TRIGGER_ID, internalExpandedState]
   );
 

--- a/packages/accordion/src/useAccordion.ts
+++ b/packages/accordion/src/useAccordion.ts
@@ -5,185 +5,150 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { useState, HTMLProps, useMemo } from 'react';
-import { useUIDSeed } from 'react-uid';
+import { useState, useMemo, useCallback } from 'react';
 import {
-  composeEventHandlers,
   KEY_CODES,
-  getControlledValue
+  composeEventHandlers,
+  getControlledValue,
+  useId
 } from '@zendeskgarden/container-utilities';
 
-export interface IUseAccordionProps {
-  /** Prefixes IDs for the accordion trigger and panels  */
-  idPrefix?: string;
-  /** Sets the expanded sections in a controlled accordion */
-  expandedSections?: number[];
-  /** Sets the default expanded sections in a uncontrolled accordion */
-  defaultExpandedSections?: number[];
-  /** Handles accordion expansion changes */
-  onChange?: (expanded: number) => any;
-  /** Determines if multiple panels can be expanded at the same time in an uncontrolled accordion */
-  expandable?: boolean;
-  /** Determines if panels can be collapsed in an uncontrolled accordion */
-  collapsible?: boolean;
-}
-
-interface IHeaderProps extends HTMLProps<any> {
-  ariaLevel?: number | null;
-  role?: any;
-}
-
-interface ITriggerProps extends HTMLProps<any> {
-  index?: number;
-  role?: any;
-  tabIndex?: any;
-}
-
-interface IPanelProps extends HTMLProps<any> {
-  index?: number;
-  role?: any;
-}
-
-export interface IUseAccordionPropGetters {
-  getHeaderProps: <T>(options?: T & IHeaderProps) => any;
-  getTriggerProps: <T>(options?: T & ITriggerProps) => any;
-  getPanelProps: <T>(options?: T & IPanelProps) => any;
-}
-
-export interface IUseAccordionReturnValue extends IUseAccordionPropGetters {
-  expandedSections: number[];
-  disabledSections: number[];
-}
+import {
+  IUseAccordionProps,
+  IUseAccordionReturnValue,
+  IHeaderProps,
+  ITriggerProps,
+  IPanelProps
+} from './types';
 
 export function useAccordion({
   idPrefix,
+  sections,
   expandedSections,
+  defaultExpandedSections,
   onChange,
   expandable = true,
-  collapsible = true,
-  defaultExpandedSections
+  collapsible = true
 }: IUseAccordionProps = {}): IUseAccordionReturnValue {
-  const isControlled = expandedSections !== null && expandedSections !== undefined;
-  const seed = useUIDSeed();
-  const prefix = useMemo<string>(
-    () => idPrefix || seed(`accordion_${PACKAGE_VERSION}`),
-    [idPrefix, seed]
-  );
+  const prefix = useId(idPrefix);
   const TRIGGER_ID = `${prefix}--trigger`;
   const PANEL_ID = `${prefix}--panel`;
+
+  const isControlled = expandedSections !== null && expandedSections !== undefined;
   const [expandedState, setExpandedState] = useState<number[]>(defaultExpandedSections || [0]);
-
-  const controlledExpandedState = getControlledValue(expandedSections, expandedState)!;
-
   const [disabledState, setDisabledState] = useState(collapsible ? [] : expandedState);
+  const internalExpandedState = getControlledValue(expandedSections, expandedState)!;
 
-  const sectionIndices: number[] = [];
-  const toggle = (index: number) => {
-    const expanded: number[] = [];
-    const disabled: number[] = [];
+  const toggle = useCallback(
+    (index: number) => {
+      const expanded: number[] = [];
+      const disabled: number[] = [];
 
-    sectionIndices.forEach(sectionIndex => {
-      let isExpanded = false;
+      sections!.forEach(sectionIndex => {
+        let isExpanded = false;
 
-      if (sectionIndex === index) {
-        isExpanded = collapsible ? expandedState.indexOf(sectionIndex) === -1 : true;
-      } else if (expandable) {
-        isExpanded = expandedState.indexOf(sectionIndex) !== -1;
+        if (sectionIndex === index) {
+          isExpanded = collapsible ? expandedState.indexOf(sectionIndex) === -1 : true;
+        } else if (expandable) {
+          isExpanded = expandedState.indexOf(sectionIndex) !== -1;
+        }
+
+        if (isExpanded) {
+          expanded.push(sectionIndex);
+
+          if (!collapsible) {
+            disabled.push(sectionIndex);
+          }
+        }
+      });
+
+      if (onChange) {
+        onChange(index);
       }
 
-      if (isExpanded) {
-        expanded.push(sectionIndex);
-
-        if (!collapsible) {
-          disabled.push(sectionIndex);
-        }
+      if (isControlled === false) {
+        setExpandedState(expanded);
       }
-    });
 
-    if (onChange) {
-      onChange(index);
-    }
+      setDisabledState(disabled);
+    },
+    [sections, expandedState, collapsible, expandable, isControlled, onChange]
+  );
 
-    if (isControlled === false) {
-      setExpandedState(expanded);
-    }
+  const getHeaderProps = useCallback(
+    ({ role = 'heading', ariaLevel, ...props }: IHeaderProps = {}) => {
+      if (ariaLevel === undefined) {
+        throw new Error(
+          'Accessibility Error: You must apply the `ariaLevel` prop to `getHeaderProps()`'
+        );
+      }
 
-    setDisabledState(disabled);
-  };
+      return {
+        role,
+        'aria-level': ariaLevel,
+        'data-garden-container-id': 'containers.accordion',
+        'data-garden-container-version': PACKAGE_VERSION,
+        ...props
+      };
+    },
+    []
+  );
 
-  const getHeaderProps = ({ role = 'heading', ariaLevel, ...props }: IHeaderProps = {}) => {
-    if (ariaLevel === undefined) {
-      throw new Error(
-        'Accessibility Error: You must apply the `ariaLevel` prop to the element that contains your heading.'
-      );
-    }
+  const getTriggerProps = useCallback(
+    ({ index, role = 'button', tabIndex = 0, ...props }: ITriggerProps = {}) => {
+      if (index === undefined) {
+        throw new Error(
+          'Accessibility Error: You must provide an `index` option to `getTriggerProps()`'
+        );
+      }
 
-    return {
-      role,
-      'aria-level': ariaLevel,
-      'data-garden-container-id': 'containers.accordion',
-      'data-garden-container-version': PACKAGE_VERSION,
-      ...props
-    };
-  };
+      return {
+        id: `${TRIGGER_ID}:${index}`,
+        role,
+        tabIndex,
+        'aria-controls': `${PANEL_ID}:${index}`,
+        'aria-disabled': disabledState.includes(index),
+        'aria-expanded': internalExpandedState.includes(index),
+        onClick: composeEventHandlers(props.onClick, () => toggle(index)),
+        onKeyDown: composeEventHandlers(props.onKeyDown, (event: KeyboardEvent) => {
+          if (event.keyCode === KEY_CODES.SPACE || event.keyCode === KEY_CODES.ENTER) {
+            toggle(index);
+            event.preventDefault();
+          }
+        }),
+        ...props
+      };
+    },
+    [PANEL_ID, TRIGGER_ID, internalExpandedState, disabledState, toggle]
+  );
 
-  const getTriggerProps = ({
-    index,
-    role = 'button',
-    tabIndex = 0,
-    ...props
-  }: ITriggerProps = {}) => {
-    if (index === undefined) {
-      throw new Error(
-        'Accessibility Error: You must provide an `index` option to `getTriggerProps()`'
-      );
-    }
+  const getPanelProps = useCallback(
+    ({ index, role = 'region', ...props }: IPanelProps = {}) => {
+      if (index === undefined) {
+        throw new Error(
+          'Accessibility Error: You must provide an `index` option to `getPanelProps()`'
+        );
+      }
 
-    sectionIndices.push(index);
+      return {
+        id: `${PANEL_ID}:${index}`,
+        role,
+        'aria-hidden': !internalExpandedState.includes(index),
+        'aria-labelledby': `${TRIGGER_ID}:${index}`,
+        ...props
+      };
+    },
+    [PANEL_ID, TRIGGER_ID, internalExpandedState]
+  );
 
-    return {
-      id: `${TRIGGER_ID}:${index}`,
-      role,
-      tabIndex,
-      'aria-controls': `${PANEL_ID}:${index}`,
-      'aria-disabled': disabledState.indexOf(index) !== -1,
-      'aria-expanded': isControlled
-        ? controlledExpandedState.includes(index)
-        : expandedState.includes(index),
-      onClick: composeEventHandlers(props.onClick, () => toggle(index)),
-      onKeyDown: composeEventHandlers(props.onKeyDown, (event: KeyboardEvent) => {
-        if (event.keyCode === KEY_CODES.SPACE || event.keyCode === KEY_CODES.ENTER) {
-          toggle(index);
-          event.preventDefault();
-        }
-      }),
-      ...props
-    };
-  };
-
-  const getPanelProps = ({ index, role = 'region', ...props }: IPanelProps = {}) => {
-    if (index === undefined) {
-      throw new Error(
-        'Accessibility Error: You must provide an `index` option to `getSectionProps()`'
-      );
-    }
-
-    return {
-      id: `${PANEL_ID}:${index}`,
-      role,
-      'aria-hidden': isControlled
-        ? !controlledExpandedState.includes(index)
-        : !expandedState.includes(index),
-      'aria-labelledby': `${TRIGGER_ID}:${index}`,
-      ...props
-    };
-  };
-
-  return {
-    getHeaderProps,
-    getTriggerProps,
-    getPanelProps,
-    expandedSections: controlledExpandedState,
-    disabledSections: disabledState
-  };
+  return useMemo(
+    () => ({
+      getHeaderProps,
+      getTriggerProps,
+      getPanelProps,
+      expandedSections: internalExpandedState,
+      disabledSections: disabledState
+    }),
+    [getHeaderProps, getTriggerProps, getPanelProps, internalExpandedState, disabledState]
+  );
 }

--- a/packages/accordion/src/useAccordion.ts
+++ b/packages/accordion/src/useAccordion.ts
@@ -40,7 +40,7 @@ export function useAccordion<Value>({
       const expanded: Value[] = [];
       const disabled: Value[] = [];
 
-      sections!.forEach(sectionValue => {
+      sections.forEach(sectionValue => {
         let isExpanded = false;
 
         if (sectionValue === value) {

--- a/packages/accordion/yarn.lock
+++ b/packages/accordion/yarn.lock
@@ -9,19 +9,27 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-react-uid@^2.2.0:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/react-uid/-/react-uid-2.3.3.tgz#6a485ccc868555997f3506c6db97a3e735d97adf"
-  integrity sha512-iNpDovcb9qBpBTo8iUgqRSQOS8GV3bWoNaTaUptHkXtAooXSo0OWe7vN6TqqB8x3x0bNBbQx96kkmSltQ5h9kQ==
+"@reach/auto-id@^0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.18.0.tgz#4b97085cd1cf1360a9bedc6e9c78e97824014f0d"
+  integrity sha512-XwY1IwhM7mkHZFghhjiqjQ6dstbOdpbFLdggeke75u8/8icT8uEHLbovFUgzKjy9qPvYwZIB87rLiR8WdtOXCg==
   dependencies:
-    tslib "^2.0.0"
+    "@reach/utils" "0.18.0"
+
+"@reach/utils@0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.18.0.tgz#4f3cebe093dd436eeaff633809bf0f68f4f9d2ee"
+  integrity sha512-KdVMdpTgDyK8FzdKO9SCpiibuy/kbv3pwgfXshTI6tEcQT1OOwj7BAksnzGC0rPz0UholwC+AgkqEl3EJX3M1A==
+
+"@zendeskgarden/container-utilities@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-1.0.8.tgz#c2e59d355080cfcb2b9a516c53ddda604e9b34fc"
+  integrity sha512-7ERJtrnaVUD+qOnp8XTlofuV67+j5XleVRXJy1QmVi/Yy/usqjcCFpMosZnYVMgDHmJgvHomUyqTNvKdgqwfrg==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@reach/auto-id" "^0.18.0"
 
 regenerator-runtime@^0.13.11:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
-
-tslib@^2.0.0:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.3.tgz#24944ba2d990940e6e982c4bea147aba80209913"
-  integrity sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==


### PR DESCRIPTION
- [x] **BREAKING CHANGE?**

## Description

Adds a new `sections` prop to explicitly define each section. Moving forward, `sections` will be needed for the `useAccordion` container to work properly. There have been additional changes to the distribution exports.

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [ ] :guardsman: ~includes new unit tests~
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge