### PR TITLE
fix(combobox): workaround Downshift cursor bug

### DIFF
--- a/packages/combobox/src/ComboboxContainer.spec.tsx
+++ b/packages/combobox/src/ComboboxContainer.spec.tsx
@@ -830,7 +830,7 @@ describe('ComboboxContainer', () => {
 
       describe('controlled', () => {
         const handleChange = jest.fn();
-        let input: HTMLElement;
+        let input: HTMLInputElement;
         let listboxOptions: HTMLElement[];
         let rerender: RenderResult['rerender'];
 
@@ -853,7 +853,7 @@ describe('ComboboxContainer', () => {
             />
           );
 
-          input = getByTestId('input');
+          input = getByTestId('input') as HTMLInputElement;
           listboxOptions = getAllByRole('option');
           rerender = _rerender;
         });
@@ -867,6 +867,19 @@ describe('ComboboxContainer', () => {
           const changeTypes = handleChange.mock.calls.map(([change]) => change.type);
 
           expect(changeTypes).toMatchObject(['input:click', 'input:keyDown:ArrowDown']);
+        });
+
+        it('retains cursor position on input change', async () => {
+          await user.type(input, 'tet');
+          await user.keyboard('{ArrowLeft}');
+
+          expect(input.selectionStart).toBe(2);
+
+          await user.keyboard('s');
+
+          expect(input).toHaveValue('test');
+          expect(input.selectionStart).toBe(3);
+          expect(handleChange).toHaveBeenCalledTimes(5);
         });
 
         it('handles IME input as expected', () => {

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -67,6 +67,7 @@ export const useCombobox = <
   }
 
   const [triggerContainsInput, setTriggerContainsInput] = useState<boolean>();
+  const [downshiftInputValue, setDownshiftInputValue] = useState(inputValue);
   const [matchValue, setMatchValue] = useState('');
   const matchTimeoutRef = useRef<number>();
   const previousStateRef = useRef<IPreviousState>();
@@ -310,7 +311,7 @@ export const useCombobox = <
     menuId: idRef.current.listbox,
     getItemId: idRef.current.getOptionId,
     items: values,
-    inputValue,
+    inputValue: downshiftInputValue,
     initialInputValue,
     itemToString: transformValue as any /* HACK around Downshift's generic type overuse */,
     selectedItem: selectionValue,
@@ -640,14 +641,20 @@ export const useCombobox = <
 
       if (isEditable) {
         const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-          // Override needed to workaround Downshift IME bug.
-          // https://github.com/downshift-js/downshift/issues/1452
-          if (inputValue !== undefined && (event.nativeEvent as InputEvent).isComposing) {
-            /* istanbul ignore next */
-            handleDownshiftStateChange({
-              type: useDownshift.stateChangeTypes.InputChange,
-              inputValue: event.target.value
-            });
+          if (inputValue !== undefined) {
+            // Override needed to workaround Downshift cursor bug.
+            // https://github.com/downshift-js/downshift/issues/1108
+            setDownshiftInputValue(event.target.value);
+
+            // Override needed to workaround Downshift IME bug.
+            // https://github.com/downshift-js/downshift/issues/1452
+            if ((event.nativeEvent as InputEvent).isComposing) {
+              /* istanbul ignore next */
+              handleDownshiftStateChange({
+                type: useDownshift.stateChangeTypes.InputChange,
+                inputValue: event.target.value
+              });
+            }
           }
         };
 


### PR DESCRIPTION
## Description

The Downshift `useCombobox` hook currently has an issue that jumps the input cursor to the end while attempting to modify a _controlled_ `inputValue`. This [workaround](https://github.com/downshift-js/downshift/issues/1108#issuecomment-674180157) manages `inputValue` state locally. 

**Before**

https://github.com/zendeskgarden/react-containers/assets/143773/d0df995d-14c4-446e-b469-8aad7cd63914

**After**

https://github.com/zendeskgarden/react-containers/assets/143773/825cc6b7-681d-4ec9-96a5-6220da97dab8


## Detail

https://github.com/downshift-js/downshift/issues/1108

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [ ] :globe_with_meridians: ~demo is up-to-date (`npm start`)~
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
