### PR TITLE
fix(utilities): update `useId` to handle SSR

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@testing-library/dom": "9.3.1",
     "@testing-library/jest-dom": "5.17.0",
     "@testing-library/react": "12.1.5",
+    "@testing-library/react-hooks": "8.0.1",
     "@testing-library/user-event": "14.4.3",
     "@types/jest": "29.5.3",
     "@types/prop-types": "15.7.5",

--- a/packages/utilities/.size-snapshot.json
+++ b/packages/utilities/.size-snapshot.json
@@ -19,14 +19,14 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 4093,
-    "minified": 2568,
-    "gzipped": 1235
+    "bundled": 4092,
+    "minified": 2567,
+    "gzipped": 1234
   },
   "index.esm.js": {
-    "bundled": 3878,
-    "minified": 2369,
-    "gzipped": 1199,
+    "bundled": 3877,
+    "minified": 2368,
+    "gzipped": 1198,
     "treeshaked": {
       "rollup": {
         "code": 282,

--- a/packages/utilities/.size-snapshot.json
+++ b/packages/utilities/.size-snapshot.json
@@ -19,14 +19,14 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 4092,
-    "minified": 2566,
-    "gzipped": 1244
+    "bundled": 4093,
+    "minified": 2568,
+    "gzipped": 1235
   },
   "index.esm.js": {
-    "bundled": 3777,
-    "minified": 2284,
-    "gzipped": 1156,
+    "bundled": 3878,
+    "minified": 2369,
+    "gzipped": 1199,
     "treeshaked": {
       "rollup": {
         "code": 282,

--- a/packages/utilities/src/utils/useId.spec.tsx
+++ b/packages/utilities/src/utils/useId.spec.tsx
@@ -18,9 +18,13 @@ describe('useId()', () => {
   });
 
   it('generates ID', () => {
-    const { result } = renderHook(() => useId(undefined));
+    const { result, hydrate } = renderHook(() => useId(undefined));
 
     expect(result.current).toContain('id:');
+
+    hydrate();
+
+    expect(result.current).toBeGreaterThanOrEqual(0);
   });
 
   it('accepts an ID', () => {

--- a/packages/utilities/src/utils/useId.spec.tsx
+++ b/packages/utilities/src/utils/useId.spec.tsx
@@ -1,0 +1,35 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+// import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react-hooks/server';
+import { useId } from './useId';
+
+describe('useId()', () => {
+  const consoleError = console.error;
+
+  beforeEach(() => {
+    // filter @reach/auto-id useLayoutEffect console errors
+    console.error = jest.fn();
+  });
+
+  it('generates ID', () => {
+    const { result } = renderHook(() => useId(undefined));
+
+    expect(result.current).toContain('id:');
+  });
+
+  it('accepts an ID', () => {
+    const { result } = renderHook(() => useId('test'));
+
+    expect(result.current).toBe('test');
+  });
+
+  afterEach(() => {
+    console.error = consoleError;
+  });
+});

--- a/packages/utilities/src/utils/useId.ts
+++ b/packages/utilities/src/utils/useId.ts
@@ -16,4 +16,4 @@ let idCounter = 0;
  *
  * @returns A generated ID that can be passed to accessibility attributes
  */
-export const useId = (id: any): string | number => useReachId(id) || `id:${idCounter++}`;
+export const useId = (id: any) => useReachId(id) || `id:${idCounter++}`;

--- a/packages/utilities/src/utils/useId.ts
+++ b/packages/utilities/src/utils/useId.ts
@@ -16,4 +16,4 @@ let idCounter = 0;
  *
  * @returns A generated ID that can be passed to accessibility attributes
  */
-export const useId = (id: any) => useReachId(id) || `id:${idCounter++}`;
+export const useId = (id: any): string | number => useReachId(id) || `id:${idCounter++}`;

--- a/packages/utilities/src/utils/useId.ts
+++ b/packages/utilities/src/utils/useId.ts
@@ -5,7 +5,15 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+import { useId as useReachId } from '@reach/auto-id';
+
+let idCounter = 0;
+
 /**
- * Autogenerate IDs to facilitate WAI-ARIA and server rendering from @reach, https://reach.tech/auto-id.
+ * Hook for generating a unique ID
+ *
+ * @param id A user provided ID
+ *
+ * @returns A generated ID that can be passed to accessibility attributes
  */
-export * from '@reach/auto-id';
+export const useId = (id: any) => useReachId(id) || `ssr:${idCounter++}`;

--- a/packages/utilities/src/utils/useId.ts
+++ b/packages/utilities/src/utils/useId.ts
@@ -16,4 +16,4 @@ let idCounter = 0;
  *
  * @returns A generated ID that can be passed to accessibility attributes
  */
-export const useId = (id: any) => useReachId(id) || `ssr:${idCounter++}`;
+export const useId = (id: any) => useReachId(id) || `id:${idCounter++}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5332,6 +5332,14 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@12.1.5":
   version "12.1.5"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.5.tgz#bb248f72f02a5ac9d949dea07279095fa577963b"
@@ -17181,6 +17189,13 @@ react-element-to-jsx-string@^15.0.0:
     "@base2/pretty-print-object" "1.0.1"
     is-plain-object "5.0.0"
     react-is "18.1.0"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-inspector@^6.0.0:
   version "6.0.2"


### PR DESCRIPTION
## Description

Provide an `idCounter` fallback (same as used by the legacy [IdManager](https://github.com/zendeskgarden/react-containers/blob/main/packages/utilities/src/utils/IdManager.ts)) for SSR environments that produce `undefined` IDs.

## Detail

Verified the patch by testing the compiled `dist` with a build of the Garden website.
