### PR TITLE
feat(combobox): add support for `hidden` options

### DIFF
--- a/packages/combobox/demo/stories/ComboboxStory.tsx
+++ b/packages/combobox/demo/stories/ComboboxStory.tsx
@@ -37,7 +37,8 @@ const Option = ({ option, isGrouped, activeValue, selection, getOptionProps }: I
       'bg-blue-100': option.value === activeValue,
       'cursor-default': option.disabled,
       'cursor-pointer': !option.disabled,
-      'text-grey-400': option.disabled
+      'text-grey-400': option.disabled,
+      'sr-only': option.hidden
     })}
     {...getOptionProps({ option })}
   >
@@ -68,7 +69,9 @@ const Tags = ({ selection, getTagProps }: ITagsProps) => {
             selection.map((option, index) => {
               const tagProps = getTagProps<HTMLButtonElement>({
                 option,
-                'aria-label': 'Press delete or backspace to remove'
+                'aria-label': option.disabled
+                  ? ''
+                  : `Press delete or backspace to remove ${toString(option)}`
               });
               const previousDisabledOptions = selection.filter(
                 (_option, _index) => _option.disabled && _index < index

--- a/packages/combobox/demo/stories/data.ts
+++ b/packages/combobox/demo/stories/data.ts
@@ -15,7 +15,8 @@ export const OPTIONS: IUseComboboxProps['options'] = [
       { value: 'fruit-02', label: 'Banana', disabled: true },
       { value: 'fruit-03', label: 'Cherry' },
       { value: 'fruit-04', label: 'Grape' },
-      { value: 'fruit-05', label: 'Kiwi' }
+      { value: 'fruit-05', label: 'Kiwi' },
+      { value: 'fruit-06', label: 'Watermeal', hidden: true }
     ]
   },
   {
@@ -25,7 +26,8 @@ export const OPTIONS: IUseComboboxProps['options'] = [
       { value: 'vegetable-02', label: 'Broccoli', disabled: true },
       { value: 'vegetable-03', label: 'Brussel sprouts' },
       { value: 'vegetable-04', label: 'Cauliflower' },
-      { value: 'vegetable-07', label: 'Kale' }
+      { value: 'vegetable-05', label: 'Kale' },
+      { value: 'vegetable-06', label: 'Mankai', hidden: true }
     ]
   }
 ];

--- a/packages/combobox/src/ComboboxContainer.spec.tsx
+++ b/packages/combobox/src/ComboboxContainer.spec.tsx
@@ -766,6 +766,68 @@ describe('ComboboxContainer', () => {
         });
       });
 
