### PR TITLE
fix(combobox): stabilize ID usage

### DIFF
--- a/packages/combobox/.size-snapshot.json
+++ b/packages/combobox/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 26315,
-    "minified": 14219,
-    "gzipped": 4009
+    "bundled": 27148,
+    "minified": 14653,
+    "gzipped": 4144
   },
   "index.esm.js": {
-    "bundled": 25241,
-    "minified": 13146,
-    "gzipped": 3988,
+    "bundled": 26068,
+    "minified": 13574,
+    "gzipped": 4119,
     "treeshaked": {
       "rollup": {
         "code": 1296,
         "import_statements": 177
       },
       "webpack": {
-        "code": 13089
+        "code": 13523
       }
     }
   }

--- a/packages/combobox/.size-snapshot.json
+++ b/packages/combobox/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 27148,
-    "minified": 14653,
-    "gzipped": 4144
+    "bundled": 27141,
+    "minified": 14638,
+    "gzipped": 4159
   },
   "index.esm.js": {
-    "bundled": 26068,
-    "minified": 13574,
-    "gzipped": 4119,
+    "bundled": 26061,
+    "minified": 13559,
+    "gzipped": 4133,
     "treeshaked": {
       "rollup": {
         "code": 1296,
         "import_statements": 177
       },
       "webpack": {
-        "code": 13523
+        "code": 13508
       }
     }
   }

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -61,18 +61,21 @@ export const useCombobox = <
   const [triggerContainsInput, setTriggerContainsInput] = useState<boolean>();
   const [matchValue, setMatchValue] = useState('');
   const matchTimeoutRef = useRef<number>();
-  const prefix = useId(idPrefix);
-  const idRef = useRef({
-    label: `${prefix}--label`,
-    hint: `${prefix}--hint`,
-    trigger: `${prefix}--trigger`,
-    input: `${prefix}--input`,
-    listbox: `${prefix}--listbox`,
-    message: `${prefix}--message`,
-    getOptionId: (index: number, isDisabled?: boolean) =>
-      `${prefix}--option${isDisabled ? '-disabled' : ''}-${index}`
-  });
   const previousStateRef = useRef<IPreviousState>();
+  const prefix = useId(idPrefix);
+  const ids = useMemo(
+    () => ({
+      label: `${prefix}--label`,
+      hint: `${prefix}--hint`,
+      trigger: `${prefix}--trigger`,
+      input: `${prefix}--input`,
+      listbox: `${prefix}--listbox`,
+      message: `${prefix}--message`,
+      getOptionId: (index: number, isDisabled?: boolean) =>
+        `${prefix}--option${isDisabled ? '-disabled' : ''}-${index}`
+    }),
+    [prefix]
+  );
   const labels: Record<string, string> = useMemo(() => ({}), []);
   const selectedValues: OptionValue[] = useMemo(() => [], []);
   const disabledValues: OptionValue[] = useMemo(() => [], []);
