### PR TITLE
fix(menu): provide consistent selection behavior in `selectedItems` data

### DIFF
--- a/packages/menu/.size-snapshot.json
+++ b/packages/menu/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "index.cjs.js": {
-    "bundled": 26413,
-    "minified": 13588,
-    "gzipped": 3729
+    "bundled": 26382,
+    "minified": 13587,
+    "gzipped": 3731
   },
   "index.esm.js": {
-    "bundled": 25471,
-    "minified": 12645,
-    "gzipped": 3711,
+    "bundled": 25440,
+    "minified": 12644,
+    "gzipped": 3713,
     "treeshaked": {
       "rollup": {
         "code": 386,

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -229,10 +229,10 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
         const index = changes.findIndex(item => item.name === name);
 
         if (index > -1) {
-          changes.splice(index, 1, selectedItem);
-        } else {
-          changes.push(selectedItem);
+          changes.splice(index, 1);
         }
+
+        changes.push(selectedItem);
       }
 
       return changes;


### PR DESCRIPTION
## Description

A subtle but non-breaking API change to make `selectedItems` updates predictable between `radio` and `checkbox` item selection.

## Detail

Currently, `radio` and `checkbox` selection  is handled differently depending on if a `'checkbox'` or `'radio'` item is selected.

**Current behavior:**
- Checkbox: selected item is pushed into `selectedItems`.
- Radio: selected item is replaces the previously selected radio item (e.g., it has a matching `name`), otherwise it is pushed into `selectedItems`.

The inconsistency of selection handling here might be confusing if a consumer wants to have alternate behavior between item types.

**This PR proposes:**
- Checkbox: selected item is pushed into `selectedItems`.
- Radio: selected item is pushed into `selectedItems` (if another item in the set has a matching `name`, it is removed).

The corrected behavior affects both the hook's return value and `changes.selectedItems` in the `onChange` arg.

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
  ~~:wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance~~
  ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~
