### PR TITLE
fix(combobox): stabilize ID prefix

### DIFF
--- a/packages/combobox/.size-snapshot.json
+++ b/packages/combobox/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 26260,
-    "minified": 14174,
-    "gzipped": 4004
+    "bundled": 26315,
+    "minified": 14219,
+    "gzipped": 4009
   },
   "index.esm.js": {
-    "bundled": 25192,
-    "minified": 13107,
-    "gzipped": 3982,
+    "bundled": 25241,
+    "minified": 13146,
+    "gzipped": 3988,
     "treeshaked": {
       "rollup": {
         "code": 1296,
         "import_statements": 177
       },
       "webpack": {
-        "code": 13044
+        "code": 13089
       }
     }
   }

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -58,10 +58,10 @@ export const useCombobox = <
     altKey?: boolean;
   }
 
-  const prefix = `${useId(idPrefix)}-`;
   const [triggerContainsInput, setTriggerContainsInput] = useState<boolean>();
   const [matchValue, setMatchValue] = useState('');
   const matchTimeoutRef = useRef<number>();
+  const prefixRef = useRef(`${useId(idPrefix)}-`);
   const previousStateRef = useRef<IPreviousState>();
   const labels: Record<string, string> = useMemo(() => ({}), []);
   const selectedValues: OptionValue[] = useMemo(() => [], []);
@@ -266,8 +266,8 @@ export const useCombobox = <
 
   const getOptionId = useCallback(
     (index: number, isDisabled?: boolean) =>
-      `${prefix}-option${isDisabled ? '-disabled' : ''}-${index}`,
-    [prefix]
+      `${prefixRef.current}-option${isDisabled ? '-disabled' : ''}-${index}`,
+    []
   );
 
   /** Hooks */
@@ -286,9 +286,9 @@ export const useCombobox = <
     setHighlightedIndex,
     selectItem
   } = useDownshift<OptionValue | OptionValue[]>({
-    id: prefix,
-    toggleButtonId: `${prefix}-trigger`,
-    menuId: `${prefix}-listbox`,
+    id: prefixRef.current,
+    toggleButtonId: `${prefixRef.current}-trigger`,
+    menuId: `${prefixRef.current}-listbox`,
     getItemId: getOptionId,
     items: values,
     inputValue,

--- a/packages/utilities/src/utils/useId.spec.tsx
+++ b/packages/utilities/src/utils/useId.spec.tsx
@@ -17,10 +17,14 @@ describe('useId()', () => {
     console.error = jest.fn();
   });
 
-  it('generates ID', () => {
-    const { result, hydrate } = renderHook(() => useId(undefined));
+  it('generates SSR ID', () => {
+    const { result } = renderHook(() => useId());
 
     expect(result.current).toContain('id:');
+  });
+
+  it('generates CSR ID', () => {
+    const { result, hydrate } = renderHook(() => useId());
 
     hydrate();
 

--- a/packages/utilities/src/utils/useId.ts
+++ b/packages/utilities/src/utils/useId.ts
@@ -16,4 +16,4 @@ let idCounter = 0;
  *
  * @returns A generated ID that can be passed to accessibility attributes
  */
-export const useId = (id: any) => useReachId(id) || `id:${idCounter++}`;
+export const useId = (id?: any) => useReachId(id) || `id:${idCounter++}`;


### PR DESCRIPTION
## Description

Prior to this PR, `useId` was called and IDs/ID prefixes were handed off to both the Garden `useField` and Downshift `useCombobox` hooks. Upon hydration, `useField` was updated with the underlying `@reach/auto-id` layout effect. But Downshift puts IDs in a ref, where they are not updated. The effect is ID mismatch between label & input.

By wrapping the `useId` call in `useRef`, we prevent the ID state update on hydration and cross-references remain stable.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
