### PR TITLE
feat(combobox)!: prefer strings as option values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32357,6 +32357,48 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/http-cache-semantics": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
@@ -32396,6 +32438,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/netlify-cli/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.9.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
@@ -32411,11 +32459,33 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "extraneous": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/netlify-cli/node_modules/@types/yargs-parser": {
       "version": "20.2.1",
@@ -32870,6 +32940,22 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "extraneous": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/netlify-cli/node_modules/ajv-formats": {
@@ -36253,6 +36339,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.7.0.tgz",
@@ -38760,6 +38852,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",
@@ -77320,6 +77418,47 @@
           "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
           "dev": true
         },
+        "@types/body-parser": {
+          "version": "1.19.2",
+          "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+          "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+          "extraneous": true,
+          "requires": {
+            "@types/connect": "*",
+            "@types/node": "*"
+          }
+        },
+        "@types/connect": {
+          "version": "3.4.35",
+          "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+          "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+          "extraneous": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/express": {
+          "version": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+          "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+          "extraneous": true,
+          "requires": {
+            "@types/body-parser": "*",
+            "@types/express-serve-static-core": "^4.17.18",
+            "@types/qs": "*",
+            "@types/serve-static": "*"
+          }
+        },
+        "@types/express-serve-static-core": {
+          "version": "4.17.28",
+          "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+          "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+          "extraneous": true,
+          "requires": {
+            "@types/node": "*",
+            "@types/qs": "*",
+            "@types/range-parser": "*"
+          }
+        },
         "@types/http-cache-semantics": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
@@ -77359,6 +77498,12 @@
             "@types/istanbul-lib-report": "*"
           }
         },
+        "@types/mime": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+          "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+          "extraneous": true
+        },
         "@types/node": {
           "version": "20.9.0",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
@@ -77374,11 +77519,33 @@
           "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
           "dev": true
         },
+        "@types/qs": {
+          "version": "6.9.7",
+          "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+          "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+          "extraneous": true
+        },
+        "@types/range-parser": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+          "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+          "extraneous": true
+        },
         "@types/retry": {
           "version": "0.12.1",
           "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
           "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
           "dev": true
+        },
+        "@types/serve-static": {
+          "version": "1.13.10",
+          "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+          "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+          "extraneous": true,
+          "requires": {
+            "@types/mime": "^1",
+            "@types/node": "*"
+          }
         },
         "@types/yargs-parser": {
           "version": "20.2.1",
@@ -77708,6 +77875,17 @@
           "dev": true,
           "requires": {
             "debug": "4"
+          }
+        },
+        "ajv": {
+          "version": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "extraneous": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
           }
         },
         "ajv-formats": {
@@ -80277,6 +80455,12 @@
             "micromatch": "^4.0.4"
           }
         },
