### PR TITLE
chore: replace deprecated `KEY_CODES` with `KEYS` constants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
         "@zendeskgarden/react-theming": "8.73.4",
         "@zendeskgarden/scripts": "2.0.4",
         "@zendeskgarden/tailwindcss": "3.1.1",
-        "acorn-jsx": "5.3.2",
         "autoprefixer": "10.4.17",
         "babel-plugin-module-resolver": "5.0.0",
         "babel-plugin-styled-components": "2.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32150,6 +32150,48 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/http-cache-semantics": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
@@ -32189,6 +32231,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/netlify-cli/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.9.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
@@ -32204,11 +32252,33 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "extraneous": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/netlify-cli/node_modules/@types/yargs-parser": {
       "version": "20.2.1",
@@ -32663,6 +32733,22 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "extraneous": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/netlify-cli/node_modules/ajv-formats": {
@@ -36046,6 +36132,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.7.0.tgz",
@@ -38553,6 +38645,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",
@@ -76941,6 +77039,47 @@
           "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
           "dev": true
         },
+        "@types/body-parser": {
+          "version": "1.19.2",
+          "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+          "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+          "extraneous": true,
+          "requires": {
+            "@types/connect": "*",
+            "@types/node": "*"
+          }
+        },
+        "@types/connect": {
+          "version": "3.4.35",
+          "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+          "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+          "extraneous": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/express": {
+          "version": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+          "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+          "extraneous": true,
+          "requires": {
+            "@types/body-parser": "*",
+            "@types/express-serve-static-core": "^4.17.18",
+            "@types/qs": "*",
+            "@types/serve-static": "*"
+          }
+        },
+        "@types/express-serve-static-core": {
+          "version": "4.17.28",
+          "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+          "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+          "extraneous": true,
+          "requires": {
+            "@types/node": "*",
+            "@types/qs": "*",
+            "@types/range-parser": "*"
+          }
+        },
         "@types/http-cache-semantics": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
@@ -76980,6 +77119,12 @@
             "@types/istanbul-lib-report": "*"
           }
         },
+        "@types/mime": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+          "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+          "extraneous": true
+        },
         "@types/node": {
           "version": "20.9.0",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
@@ -76995,11 +77140,33 @@
           "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
           "dev": true
         },
+        "@types/qs": {
+          "version": "6.9.7",
+          "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+          "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+          "extraneous": true
+        },
+        "@types/range-parser": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+          "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+          "extraneous": true
+        },
         "@types/retry": {
           "version": "0.12.1",
           "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
           "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
           "dev": true
+        },
+        "@types/serve-static": {
+          "version": "1.13.10",
+          "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+          "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+          "extraneous": true,
+          "requires": {
+            "@types/mime": "^1",
+            "@types/node": "*"
+          }
         },
         "@types/yargs-parser": {
           "version": "20.2.1",
@@ -77329,6 +77496,17 @@
           "dev": true,
           "requires": {
             "debug": "4"
+          }
+        },
+        "ajv": {
+          "version": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "extraneous": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
           }
         },
         "ajv-formats": {
@@ -79898,6 +80076,12 @@
             "micromatch": "^4.0.4"
           }
         },