+      describe('with hidden options', () => {
+        let input: HTMLElement;
+        let listboxOptions: HTMLElement[];
+        let rerender: RenderResult['rerender'];
+
+        beforeEach(async () => {
+          const {
+            getByTestId,
+            getAllByRole,
+            rerender: _rerender
+          } = render(
+            <TestCombobox
+              layout={layout}
+              options={[
+                { value: 'test-1' },
+                { value: 'test-2', hidden: true },
+                { value: 'test-3' }
+              ]}
+            />
+          );
+
+          input = getByTestId('input');
+          listboxOptions = getAllByRole('option', { hidden: true });
+          rerender = _rerender;
+
+          input.focus();
+          await user.keyboard('{ArrowDown}');
+        });
+
+        it('applies correct accessibility attributes', () => {
+          expect(listboxOptions[1]).toHaveAttribute('aria-hidden', 'true');
+        });
+
+        it('prevents hidden option activation', async () => {
+          await user.keyboard('{ArrowDown}');
+
+          expect(input).toHaveAttribute(
+            'aria-activedescendant',
+            listboxOptions[2].getAttribute('id')
+          );
+
+          await user.hover(listboxOptions[1]);
+
+          expect(input).not.toHaveAttribute(
+            'aria-activedescendant',
+            listboxOptions[1].getAttribute('id')
+          );
+        });
+
+        it('unhides options as expected', () => {
+          rerender(
+            /* simulate dynamic option unhiding */
+            <TestCombobox
+              layout={layout}
+              options={[{ value: 'test-1' }, { value: 'test-2' }, { value: 'test-3' }]}
+            />
+          );
+
+          expect(listboxOptions[1]).not.toHaveAttribute('aria-hidden');
+        });
+      });
+
       describe('controlled', () => {
         const handleChange = jest.fn();
         let input: HTMLElement;

--- a/packages/combobox/src/types.ts
+++ b/packages/combobox/src/types.ts
@@ -14,6 +14,7 @@ interface ISelectedOption {
   value: OptionValue;
   label?: string;
   disabled?: boolean;
+  hidden?: boolean;
 }
 
 export interface IOption extends ISelectedOption {

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -819,6 +819,7 @@ export const useCombobox = <
 
       if (option?.hidden) {
         return {
+          'aria-disabled': option.disabled ? true : undefined,
           'aria-hidden': true,
           'aria-selected': ariaSelected,
           id: option

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -78,26 +78,37 @@ export const useCombobox = <
     input: `${prefix}--input`,
     listbox: `${prefix}--listbox`,
     message: `${prefix}--message`,
-    getOptionId: (index: number, isDisabled?: boolean) =>
-      `${prefix}--option${isDisabled ? '-disabled' : ''}-${index}`
+    getOptionId: (index: number, isDisabled?: boolean, isHidden?: boolean) =>
+      `${prefix}--option${isDisabled ? '-disabled' : ''}${isHidden ? '-hidden' : ''}-${index}`
   });
   const labels: Record<string, string> = useMemo(() => ({}), []);
   const selectedValues: OptionValue[] = useMemo(() => [], []);
   const disabledValues: OptionValue[] = useMemo(() => [], []);
+  const hiddenValues: OptionValue[] = useMemo(() => [], []);
   const values = useMemo(() => {
     const retVal: OptionValue[] = [];
     const setValues = (option: IOption) => {
-      if (option.disabled) {
-        if (!disabledValues.includes(option.value)) {
+      if (option.disabled || option.hidden) {
+        if (option.disabled && !disabledValues.includes(option.value)) {
           disabledValues.push(option.value);
+        }
+
+        if (option.hidden && !hiddenValues.includes(option.value)) {
+          hiddenValues.push(option.value);
         }
       } else {
         retVal.push(option.value);
 
-        const index = disabledValues.indexOf(option.value);
+        const disabledIndex = disabledValues.indexOf(option.value);
 
-        if (index !== -1) {
-          disabledValues.splice(index, 1);
+        if (disabledIndex !== -1) {
+          disabledValues.splice(disabledIndex, 1);
+        }
+
+        const hiddenIndex = hiddenValues.indexOf(option.value);
+
+        if (hiddenIndex !== -1) {
+          hiddenValues.splice(hiddenIndex, 1);
         }
       }
 
@@ -119,7 +130,7 @@ export const useCombobox = <
     });
 
     return retVal;
-  }, [options, disabledValues, selectedValues, labels]);
+  }, [options, disabledValues, hiddenValues, selectedValues, labels]);
   const initialSelectionValue = isMultiselectable ? selectedValues : selectedValues[0];
   const initialInputValue = isMultiselectable ? '' : toLabel(labels, initialSelectionValue);
   const _defaultActiveIndex = useMemo(() => {
@@ -806,6 +817,21 @@ export const useCombobox = <
           : _selectionValue === option?.value;
       }
 
+      if (option?.hidden) {
+        return {
+          'aria-hidden': true,
+          'aria-selected': ariaSelected,
+          id: option
+            ? idRef.current.getOptionId(
+                hiddenValues.indexOf(option.value),
+                option.disabled,
+                option.hidden
+              )
+            : undefined,
+          ...optionProps
+        };
+      }
+
       if (option === undefined || option.disabled) {
         // Prevent downshift listbox mouse leave event.
         const handleMouseDown = (event: MouseEvent) => event.preventDefault();
@@ -814,7 +840,11 @@ export const useCombobox = <
           'aria-disabled': true,
           'aria-selected': ariaSelected,
           id: option
-            ? idRef.current.getOptionId(disabledValues.indexOf(option.value), option.disabled)
+            ? idRef.current.getOptionId(
+                disabledValues.indexOf(option.value),
+                option.disabled,
+                option.hidden
+              )
             : undefined,
           ...optionProps,
           onMouseDown: composeEventHandlers(onMouseDown, handleMouseDown)
@@ -825,11 +855,12 @@ export const useCombobox = <
         item: option.value,
         index: values.indexOf(option.value),
         'aria-disabled': undefined,
+        'aria-hidden': undefined,
         'aria-selected': ariaSelected,
         ...optionProps
       } as IDownshiftOptionProps<OptionValue>);
     },
-    [getDownshiftOptionProps, disabledValues, values, _selectionValue]
+    [getDownshiftOptionProps, disabledValues, hiddenValues, values, _selectionValue]
   );
 
   const getMessageProps = useCallback<IUseComboboxReturnValue['getMessageProps']>(
@@ -867,18 +898,20 @@ export const useCombobox = <
       return _selectionValue.map(value => ({
         value,
         label: labels[value],
-        disabled: disabledValues.includes(value)
+        disabled: disabledValues.includes(value),
+        hidden: hiddenValues.includes(value)
       }));
     } else if (_selectionValue) {
       return {
         value: _selectionValue,
         label: toLabel(labels, _selectionValue),
-        disabled: disabledValues.includes(_selectionValue)
+        disabled: disabledValues.includes(_selectionValue),
+        hidden: hiddenValues.includes(_selectionValue)
       };
     }
 
     return null;
-  }, [_selectionValue, disabledValues, labels]);
+  }, [_selectionValue, disabledValues, hiddenValues, labels]);
 
   return useMemo<IUseComboboxReturnValue>(
     () => ({


### PR DESCRIPTION
## Description

A [nested](https://garden.zendesk.com/components/combobox#nested) multiselectable combobox must render selected options at every level of the listbox. The addition of the `hidden` attribute allows selected options to be accessibly rendered – even outside their visual sub-level. This PR provides the necessary baseline for enhancing the `Combobox` component in `react-components`.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
