### PR TITLE
fix(combobox): keep local `inputValue` state in sync with Downshift

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32159,6 +32159,48 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/http-cache-semantics": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
@@ -32198,6 +32240,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/netlify-cli/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.9.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
@@ -32213,11 +32261,33 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "extraneous": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/netlify-cli/node_modules/@types/yargs-parser": {
       "version": "20.2.1",
@@ -32672,6 +32742,22 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "extraneous": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/netlify-cli/node_modules/ajv-formats": {
@@ -36055,6 +36141,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.7.0.tgz",
@@ -38562,6 +38654,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",
@@ -76954,6 +77052,47 @@
           "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
           "dev": true
         },
+        "@types/body-parser": {
+          "version": "1.19.2",
+          "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+          "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+          "extraneous": true,
+          "requires": {
+            "@types/connect": "*",
+            "@types/node": "*"
+          }
+        },
+        "@types/connect": {
+          "version": "3.4.35",
+          "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+          "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+          "extraneous": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/express": {
+          "version": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+          "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+          "extraneous": true,
+          "requires": {
+            "@types/body-parser": "*",
+            "@types/express-serve-static-core": "^4.17.18",
+            "@types/qs": "*",
+            "@types/serve-static": "*"
+          }
+        },
+        "@types/express-serve-static-core": {
+          "version": "4.17.28",
+          "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+          "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+          "extraneous": true,
+          "requires": {
+            "@types/node": "*",
+            "@types/qs": "*",
+            "@types/range-parser": "*"
+          }
+        },
         "@types/http-cache-semantics": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
@@ -76993,6 +77132,12 @@
             "@types/istanbul-lib-report": "*"
           }
         },
+        "@types/mime": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+          "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+          "extraneous": true
+        },
         "@types/node": {
           "version": "20.9.0",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
@@ -77008,11 +77153,33 @@
           "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
           "dev": true
         },
+        "@types/qs": {
+          "version": "6.9.7",
+          "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+          "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+          "extraneous": true
+        },
+        "@types/range-parser": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+          "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+          "extraneous": true
+        },
         "@types/retry": {
           "version": "0.12.1",
           "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
           "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
           "dev": true
+        },
+        "@types/serve-static": {
+          "version": "1.13.10",
+          "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+          "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+          "extraneous": true,
+          "requires": {
+            "@types/mime": "^1",
+            "@types/node": "*"
+          }
         },
         "@types/yargs-parser": {
           "version": "20.2.1",
@@ -77342,6 +77509,17 @@
           "dev": true,
           "requires": {
             "debug": "4"
+          }
+        },
+        "ajv": {
+          "version": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "extraneous": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
           }
         },
         "ajv-formats": {
@@ -79911,6 +80089,12 @@
             "micromatch": "^4.0.4"
           }
         },
+        "fast-json-stable-stringify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+          "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+          "extraneous": true
+        },
         "fast-json-stringify": {
           "version": "5.7.0",
           "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.7.0.tgz",
@@ -81770,6 +81954,12 @@
           "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
           "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
           "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "extraneous": true
         },
         "jsonc-parser": {
           "version": "3.2.0",

--- a/packages/combobox/src/ComboboxContainer.spec.tsx
+++ b/packages/combobox/src/ComboboxContainer.spec.tsx
@@ -894,14 +894,16 @@ describe('ComboboxContainer', () => {
         });
 
         it('handles controlled selection as expected', () => {
+          const _options = [{ value: 'test-1' }, { value: 'test-2' }, { value: 'test-3' }];
+
           expect(listboxOptions[0]).toHaveAttribute('aria-selected', 'false');
 
           rerender(
             <TestCombobox
               layout={layout}
-              options={[{ value: 'test-1' }, { value: 'test-2' }, { value: 'test-3' }]}
+              options={_options}
               isExpanded={false}
-              inputValue=""
+              inputValue="test-1"
               activeIndex={-1}
               selectionValue="test-1"
               onChange={handleChange}
@@ -909,6 +911,23 @@ describe('ComboboxContainer', () => {
           );
 
           expect(listboxOptions[0]).toHaveAttribute('aria-selected', 'true');
+          expect(input).toHaveValue('test-1');
+
+          // simulate controlled selection change
+          rerender(
+            <TestCombobox
+              layout={layout}
+              options={_options}
+              isExpanded={false}
+              inputValue="test-2"
+              activeIndex={-1}
+              selectionValue="test-2"
+              onChange={handleChange}
+            />
+          );
+
+          expect(listboxOptions[1]).toHaveAttribute('aria-selected', 'true');
+          expect(input).toHaveValue('test-2');
         });
 
         it('handles controlled multiple selection as expected', () => {

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -69,6 +69,7 @@ export const useCombobox = <
   const [triggerContainsInput, setTriggerContainsInput] = useState<boolean>();
   const [downshiftInputValue, setDownshiftInputValue] = useState(inputValue);
   const [matchValue, setMatchValue] = useState('');
+  const useInputValueRef = useRef(true);
   const matchTimeoutRef = useRef<number>();
   const previousStateRef = useRef<IPreviousState>();
   const prefix = useId(idPrefix);
@@ -141,6 +142,13 @@ export const useCombobox = <
 
     return defaultActiveIndex;
   }, [defaultActiveIndex, isAutocomplete, isEditable]);
+
+  if (useInputValueRef.current && inputValue !== downshiftInputValue) {
+    // Update local state with Downshift `inputValue` for non-buggy cases.
+    setDownshiftInputValue(inputValue);
+  } else {
+    useInputValueRef.current = true;
+  }
 
   /*
    * Validation
@@ -645,6 +653,7 @@ export const useCombobox = <
             // Override needed to workaround Downshift cursor bug.
             // https://github.com/downshift-js/downshift/issues/1108
             setDownshiftInputValue(event.target.value);
+            useInputValueRef.current = false;
 
             // Override needed to workaround Downshift IME bug.
             // https://github.com/downshift-js/downshift/issues/1452


### PR DESCRIPTION
## Description

The combobox cursor fix in #625 regressed controlled `inputValue` behavior – preventing proper change handling and stateful setting of the controlled value. This fix expands on the previous by keeping local `downshiftInputValue` state in sync with the controlled `inputValue`.

## Detail

The added tests apply coverage to the conditional state setter.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [ ] :memo: ~tested in Chrome, Firefox, Safari, and Edge~
