### PR TITLE
fix(menu): prevents over-eager trigger focus when items are selected via keyboard

### DIFF
--- a/packages/menu/.size-snapshot.json
+++ b/packages/menu/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "index.cjs.js": {
-    "bundled": 26616,
-    "minified": 13661,
-    "gzipped": 3743
+    "bundled": 26821,
+    "minified": 13705,
+    "gzipped": 3777
   },
   "index.esm.js": {
-    "bundled": 25674,
-    "minified": 12718,
-    "gzipped": 3725,
+    "bundled": 25881,
+    "minified": 12763,
+    "gzipped": 3756,
     "treeshaked": {
       "rollup": {
         "code": 386,

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -12,6 +12,7 @@ import React, {
   useEffect,
   useMemo,
   useReducer,
+  useRef,
   useState
 } from 'react';
 import { useSelection } from '@zendeskgarden/container-selection';
@@ -92,6 +93,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
    */
 
   const [menuVisible, setMenuVisible] = useState<boolean>(false);
+  const focusTriggerRef = useRef<boolean>(false);
 
   const [state, dispatch] = useReducer(stateReducer, {
     focusedValue: focusedValue || defaultFocusedValue,
@@ -316,14 +318,14 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
 
         const type = StateChangeTypes[key === KEYS.ESCAPE ? 'MenuKeyDownEscape' : 'MenuKeyDownTab'];
 
-        closeMenu(type);
-
-        if (triggerRef?.current && KEYS.ESCAPE === key) {
-          triggerRef.current.focus();
+        if (KEYS.ESCAPE === key) {
+          focusTriggerRef.current = true;
         }
+
+        closeMenu(type);
       }
     },
-    [closeMenu, triggerRef]
+    [closeMenu, focusTriggerRef]
   );
 
   const handleMenuBlur = useCallback(
@@ -423,8 +425,8 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
           ...(nextSelection && { selectedItems: nextSelection })
         };
 
-        if (triggerRef?.current && !isTransitionItem) {
-          triggerRef.current.focus();
+        if (!isTransitionItem) {
+          focusTriggerRef.current = true;
         }
       } else if (key === KEYS.RIGHT) {
         if (rtl && isPrevious) {
@@ -490,11 +492,11 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
     },
     [
       rtl,
-      triggerRef,
       state.nestedPathIds,
       isExpandedControlled,
       isFocusedValueControlled,
       isSelectedItemsControlled,
+      focusTriggerRef,
       getNextFocusedValue,
       getSelectedItems,
       onChange
@@ -553,7 +555,12 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
   }, [controlledIsExpanded, handleMenuBlur, handleMenuKeyDown, environment]);
 
   /**
-   * Focus initial item when menu opens or changes due to sub-menu transition
+   * Handles focus depending on menu state:
+   * - When opened, focus the menu via `focusedValue`
+   * - When closed, focus the trigger via `triggerRef`
+   *
+   * This effect is intended to prevent focusing the trigger or menu
+   * unless the menu is in the right expansion state.
    */
   useEffect(() => {
     if (state.focusOnOpen && menuVisible && controlledFocusedValue && controlledIsExpanded) {
@@ -568,13 +575,20 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
 
       ref && ref.focus();
     }
+
+    if (!menuVisible && !controlledIsExpanded && focusTriggerRef.current) {
+      triggerRef?.current?.focus();
+      focusTriggerRef.current = false;
+    }
   }, [
+    focusTriggerRef,
     values,
     menuVisible,
     itemRefs,
     controlledFocusedValue,
     state.focusOnOpen,
-    controlledIsExpanded
+    controlledIsExpanded,
+    triggerRef
   ]);
 
   /**


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

The keydown handler on menu items has an over-eager trigger focus condition that always moves focus back to the trigger element as long as the chosen item isn't enabling nested/sub-menu behavior.

By fixing that condition (see [detail](#Detail) below), the menu hook enables consumers to retain expansion without losing focus within the menu, even during item selection, if desired.

## Detail

Here is a [reproduction](https://codesandbox.io/s/menu-trigger-focus-bug-srr7l2) of the incorrect behavior (use keyboard to select an item).

The fix relies on a central conditional in `useEffect` that waits for the menu to be properly closed before trying to focus the trigger. A ref is used to track if the trigger should or shouldn't be focused, and once the menu is closed and ref is `true`, the trigger can be focused. This block also resets the ref back to `false` to keep state clean for the next interaction.

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`yarn start`)
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
  ~~:guardsman: includes new unit tests~~