@@ -290,9 +293,9 @@ export const useCombobox = <
     setHighlightedIndex,
     selectItem
   } = useDownshift<OptionValue | OptionValue[]>({
-    toggleButtonId: idRef.current.trigger,
-    menuId: idRef.current.listbox,
-    getItemId: idRef.current.getOptionId,
+    toggleButtonId: ids.trigger,
+    menuId: ids.listbox,
+    getItemId: ids.getOptionId,
     items: values,
     inputValue,
     initialInputValue,
@@ -546,7 +549,7 @@ export const useCombobox = <
           ...triggerProps,
           'aria-activedescendant': ariaActiveDescendant,
           'aria-haspopup': 'listbox',
-          'aria-labelledby': idRef.current.label,
+          'aria-labelledby': ids.label,
           'aria-disabled': disabled || undefined,
           disabled: undefined,
           role: 'combobox',
@@ -574,6 +577,7 @@ export const useCombobox = <
       values,
       labels,
       triggerContainsInput,
+      ids.label,
       isAutocomplete,
       isEditable,
       isMultiselectable,
@@ -584,8 +588,8 @@ export const useCombobox = <
   const getLabelProps = useCallback<IUseComboboxReturnValue['getLabelProps']>(
     ({ onClick, ...other } = {}) => {
       const { htmlFor, ...labelProps } = getFieldLabelProps({
-        id: idRef.current.label,
-        htmlFor: idRef.current.input,
+        id: ids.label,
+        htmlFor: ids.input,
         ...other
       });
       const handleClick = () => !isEditable && triggerRef.current?.focus();
@@ -596,12 +600,12 @@ export const useCombobox = <
         htmlFor: isEditable ? htmlFor : undefined
       };
     },
-    [getFieldLabelProps, isEditable, triggerRef]
+    [getFieldLabelProps, ids.input, ids.label, isEditable, triggerRef]
   );
 
   const getHintProps = useCallback<IUseComboboxReturnValue['getHintProps']>(
-    props => getFieldHintProps({ id: idRef.current.hint, ...props }),
-    [getFieldHintProps]
+    props => getFieldHintProps({ id: ids.hint, ...props }),
+    [getFieldHintProps, ids.hint]
   );
 
   const getInputProps = useCallback<IUseComboboxReturnValue['getInputProps']>(
@@ -624,11 +628,11 @@ export const useCombobox = <
         const describedBy = [];
 
         if (hasHint) {
-          describedBy.push(idRef.current.hint);
+          describedBy.push(ids.hint);
         }
 
         if (hasMessage) {
-          describedBy.push(idRef.current.message);
+          describedBy.push(ids.message);
         }
 
         return getDownshiftInputProps<any>({
@@ -638,8 +642,8 @@ export const useCombobox = <
           'aria-autocomplete': isAutocomplete ? 'list' : undefined,
           onClick: composeEventHandlers(onClick, handleClick),
           ...getFieldInputProps({
-            id: idRef.current.input,
-            'aria-labelledby': idRef.current.label,
+            id: ids.input,
+            'aria-labelledby': ids.label,
             'aria-describedby': describedBy.length > 0 ? describedBy.join(' ') : undefined
           }),
           ...other
@@ -679,6 +683,10 @@ export const useCombobox = <
       getFieldInputProps,
       hasHint,
       hasMessage,
+      ids.hint,
+      ids.input,
+      ids.label,
+      ids.message,
       inputRef,
       triggerRef,
       disabled,
@@ -787,7 +795,7 @@ export const useCombobox = <
           'aria-disabled': true,
           'aria-selected': ariaSelected,
           id: option
-            ? idRef.current.getOptionId(disabledValues.indexOf(option.value), option.disabled)
+            ? ids.getOptionId(disabledValues.indexOf(option.value), option.disabled)
             : undefined,
           ...optionProps,
           onMouseDown: composeEventHandlers(onMouseDown, handleMouseDown)
@@ -802,12 +810,12 @@ export const useCombobox = <
         ...optionProps
       } as IDownshiftOptionProps<OptionValue>);
     },
-    [getDownshiftOptionProps, disabledValues, values, _selectionValue]
+    [getDownshiftOptionProps, disabledValues, ids, values, _selectionValue]
   );
 
   const getMessageProps = useCallback<IUseComboboxReturnValue['getMessageProps']>(
-    props => getFieldMessageProps({ id: idRef.current.message, ...props }),
-    [getFieldMessageProps]
+    props => getFieldMessageProps({ id: ids.message, ...props }),
+    [getFieldMessageProps, ids.message]
   );
 
   /** Actions */

--- a/packages/field/.size-snapshot.json
+++ b/packages/field/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "index.cjs.js": {
-    "bundled": 2943,
-    "minified": 1647,
-    "gzipped": 633
+    "bundled": 3142,
+    "minified": 1698,
+    "gzipped": 649
   },
   "index.esm.js": {
-    "bundled": 2854,
-    "minified": 1563,
-    "gzipped": 622,
+    "bundled": 3053,
+    "minified": 1614,
+    "gzipped": 635,
     "treeshaked": {
       "rollup": {
         "code": 120,

--- a/packages/field/src/FieldContainer.spec.tsx
+++ b/packages/field/src/FieldContainer.spec.tsx
@@ -74,6 +74,18 @@ describe('FieldContainer', () => {
           .trim()
       );
     });
+
+    it('overrides `aria-describedby` if provided', () => {
+      const { getByTestId } = render(
+        <FieldContainer>
+          {({ getInputProps }) => (
+            <input data-test-id="input" {...getInputProps({ 'aria-describedby': 'test' })} />
+          )}
+        </FieldContainer>
+      );
+
+      expect(getByTestId('input')).toHaveAttribute('aria-describedby', 'test');
+    });
   });
 
   describe('getHintProps', () => {

--- a/packages/field/src/useField.ts
+++ b/packages/field/src/useField.ts
@@ -42,23 +42,31 @@ export const useField = ({
   );
 
   const getInputProps = useCallback<IUseFieldReturnValue['getInputProps']>(
-    ({ id = inputId, ...other } = {}) => {
-      const describedBy = [];
+    ({ id = inputId, 'aria-describedby': ariaDescribedBy, ...other } = {}) => {
+      const getDescribedBy = () => {
+        if (ariaDescribedBy) {
+          return ariaDescribedBy;
+        }
 
-      if (hasHint) {
-        describedBy.push(hintId);
-      }
+        const describedBy = [];
 
-      if (hasMessage) {
-        describedBy.push(messageId);
-      }
+        if (hasHint) {
+          describedBy.push(hintId);
+        }
+
+        if (hasMessage) {
+          describedBy.push(messageId);
+        }
+
+        return describedBy.length > 0 ? describedBy.join(' ') : undefined;
+      };
 
       return {
         'data-garden-container-id': 'containers.field.input',
         'data-garden-container-version': PACKAGE_VERSION,
         id,
         'aria-labelledby': labelId,
-        'aria-describedby': describedBy.length > 0 ? describedBy.join(' ') : undefined,
+        'aria-describedby': getDescribedBy(),
         ...other
       };
     },


### PR DESCRIPTION
## Description

This PR centralizes ID control within `useCombobox`, preventing either of the underlying hooks (`useDownshift` & `useField`) from generating IDs. With effects in play, partial rerenders could inadvertently bump and invalidate component ID relationships. These relationships are now maintained throughout the lifetime of the component.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