+        "fast-json-stable-stringify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+          "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+          "extraneous": true
+        },
         "fast-json-stringify": {
           "version": "5.7.0",
           "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.7.0.tgz",
@@ -82136,6 +82320,12 @@
           "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
           "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
           "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "extraneous": true
         },
         "jsonc-parser": {
           "version": "3.2.0",

--- a/packages/combobox/demo/stories/ComboboxStory.tsx
+++ b/packages/combobox/demo/stories/ComboboxStory.tsx
@@ -19,8 +19,7 @@ import {
 } from '@zendeskgarden/container-combobox';
 import { useGrid } from '@zendeskgarden/container-grid';
 
-const toString = (option: IOption) =>
-  option.label || (typeof option.value === 'string' ? option.value : JSON.stringify(option.value));
+const getLabel = (option: IOption) => option.label || option.value;
 
 interface IOptionProps extends LiHTMLAttributes<HTMLLIElement> {
   option: IOption;
@@ -45,7 +44,7 @@ const Option = ({ option, isGrouped, activeValue, selection, getOptionProps }: I
     {(Array.isArray(selection)
       ? selection.find(value => value.value === option.value) !== undefined
       : selection && selection.value === option.value) && '✓ '}
-    {toString(option)}
+    {getLabel(option)}
   </li>
 );
 
@@ -71,7 +70,7 @@ const Tags = ({ selection, getTagProps }: ITagsProps) => {
                 option,
                 'aria-label': option.disabled
                   ? ''
-                  : `Press delete or backspace to remove ${toString(option)}`
+                  : `Press delete or backspace to remove ${getLabel(option)}`
               });
               const previousDisabledOptions = selection.filter(
                 (_option, _index) => _option.disabled && _index < index
@@ -87,7 +86,7 @@ const Tags = ({ selection, getTagProps }: ITagsProps) => {
               return (
                 <td key={index} role={role} className="inline">
                   <button className="mr-1 px-1" disabled={option.disabled} {...props} type="button">
-                    {toString(option)}
+                    {getLabel(option)}
                   </button>
                 </td>
               );
@@ -286,7 +285,7 @@ export const ComboboxStory: Story<IArgs> = ({ as, ...props }) => {
 
         const regex = new RegExp(value.replace(/[.*+?^${}()|[\]\\]/giu, '\\$&'), 'gui');
 
-        setOptions(_options.filter(option => toString(option).match(regex)));
+        setOptions(_options.filter(option => getLabel(option).match(regex)));
       }
     }
   };

--- a/packages/combobox/src/ComboboxContainer.spec.tsx
+++ b/packages/combobox/src/ComboboxContainer.spec.tsx
@@ -91,7 +91,7 @@ describe('ComboboxContainer', () => {
                 {Array.isArray(selection) &&
                   selection.map(option => (
                     <button
-                      key={option.value as string}
+                      key={option.value}
                       data-test-id={tagTestId}
                       disabled={option.disabled}
                       {...getTagProps({ 'aria-label': 'tag', option })}
@@ -110,7 +110,7 @@ describe('ComboboxContainer', () => {
                 {Array.isArray(selection) &&
                   selection.map(option => (
                     <button
-                      key={option.value as string}
+                      key={option.value}
                       data-test-id={tagTestId}
                       disabled={option.disabled}
                       {...getTagProps({ 'aria-label': 'tag', option })}
@@ -140,7 +140,7 @@ describe('ComboboxContainer', () => {
                     >
                       {option.options.map((groupOption, groupIndex) => (
                         <li
-                          key={(groupOption.value as string) || groupIndex}
+                          key={groupOption.value || groupIndex}
                           data-test-id={`${optionTestIdPrefix}-${index + 1}.${groupIndex + 1}`}
                           {...getOptionProps({ option: groupOption })}
                         >
@@ -151,7 +151,7 @@ describe('ComboboxContainer', () => {
                   </li>
                 ) : (
                   <li
-                    key={(option.value as string) || index}
+                    key={option.value || index}
                     data-test-id={`${optionTestIdPrefix}-${index + 1}`}
                     {...getOptionProps({ option })}
                   >

--- a/packages/combobox/src/ComboboxContainer.tsx
+++ b/packages/combobox/src/ComboboxContainer.tsx
@@ -31,7 +31,7 @@ ComboboxContainer.propTypes = {
   hasMessage: PropTypes.bool,
   options: PropTypes.arrayOf(PropTypes.any).isRequired,
   inputValue: PropTypes.string,
-  selectionValue: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  selectionValue: PropTypes.any,
   isExpanded: PropTypes.bool,
   defaultExpanded: PropTypes.bool,
   initialExpanded: PropTypes.bool,

--- a/packages/combobox/src/types.ts
+++ b/packages/combobox/src/types.ts
@@ -8,8 +8,10 @@
 import { IUseFieldReturnValue } from '@zendeskgarden/container-field';
 import { HTMLProps, ReactNode, RefObject } from 'react';
 
+export type OptionValue = string;
+
 interface ISelectedOption {
-  value: string;
+  value: OptionValue;
   label?: string;
   disabled?: boolean;
   hidden?: boolean;
@@ -43,7 +45,7 @@ export interface IUseComboboxProps<T = HTMLElement, L = HTMLElement> {
   /**
    * Provides an ordered list of option groups and options
    *
-   * @param {string} option.value Unique option value
+   * @param {OptionValue} option.value Unique option value
    * @param {string} option.label Optional human-readable text (defaults to `option.value`)
    * @param {boolean} option.selected Sets initial selection for the option
    * @param {boolean} option.disabled Indicates that the option is not interactive
@@ -53,7 +55,7 @@ export interface IUseComboboxProps<T = HTMLElement, L = HTMLElement> {
   /** Sets the input value in a controlled combobox */
   inputValue?: string;
   /** Sets the selection value (or `isMultiselectable` values) in a controlled combobox */
-  selectionValue?: string | string[] | null;
+  selectionValue?: OptionValue | OptionValue[] | null;
   /** Determines listbox expansion in a controlled combobox */
   isExpanded?: boolean;
   /** Determines default listbox expansion in an uncontrolled combobox */
@@ -71,14 +73,14 @@ export interface IUseComboboxProps<T = HTMLElement, L = HTMLElement> {
    *
    * @param {string} changes.type The event type that triggered the change
    * @param {boolean} [changes.isExpanded] The updated listbox expansion
-   * @param {string|string[]} [changes.selectionValue] The updated selection value(s)
+   * @param {OptionValue|OptionValue[]} [changes.selectionValue] The updated selection value(s)
    * @param {string} [changes.inputValue] The updated input value
    * @param {number} [changes.activeIndex] The updated active option index
    */
   onChange?: (changes: {
     type: string;
     isExpanded?: boolean;
-    selectionValue?: string | string[] | null;
+    selectionValue?: OptionValue | OptionValue[] | null;
     inputValue?: string;
     activeIndex?: number;
   }) => void;
@@ -88,7 +90,7 @@ export interface IUseComboboxProps<T = HTMLElement, L = HTMLElement> {
 
 export interface IUseComboboxReturnValue {
   isExpanded: boolean;
-  activeValue?: string;
+  activeValue?: OptionValue;
   selection: ISelectedOption | ISelectedOption[] | null;
   inputValue?: string;
   getLabelProps: IUseFieldReturnValue['getLabelProps'];
@@ -124,7 +126,7 @@ export interface IUseComboboxReturnValue {
     }
   ) => HTMLProps<T>;
   getMessageProps: IUseFieldReturnValue['getMessageProps'];
-  removeSelection: (value?: ISelectedOption | string) => void;
+  removeSelection: (value?: ISelectedOption | OptionValue) => void;
 }
 
 export interface IComboboxContainerProps<T = HTMLElement, L = HTMLElement>
@@ -142,7 +144,7 @@ export interface IComboboxContainerProps<T = HTMLElement, L = HTMLElement>
    * @param {function} [options.getOptionProps] Option props getter
    * @param {function} [options.getMessageProps] Message props getter
    * @param {boolean} options.isExpanded Current listbox expansion
-   * @param {string} [options.activeValue] Current active option value
+   * @param {OptionValue} [options.activeValue] Current active option value
    * @param {object|object[]} options.selection Current selection
    * @param {string} [options.inputValue] Current input value
    * @param {function} [options.removeSelection] Remove the specified selection value or all values if unspecified

--- a/packages/combobox/src/types.ts
+++ b/packages/combobox/src/types.ts
@@ -8,10 +8,8 @@
 import { IUseFieldReturnValue } from '@zendeskgarden/container-field';
 import { HTMLProps, ReactNode, RefObject } from 'react';
 
-export type OptionValue = string | object;
-
 interface ISelectedOption {
-  value: OptionValue;
+  value: string;
   label?: string;
   disabled?: boolean;
   hidden?: boolean;
@@ -45,7 +43,7 @@ export interface IUseComboboxProps<T = HTMLElement, L = HTMLElement> {
   /**
    * Provides an ordered list of option groups and options
    *
-   * @param {OptionValue} option.value Unique option value
+   * @param {string} option.value Unique option value
    * @param {string} option.label Optional human-readable text (defaults to `option.value`)
    * @param {boolean} option.selected Sets initial selection for the option
    * @param {boolean} option.disabled Indicates that the option is not interactive
@@ -55,7 +53,7 @@ export interface IUseComboboxProps<T = HTMLElement, L = HTMLElement> {
   /** Sets the input value in a controlled combobox */
   inputValue?: string;
   /** Sets the selection value (or `isMultiselectable` values) in a controlled combobox */
-  selectionValue?: OptionValue | OptionValue[] | null;
+  selectionValue?: string | string[] | null;
   /** Determines listbox expansion in a controlled combobox */
   isExpanded?: boolean;
   /** Determines default listbox expansion in an uncontrolled combobox */
@@ -73,14 +71,14 @@ export interface IUseComboboxProps<T = HTMLElement, L = HTMLElement> {
    *
    * @param {string} changes.type The event type that triggered the change
    * @param {boolean} [changes.isExpanded] The updated listbox expansion
-   * @param {OptionValue|OptionValue[]} [changes.selectionValue] The updated selection value(s)
+   * @param {string|string[]} [changes.selectionValue] The updated selection value(s)
    * @param {string} [changes.inputValue] The updated input value
    * @param {number} [changes.activeIndex] The updated active option index
    */
   onChange?: (changes: {
     type: string;
     isExpanded?: boolean;
-    selectionValue?: OptionValue | OptionValue[] | null;
+    selectionValue?: string | string[] | null;
     inputValue?: string;
     activeIndex?: number;
   }) => void;
@@ -90,7 +88,7 @@ export interface IUseComboboxProps<T = HTMLElement, L = HTMLElement> {
 
 export interface IUseComboboxReturnValue {
   isExpanded: boolean;
-  activeValue?: OptionValue;
+  activeValue?: string;
   selection: ISelectedOption | ISelectedOption[] | null;
   inputValue?: string;
   getLabelProps: IUseFieldReturnValue['getLabelProps'];
@@ -126,7 +124,7 @@ export interface IUseComboboxReturnValue {
     }
   ) => HTMLProps<T>;
   getMessageProps: IUseFieldReturnValue['getMessageProps'];
-  removeSelection: (value?: ISelectedOption | OptionValue) => void;
+  removeSelection: (value?: ISelectedOption | string) => void;
 }
 
 export interface IComboboxContainerProps<T = HTMLElement, L = HTMLElement>
@@ -144,7 +142,7 @@ export interface IComboboxContainerProps<T = HTMLElement, L = HTMLElement>
    * @param {function} [options.getOptionProps] Option props getter
    * @param {function} [options.getMessageProps] Message props getter
    * @param {boolean} options.isExpanded Current listbox expansion
-   * @param {OptionValue} [options.activeValue] Current active option value
+   * @param {string} [options.activeValue] Current active option value
    * @param {object|object[]} options.selection Current selection
    * @param {string} [options.inputValue] Current input value
    * @param {function} [options.removeSelection] Remove the specified selection value or all values if unspecified

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -26,7 +26,7 @@ import {
   UseComboboxState as IDownshiftState,
   UseComboboxStateChangeTypes as IDownshiftStateChangeType
 } from 'downshift';
-import { IOption, IUseComboboxProps, IUseComboboxReturnValue, OptionValue } from './types';
+import { IOption, IUseComboboxProps, IUseComboboxReturnValue } from './types';
 import { toLabel, toType } from './utils';
 
 export const useCombobox = <
@@ -61,7 +61,7 @@ export const useCombobox = <
    * State
    */
 
-  interface IPreviousState extends IDownshiftState<OptionValue> {
+  interface IPreviousState extends IDownshiftState<string> {
     type: IDownshiftStateChangeType;
     altKey?: boolean;
   }
@@ -84,11 +84,11 @@ export const useCombobox = <
       `${prefix}--option${isDisabled ? '-disabled' : ''}${isHidden ? '-hidden' : ''}-${index}`
   });
   const labels: Record<string, string> = useMemo(() => ({}), []);
-  const selectedValues: OptionValue[] = useMemo(() => [], []);
-  const disabledValues: OptionValue[] = useMemo(() => [], []);
-  const hiddenValues: OptionValue[] = useMemo(() => [], []);
+  const selectedValues: string[] = useMemo(() => [], []);
+  const disabledValues: string[] = useMemo(() => [], []);
+  const hiddenValues: string[] = useMemo(() => [], []);
   const values = useMemo(() => {
-    const retVal: OptionValue[] = [];
+    const retVal: string[] = [];
     const setValues = (option: IOption) => {
       if (option.disabled || option.hidden) {
         if (option.disabled && !disabledValues.includes(option.value)) {
@@ -118,9 +118,7 @@ export const useCombobox = <
         selectedValues.push(option.value);
       }
 
-      const key = typeof option.value === 'string' ? option.value : JSON.stringify(option.value);
-
-      labels[key] = option.label || key;
+      labels[option.value] = option.label || option.value;
     };
 
     options.forEach(option => {
@@ -134,7 +132,9 @@ export const useCombobox = <
     return retVal;
   }, [options, disabledValues, hiddenValues, selectedValues, labels]);
   const initialSelectionValue = isMultiselectable ? selectedValues : selectedValues[0];
-  const initialInputValue = isMultiselectable ? '' : toLabel(labels, initialSelectionValue);
+  const initialInputValue = isMultiselectable
+    ? ''
+    : toLabel(labels, initialSelectionValue as string);
   const _defaultActiveIndex = useMemo(() => {
     if (defaultActiveIndex === undefined) {
       return isAutocomplete && isEditable ? 0 : undefined;
@@ -175,7 +175,7 @@ export const useCombobox = <
    */
 
   const handleDownshiftStateChange = useCallback<
-    NonNullable<IUseDownshiftProps<OptionValue | OptionValue[]>['onStateChange']>
+    NonNullable<IUseDownshiftProps<string | string[]>['onStateChange']>
   >(
     ({ type, isOpen, selectedItem, inputValue: _inputValue, highlightedIndex }) =>
       onChange({
@@ -279,7 +279,7 @@ export const useCombobox = <
           changes.selectedItem !== null
         ) {
           if (state.selectedItem.includes(changes.selectedItem)) {
-            changes.selectedItem = (state.selectedItem as OptionValue[]).filter(
+            changes.selectedItem = (state.selectedItem as string[]).filter(
               value => value !== changes.selectedItem
             );
           } else {
@@ -297,7 +297,7 @@ export const useCombobox = <
       return changes;
     };
 
-  const transformValue = (value: OptionValue | null) => (value ? toLabel(labels, value) : '');
+  const transformValue = (value: string | null) => (value ? toLabel(labels, value) : '');
 
   /** Hooks */
 
@@ -314,7 +314,7 @@ export const useCombobox = <
     openMenu,
     setHighlightedIndex,
     selectItem
-  } = useDownshift<OptionValue | OptionValue[]>({
+  } = useDownshift<string | string[]>({
     toggleButtonId: idRef.current.trigger,
     menuId: idRef.current.listbox,
     getItemId: idRef.current.getOptionId,
@@ -357,7 +357,7 @@ export const useCombobox = <
   );
 
   const setDownshiftSelection = useCallback(
-    (value: OptionValue | OptionValue[] | null) => {
+    (value: string | string[] | null) => {
       selectItem(value);
       onChange({
         type: toType(useDownshift.stateChangeTypes.FunctionSelectItem),
@@ -875,7 +875,7 @@ export const useCombobox = <
         'aria-hidden': undefined,
         'aria-selected': ariaSelected,
         ...optionProps
-      } as IDownshiftOptionProps<OptionValue>);
+      } as IDownshiftOptionProps<string>);
     },
     [getDownshiftOptionProps, disabledValues, hiddenValues, values, _selectionValue]
   );

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -26,7 +26,7 @@ import {
   UseComboboxState as IDownshiftState,
   UseComboboxStateChangeTypes as IDownshiftStateChangeType
 } from 'downshift';
-import { IOption, IUseComboboxProps, IUseComboboxReturnValue } from './types';
+import { IOption, IUseComboboxProps, IUseComboboxReturnValue, OptionValue } from './types';
 import { toLabel, toType } from './utils';
 
 export const useCombobox = <
@@ -61,7 +61,7 @@ export const useCombobox = <
    * State
    */
 
-  interface IPreviousState extends IDownshiftState<string> {
+  interface IPreviousState extends IDownshiftState<OptionValue> {
     type: IDownshiftStateChangeType;
     altKey?: boolean;
   }
@@ -84,11 +84,11 @@ export const useCombobox = <
       `${prefix}--option${isDisabled ? '-disabled' : ''}${isHidden ? '-hidden' : ''}-${index}`
   });
   const labels: Record<string, string> = useMemo(() => ({}), []);
-  const selectedValues: string[] = useMemo(() => [], []);
-  const disabledValues: string[] = useMemo(() => [], []);
-  const hiddenValues: string[] = useMemo(() => [], []);
+  const selectedValues: OptionValue[] = useMemo(() => [], []);
+  const disabledValues: OptionValue[] = useMemo(() => [], []);
+  const hiddenValues: OptionValue[] = useMemo(() => [], []);
   const values = useMemo(() => {
-    const retVal: string[] = [];
+    const retVal: OptionValue[] = [];
     const setValues = (option: IOption) => {
       if (option.disabled || option.hidden) {
         if (option.disabled && !disabledValues.includes(option.value)) {
@@ -175,7 +175,7 @@ export const useCombobox = <
    */
 
   const handleDownshiftStateChange = useCallback<
-    NonNullable<IUseDownshiftProps<string | string[]>['onStateChange']>
+    NonNullable<IUseDownshiftProps<OptionValue | OptionValue[]>['onStateChange']>
   >(
     ({ type, isOpen, selectedItem, inputValue: _inputValue, highlightedIndex }) =>
       onChange({
@@ -279,7 +279,7 @@ export const useCombobox = <
           changes.selectedItem !== null
         ) {
           if (state.selectedItem.includes(changes.selectedItem)) {
-            changes.selectedItem = (state.selectedItem as string[]).filter(
+            changes.selectedItem = (state.selectedItem as OptionValue[]).filter(
               value => value !== changes.selectedItem
             );
           } else {
@@ -297,7 +297,7 @@ export const useCombobox = <
       return changes;
     };
 
-  const transformValue = (value: string | null) => (value ? toLabel(labels, value) : '');
+  const transformValue = (value: OptionValue | null) => (value ? toLabel(labels, value) : '');
 
   /** Hooks */
 
@@ -314,7 +314,7 @@ export const useCombobox = <
     openMenu,
     setHighlightedIndex,
     selectItem
-  } = useDownshift<string | string[]>({
+  } = useDownshift<OptionValue | OptionValue[]>({
     toggleButtonId: idRef.current.trigger,
     menuId: idRef.current.listbox,
     getItemId: idRef.current.getOptionId,
@@ -357,7 +357,7 @@ export const useCombobox = <
   );
 
   const setDownshiftSelection = useCallback(
-    (value: string | string[] | null) => {
+    (value: OptionValue | OptionValue[] | null) => {
       selectItem(value);
       onChange({
         type: toType(useDownshift.stateChangeTypes.FunctionSelectItem),
@@ -875,7 +875,7 @@ export const useCombobox = <
         'aria-hidden': undefined,
         'aria-selected': ariaSelected,
         ...optionProps
-      } as IDownshiftOptionProps<string>);
+      } as IDownshiftOptionProps<OptionValue>);
     },
     [getDownshiftOptionProps, disabledValues, hiddenValues, values, _selectionValue]
   );

--- a/packages/combobox/src/utils.ts
+++ b/packages/combobox/src/utils.ts
@@ -7,6 +7,7 @@
 
 import { KEYS } from '@zendeskgarden/container-utilities';
 import { useCombobox as useDownshift } from 'downshift';
+import { OptionValue } from './types';
 
 /** Map Downshift to Garden state change types */
 const typeMap: Record<string, string> = {
@@ -53,7 +54,7 @@ export const toType = (downshiftType: string) => {
  *
  * @returns A label from the `labels` record based on the given value.
  */
-export const toLabel = (labels: Record<string, string>, value?: string) => {
+export const toLabel = (labels: Record<string, string>, value?: OptionValue) => {
   if (value === undefined) {
     return '';
   }

--- a/packages/combobox/src/utils.ts
+++ b/packages/combobox/src/utils.ts
@@ -7,7 +7,6 @@
 
 import { KEYS } from '@zendeskgarden/container-utilities';
 import { useCombobox as useDownshift } from 'downshift';
-import { OptionValue } from './types';
 
 /** Map Downshift to Garden state change types */
 const typeMap: Record<string, string> = {
@@ -54,12 +53,10 @@ export const toType = (downshiftType: string) => {
  *
  * @returns A label from the `labels` record based on the given value.
  */
-export const toLabel = (labels: Record<string, string>, value: OptionValue) => {
+export const toLabel = (labels: Record<string, string>, value?: string) => {
   if (value === undefined) {
     return '';
   }
 
-  const key = typeof value === 'string' ? value : JSON.stringify(value);
-
-  return labels[key];
+  return labels[value];
 };


### PR DESCRIPTION
- [x] **BREAKING CHANGE?**

## Description

`container-combobox` has allowed consumers to set `option.value` with an `object` for ergonomics. This has proven to create unintended mismatches to selected values, and so this PR removes that compatibility feature, instead preferring all `value`s to be strings for the best comparison.

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- ~~:guardsman: includes new unit tests~~
- ~~:wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