+        "fast-json-stable-stringify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+          "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+          "extraneous": true
+        },
         "fast-json-stringify": {
           "version": "5.7.0",
           "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.7.0.tgz",
@@ -81757,6 +81941,12 @@
           "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
           "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
           "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "extraneous": true
         },
         "jsonc-parser": {
           "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "@zendeskgarden/react-theming": "8.73.4",
     "@zendeskgarden/scripts": "2.0.4",
     "@zendeskgarden/tailwindcss": "3.1.1",
-    "acorn-jsx": "5.3.2",
     "autoprefixer": "10.4.17",
     "babel-plugin-module-resolver": "5.0.0",
     "babel-plugin-styled-components": "2.1.4",

--- a/packages/accordion/src/AccordionContainer.spec.tsx
+++ b/packages/accordion/src/AccordionContainer.spec.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, fireEvent, screen } from '@testing-library/react';
-import { KEY_CODES } from '@zendeskgarden/container-utilities';
+import { KEYS } from '@zendeskgarden/container-utilities';
 import { AccordionContainer, IUseAccordionReturnValue, IUseAccordionProps } from './';
 
 describe('AccordionContainer', () => {
@@ -236,7 +236,7 @@ describe('AccordionContainer', () => {
         const { getAllByTestId } = render(<BasicExample />);
         const secondTrigger = getAllByTestId('trigger')[1];
 
-        fireEvent.keyDown(secondTrigger, { keyCode: KEY_CODES.SPACE });
+        fireEvent.keyDown(secondTrigger, { key: KEYS.SPACE });
 
         expect(secondTrigger).toHaveAttribute('aria-expanded', 'true');
       });
@@ -245,7 +245,7 @@ describe('AccordionContainer', () => {
         const { getAllByTestId } = render(<BasicExample />);
         const secondTrigger = getAllByTestId('trigger')[1];
 
-        fireEvent.keyDown(secondTrigger, { keyCode: KEY_CODES.ENTER });
+        fireEvent.keyDown(secondTrigger, { key: KEYS.ENTER });
 
         expect(secondTrigger).toHaveAttribute('aria-expanded', 'true');
       });
@@ -254,7 +254,7 @@ describe('AccordionContainer', () => {
         const { getAllByTestId } = render(<BasicExample />);
         const firstTrigger = getAllByTestId('trigger')[1];
 
-        fireEvent.keyDown(firstTrigger, { keyCode: KEY_CODES.DOWN });
+        fireEvent.keyDown(firstTrigger, { key: KEYS.DOWN });
 
         expect(firstTrigger).toHaveAttribute('aria-expanded', 'false');
       });
@@ -320,7 +320,7 @@ describe('AccordionContainer', () => {
         const firstTrigger = getAllByTestId('trigger')[0];
         const firstPanel = getAllByTestId('panel')[0];
 
-        fireEvent.keyDown(firstTrigger, { keyCode: KEY_CODES.SPACE });
+        fireEvent.keyDown(firstTrigger, { key: KEYS.SPACE });
 
         expect(firstPanel).toHaveAttribute('aria-hidden', 'false');
       });
@@ -330,7 +330,7 @@ describe('AccordionContainer', () => {
         const firstTrigger = getAllByTestId('trigger')[0];
         const firstPanel = getAllByTestId('panel')[0];
 
-        fireEvent.keyDown(firstTrigger, { keyCode: KEY_CODES.ENTER });
+        fireEvent.keyDown(firstTrigger, { key: KEYS.ENTER });
 
         expect(firstPanel).toHaveAttribute('aria-hidden', 'false');
       });
@@ -340,7 +340,7 @@ describe('AccordionContainer', () => {
         const firstTrigger = getAllByTestId('trigger')[1];
         const firstPanel = getAllByTestId('panel')[1];
 
-        fireEvent.keyDown(firstTrigger, { keyCode: KEY_CODES.DOWN });
+        fireEvent.keyDown(firstTrigger, { key: KEYS.DOWN });
 
         expect(firstPanel).toHaveAttribute('aria-hidden', 'true');
       });

--- a/packages/accordion/src/useAccordion.ts
+++ b/packages/accordion/src/useAccordion.ts
@@ -7,7 +7,7 @@
 
 import { useState, useMemo, useCallback } from 'react';
 import {
-  KEY_CODES,
+  KEYS,
   composeEventHandlers,
   getControlledValue,
   useId
@@ -90,7 +90,7 @@ export function useAccordion<Value>({
       'aria-expanded': internalExpandedState.includes(value),
       onClick: composeEventHandlers(props.onClick, () => toggle(value)),
       onKeyDown: composeEventHandlers(props.onKeyDown, (event: KeyboardEvent) => {
-        if (event.keyCode === KEY_CODES.SPACE || event.keyCode === KEY_CODES.ENTER) {
+        if (event.key === KEYS.SPACE || event.key === KEYS.ENTER) {
           toggle(value);
           event.preventDefault();
         }

--- a/packages/tooltip/src/TooltipContainer.spec.tsx
+++ b/packages/tooltip/src/TooltipContainer.spec.tsx
@@ -9,8 +9,7 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
-import { KEY_CODES } from '@zendeskgarden/container-utilities';
-
+import { KEYS } from '@zendeskgarden/container-utilities';
 import { TooltipContainer, ITooltipContainerProps } from './';
 
 jest.useFakeTimers();
@@ -163,7 +162,7 @@ describe('TooltipContainer', () => {
           jest.runOnlyPendingTimers();
         });
 
-        fireEvent.keyDown(trigger, { keyCode: KEY_CODES.ESCAPE });
+        fireEvent.keyDown(trigger, { key: KEYS.ESCAPE });
         act(() => {
           jest.runOnlyPendingTimers();
         });

--- a/packages/tooltip/src/useTooltip.ts
+++ b/packages/tooltip/src/useTooltip.ts
@@ -7,7 +7,7 @@
 
 import { useState, useMemo, useEffect, useRef } from 'react';
 import { useUIDSeed } from 'react-uid';
-import { composeEventHandlers, KEY_CODES } from '@zendeskgarden/container-utilities';
+import { KEYS, composeEventHandlers } from '@zendeskgarden/container-utilities';
 
 export interface IUseTooltipProps {
   /** Milliseconds of delay before open/close of tooltip is initiated  */
@@ -92,7 +92,7 @@ export const useTooltip = ({
       // Close menu immediately when blurred
       onBlur: composeEventHandlers(onBlur, () => closeTooltip(0)),
       onKeyDown: composeEventHandlers(onKeyDown, (event: KeyboardEvent) => {
-        if (event.keyCode === KEY_CODES.ESCAPE && visibility) {
+        if (event.key === KEYS.ESCAPE && visibility) {
           closeTooltip(0);
         }
       }),

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -16,7 +16,6 @@ import analyze from 'rollup-plugin-analyzer';
 import license from 'rollup-plugin-license';
 import cleanup from 'rollup-plugin-cleanup';
 import del from 'rollup-plugin-delete';
-import jsx from 'acorn-jsx';
 import { DEFAULT_EXTENSIONS } from '@babel/core';
 import tsc from 'typescript';
 
@@ -43,7 +42,6 @@ export default [
      * These are not included in the bundlesize.
      */
     external: id => externalPackages.includes(id),
-    acornInjectPlugins: [jsx()],
     plugins: [
       /**
        * Remove existing dist files and type definitions


### PR DESCRIPTION
## Description

The `KEY_CODES` utility is now deprecated.

## Detail

Also cleans up the `acornInjectPlugins` option which is no longer recognized by Rollup. The same was removed in https://github.com/zendeskgarden/react-components/pull/1641 several months ago.
