### PR TITLE
feat(menu): enables initial selected items

### DIFF
--- a/packages/menu/.size-snapshot.json
+++ b/packages/menu/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "index.cjs.js": {
-    "bundled": 26265,
-    "minified": 13472,
-    "gzipped": 3718
+    "bundled": 26329,
+    "minified": 13563,
+    "gzipped": 3732
   },
   "index.esm.js": {
-    "bundled": 25329,
-    "minified": 12535,
-    "gzipped": 3697,
+    "bundled": 25387,
+    "minified": 12620,
+    "gzipped": 3713,
     "treeshaked": {
       "rollup": {
         "code": 386,

--- a/packages/menu/demo/stories/MenuStory.tsx
+++ b/packages/menu/demo/stories/MenuStory.tsx
@@ -86,7 +86,7 @@ const Component = ({
                   {item.items.map(groupItem => (
                     <Item
                       key={groupItem.value}
-                      item={{ ...groupItem, name: item.label }}
+                      item={{ ...groupItem }}
                       getItemProps={getItemProps}
                       focusedValue={focusedValue}
                       isSelected={selectedValues.includes(groupItem.value)}

--- a/packages/menu/demo/stories/data.ts
+++ b/packages/menu/demo/stories/data.ts
@@ -23,10 +23,31 @@ export const ITEMS = [
   {
     label: 'Select one',
     items: [
-      { value: 'vegetable-01', label: 'Asparagus', type: 'radio' },
-      { value: 'vegetable-02', label: 'Broccoli', disabled: true, type: 'radio' },
-      { value: 'vegetable-03', label: 'Brussel sprouts', type: 'radio' },
-      { value: 'vegetable-04', label: 'Kale', type: 'radio' }
+      {
+        value: 'vegetable-01',
+        label: 'Asparagus',
+        type: 'radio',
+        name: 'veggies'
+      },
+      {
+        value: 'vegetable-02',
+        label: 'Broccoli',
+        disabled: true,
+        type: 'radio',
+        name: 'veggies'
+      },
+      {
+        value: 'vegetable-03',
+        label: 'Brussel sprouts',
+        type: 'radio',
+        name: 'veggies'
+      },
+      {
+        value: 'vegetable-04',
+        label: 'Kale',
+        type: 'radio',
+        name: 'veggies'
+      }
     ]
   }
 ];

--- a/packages/menu/src/MenuContainer.spec.tsx
+++ b/packages/menu/src/MenuContainer.spec.tsx
@@ -463,6 +463,25 @@ describe('MenuContainer', () => {
     });
 
     describe('selection', () => {
+      it('applies initial selected items', () => {
+        const { getByText } = render(
+          <TestMenu
+            items={[
+              {
+                label: 'Group',
+                items: [
+                  { value: 'One', type: 'checkbox' },
+                  { value: 'Two', type: 'checkbox', selected: true },
+                  { value: 'Three', type: 'checkbox' }
+                ]
+              }
+            ]}
+          />
+        );
+
+        expect(getByText('Two')).toHaveAttribute('aria-checked', 'true');
+      });
+
       it('closes menu when item is clicked', async () => {
         const { getByTestId, getByText } = render(<TestMenu items={ITEMS} />);
         const trigger = getByTestId('trigger');

--- a/packages/menu/src/types.ts
+++ b/packages/menu/src/types.ts
@@ -12,10 +12,11 @@ export interface ISelectedItem {
   label?: string;
   name?: string;
   type?: 'radio' | 'checkbox';
+  disabled?: boolean;
 }
 
 export interface IMenuItemBase extends ISelectedItem {
-  disabled?: boolean;
+  selected?: boolean;
   isNext?: boolean;
   isPrevious?: boolean;
 }
@@ -37,13 +38,14 @@ export interface IUseMenuProps<T = HTMLButtonElement, M = HTMLElement> {
    * Provides an ordered list of menu items
    *
    * @param {string} item.value Unique item value
-   * @param {string} item.label Human-readable item display value
+   * @param {string} item.label Optional human-readable text value (defaults to `item.value`)
    * @param {string} item.name A shared name corresponding to an item radio group
    * @param {boolean} item.disabled Indicates the item is not interactive
+   * @param {boolean} item.selected Sets initial selection for the option
    * @param {boolean} item.isNext - Indicates the item transitions to a nested menu
    * @param {boolean} item.isPrevious - Indicates the item will transition back from a nested menu
    * @param {boolean} item.separator Indicates the item is a placeholder for a separator
-   * @param {IMenuItemBase[]} item.items Groups a list of items
+   * @param {(IMenuItemBase | IMenuItemSeparator)[]} item.items Groups a list of items
    */
   items: MenuItem[];
   /** Provides ref access to the underlying trigger element */


### PR DESCRIPTION
## Description

Enables default selection of items in an uncontrolled menu by adding `selected: true` to a given item.

Includes a couple miscellaneous refactors/renaming & small typing fix for `IMenuItemBase`.

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :guardsman: includes new unit tests
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
~~:wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance~~