### PR TITLE
fix(combobox): handle IME via controlled input `onChange` override

### DIFF
--- a/packages/combobox/.size-snapshot.json
+++ b/packages/combobox/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "index.cjs.js": {
-    "bundled": 27154,
-    "minified": 14659,
-    "gzipped": 4144
+    "bundled": 27659,
+    "minified": 14911,
+    "gzipped": 4212
   },
   "index.esm.js": {
-    "bundled": 26074,
-    "minified": 13580,
-    "gzipped": 4119,
+    "bundled": 26546,
+    "minified": 13799,
+    "gzipped": 4186,
     "treeshaked": {
       "rollup": {
         "code": 1296,
         "import_statements": 177
       },
       "webpack": {
-        "code": 13529
+        "code": 13754
       }
     }
   }

--- a/packages/combobox/demo/~patterns/patterns.stories.mdx
+++ b/packages/combobox/demo/~patterns/patterns.stories.mdx
@@ -1,0 +1,15 @@
+import { Meta, Canvas, Story } from '@storybook/addon-docs';
+import { IMEStory } from './stories/IMEStory';
+
+<Meta title="Packages/Combobox/[patterns]" />
+
+# Patterns
+
+## IME
+
+Demonstrate a simple (sans `useArgs`) controlled combobox for testing input
+method editor (IME) values.
+
+<Canvas>
+  <Story name="IME">{args => <IMEStory {...args} />}</Story>
+</Canvas>

--- a/packages/combobox/demo/~patterns/stories/IMEStory.tsx
+++ b/packages/combobox/demo/~patterns/stories/IMEStory.tsx
@@ -54,6 +54,7 @@ export const IMEStory: Story = () => {
           className={classNames('mt-1', 'border', 'border-solid', 'absolute', 'w-full', {
             invisible: !isExpanded
           })}
+          style={{ left: 0, top: '100%' }}
           {...getListboxProps({ 'aria-label': 'Options' })}
         >
           {OPTIONS.map((option, index) => (

--- a/packages/combobox/demo/~patterns/stories/IMEStory.tsx
+++ b/packages/combobox/demo/~patterns/stories/IMEStory.tsx
@@ -1,0 +1,73 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { createRef, useState } from 'react';
+import { Story } from '@storybook/react';
+import classNames from 'classnames';
+import { IUseComboboxProps, useCombobox } from '@zendeskgarden/container-combobox';
+import { OPTIONS } from './data';
+
+export const IMEStory: Story = () => {
+  const triggerRef = createRef<HTMLDivElement>();
+  const inputRef = createRef<HTMLInputElement>();
+  const listboxRef = createRef<HTMLUListElement>();
+  const [inputValue, setInputValue] = useState(OPTIONS.find(option => option.selected)?.label);
+
+  const handleChange: IUseComboboxProps['onChange'] = ({ inputValue: _inputValue }) => {
+    if (_inputValue !== undefined) {
+      setInputValue(_inputValue);
+    }
+  };
+
+  const {
+    getLabelProps,
+    getTriggerProps,
+    getInputProps,
+    getListboxProps,
+    getOptionProps,
+    activeValue,
+    isExpanded,
+    selection
+  } = useCombobox({
+    triggerRef,
+    inputRef,
+    listboxRef,
+    options: OPTIONS,
+    inputValue,
+    onChange: handleChange
+  });
+
+  /* eslint-disable jsx-a11y/label-has-associated-control */
+  return (
+    <div className="relative">
+      <label {...getLabelProps()}>Test IME input</label>
+      <div className={classNames('border', 'border-solid', 'p-1')} {...getTriggerProps()}>
+        <input
+          className={classNames('border-none', 'background-transparent')}
+          {...getInputProps()}
+        />
+        <ul
+          className={classNames('mt-1', 'border', 'border-solid', 'absolute', 'w-full', {
+            invisible: !isExpanded
+          })}
+          {...getListboxProps({ 'aria-label': 'Options' })}
+        >
+          {OPTIONS.map((option, index) => (
+            <li
+              key={index}
+              className={classNames({ 'bg-blue-100': option.value === activeValue })}
+              {...getOptionProps({ option })}
+            >
+              {selection && !Array.isArray(selection) && selection.value === option.value && '✓ '}
+              {option.label}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};

--- a/packages/combobox/demo/~patterns/stories/data.ts
+++ b/packages/combobox/demo/~patterns/stories/data.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { IOption } from '@zendeskgarden/container-combobox';
+
+export const OPTIONS: IOption[] = [
+  { value: 'vegetable-01', label: 'Ásparagus', selected: true },
+  { value: 'vegetable-02', label: 'Broccoli' },
+  { value: 'vegetable-03', label: 'Brussel sprouts' },
+  { value: 'vegetable-04', label: 'Cauliflower' },
+  { value: 'vegetable-07', label: 'Kale' }
+];

--- a/packages/combobox/src/ComboboxContainer.spec.tsx
+++ b/packages/combobox/src/ComboboxContainer.spec.tsx
@@ -7,7 +7,7 @@
 
 import React, { createRef, PropsWithChildren } from 'react';
 import { act } from 'react-dom/test-utils';
-import { render, RenderResult } from '@testing-library/react';
+import { fireEvent, render, RenderResult } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ComboboxContainer, useCombobox } from './';
 import { IUseComboboxProps, IUseComboboxReturnValue } from './types';
@@ -805,6 +805,17 @@ describe('ComboboxContainer', () => {
           const changeTypes = handleChange.mock.calls.map(([change]) => change.type);
 
           expect(changeTypes).toMatchObject(['input:click', 'input:keyDown:ArrowDown']);
+        });
+
+        it('handles IME input as expected', () => {
+          fireEvent.change(input, { target: { value: '´' }, nativeEvent: { isComposing: true } });
+          fireEvent.change(input, { target: { value: 'á' }, nativeEvent: { isComposing: true } });
+
+          expect(handleChange).toHaveBeenCalledTimes(2);
+
+          const changeTypes = handleChange.mock.calls.map(([change]) => change.type);
+
+          expect(changeTypes).toMatchObject(['input:change', 'input:change']);
         });
 
         it('handles controlled selection as expected', () => {


### PR DESCRIPTION
## Description

The Downshift `useCombobox` hook currently has an issue that prevents IME from entering expected values in a controlled combobox. This [workaround](https://github.com/downshift-js/downshift/issues/1108#issuecomment-842407759) re-invokes `onChange` with the correct composed input value. The majority of the PR is the introduction of a new "IME" pattern storybook demo so that future updates can be tested with IME without interference from `useArgs`.

**Before**

![before](https://github.com/zendeskgarden/react-containers/assets/143773/aff38139-d1f5-430a-9c6b-0836a0bd0be9)

**After**

![after](https://github.com/zendeskgarden/react-containers/assets/143773/1521ce87-10bf-4a50-81be-5410140b1de2)

## Detail

https://github.com/downshift-js/downshift/issues/1452

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
