### PR TITLE
fix(menu): removes document event listeners when menu closes + fixes …

### DIFF
--- a/packages/menu/.size-snapshot.json
+++ b/packages/menu/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "index.cjs.js": {
-    "bundled": 26329,
-    "minified": 13563,
-    "gzipped": 3733
+    "bundled": 26413,
+    "minified": 13588,
+    "gzipped": 3729
   },
   "index.esm.js": {
-    "bundled": 25387,
-    "minified": 12620,
-    "gzipped": 3714,
+    "bundled": 25471,
+    "minified": 12645,
+    "gzipped": 3711,
     "treeshaked": {
       "rollup": {
         "code": 386,

--- a/packages/menu/src/MenuContainer.spec.tsx
+++ b/packages/menu/src/MenuContainer.spec.tsx
@@ -846,6 +846,27 @@ describe('MenuContainer', () => {
       expect(fruit1).toHaveAttribute('aria-checked', 'true');
     });
 
+    it('returns normal keyboard navigation after menu closes', async () => {
+      const { getByText, getByTestId } = render(
+        <>
+          <TestMenu items={ITEMS} />
+          <button>focus me</button>
+        </>
+      );
+      const trigger = getByTestId('trigger');
+      const nextFocusedElement = getByText('focus me');
+
+      trigger.focus();
+
+      await act(async () => {
+        await user.keyboard('{Enter}'); // select trigger
+        await user.keyboard('{Enter}'); // select first item
+        await user.keyboard('{Tab}');
+      });
+
+      expect(nextFocusedElement).toHaveFocus();
+    });
+
     describe('onChange', () => {
       const onChange = jest.fn();
 

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -538,6 +538,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
 
     return () => {
       win.document.removeEventListener('click', handleMenuBlur, true);
+      win.document.removeEventListener('keydown', handleMenuKeyDown, true);
     };
   }, [controlledIsExpanded, handleMenuBlur, handleMenuKeyDown, environment]);
 
@@ -620,7 +621,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
       'data-garden-container-version': PACKAGE_VERSION,
       ref: triggerRef,
       id: triggerId,
-      'aria-expanded': state.isExpanded,
+      'aria-expanded': controlledIsExpanded,
       'aria-haspopup': true,
       disabled,
       tabIndex: disabled ? -1 : 0,
@@ -629,7 +630,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
       onKeyDown: composeEventHandlers(onKeyDown, handleTriggerKeyDown),
       onClick: composeEventHandlers(onClick, handleTriggerClick)
     }),
-    [triggerRef, state.isExpanded, handleTriggerClick, handleTriggerKeyDown, triggerId]
+    [triggerRef, controlledIsExpanded, handleTriggerClick, handleTriggerKeyDown, triggerId]
   );
 
   const getMenuProps = useCallback<IUseMenuReturnValue['getMenuProps']>(


### PR DESCRIPTION
## Description

- Fixes incorrect `aria-expanded` state on `getTriggerProps` return value
- Fixes issue where `document`-level event listener isn't cleaned up when a menu is closed

## Detail

In cases where the menu element (with `getMenuProps`) persists in the DOM (unlike the storybook example), the global keydown event that checks outside clicks wasn't removed correctly in a `useEffect`.

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
