### PR TITLE
chore(deps): revert prettier to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "markdownlint-cli": "0.35.0",
     "ora": "5.4.1",
     "postcss": "8.4.27",
-    "prettier": "3.0.0",
+    "prettier": "2.8.8",
     "prettier-package-json": "2.8.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/packages/slider/src/useSlider.ts
+++ b/packages/slider/src/useSlider.ts
@@ -181,8 +181,8 @@ export function useSlider<T extends Element = Element, M extends HTMLElement = H
 
   const getThumbProps = useCallback(
     (
-      thumb: 'min' | 'max'
-    ): IUseSliderReturnValue['getMinThumbProps'] | IUseSliderReturnValue['getMaxThumbProps'] =>
+        thumb: 'min' | 'max'
+      ): IUseSliderReturnValue['getMinThumbProps'] | IUseSliderReturnValue['getMaxThumbProps'] =>
       ({ onKeyDown, onMouseDown, onTouchStart, ...other }) => {
         const handleKeyDown = (event: KeyboardEvent) => {
           if (!disabled) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17568,12 +17568,7 @@ prettier-package-json@2.8.0:
     sort-object-keys "^1.1.3"
     sort-order "^1.0.1"
 
-prettier@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.0.tgz#e7b19f691245a21d618c68bc54dc06122f6105ae"
-  integrity sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==
-
-prettier@^2.8.0:
+prettier@2.8.8, prettier@^2.8.0:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==


### PR DESCRIPTION
## Description

Reverting `prettier` to v2 as it is causing failure when tagging releases.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :globe_with_meridians: ~demo is up-to-date (`yarn start`)~
- [ ] :guardsman: ~includes new unit tests~
- [ ] :wheelchair: ~tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance~
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
