### PR TITLE
fix(container-menu)!: improves logic for returning focus to trigger

### DIFF
--- a/packages/menu/src/MenuContainer.spec.tsx
+++ b/packages/menu/src/MenuContainer.spec.tsx
@@ -371,6 +371,20 @@ describe('MenuContainer', () => {
 
           expect(trigger).toHaveFocus();
         });
+
+        it('does not return focus to trigger when Escape key pressed in expanded menu if `restoreFocus` is false', async () => {
+          const { getByTestId } = render(<TestMenu items={ITEMS} restoreFocus={false} />);
+          const trigger = getByTestId('trigger');
+
+          trigger.focus();
+
+          await waitFor(async () => {
+            await user.keyboard('{ArrowDown}');
+            await user.keyboard('{Escape}');
+          });
+
+          expect(trigger).not.toHaveFocus();
+        });
       });
 
       describe('menu items', () => {

--- a/packages/menu/src/MenuContainer.tsx
+++ b/packages/menu/src/MenuContainer.tsx
@@ -29,5 +29,12 @@ MenuContainer.propTypes = {
   defaultExpanded: PropTypes.bool,
   selectedItems: PropTypes.arrayOf(PropTypes.any),
   focusedValue: PropTypes.oneOfType([PropTypes.string]),
-  defaultFocusedValue: PropTypes.oneOfType([PropTypes.string])
+  defaultFocusedValue: PropTypes.oneOfType([PropTypes.string]),
+  restoreFocus: PropTypes.bool
+};
+
+MenuContainer.defaultProps = {
+  defaultExpanded: false,
+  restoreFocus: true,
+  rtl: false
 };

--- a/packages/menu/src/MenuContainer.tsx
+++ b/packages/menu/src/MenuContainer.tsx
@@ -34,7 +34,5 @@ MenuContainer.propTypes = {
 };
 
 MenuContainer.defaultProps = {
-  defaultExpanded: false,
-  restoreFocus: true,
-  rtl: false
+  restoreFocus: true
 };

--- a/packages/menu/src/types.ts
+++ b/packages/menu/src/types.ts
@@ -66,7 +66,7 @@ export interface IUseMenuProps<T = HTMLButtonElement, M = HTMLElement> {
   focusedValue?: string | null;
   /** Determines focused value on menu initialization */
   defaultFocusedValue?: string;
-  /** Returns focus to the trigger when the menu is collapsed */
+  /** Returns keyboard focus to the element that triggered the menu */
   restoreFocus?: boolean;
   /** Sets the selected values in a controlled menu */
   selectedItems?: ISelectedItem[];

--- a/packages/menu/src/types.ts
+++ b/packages/menu/src/types.ts
@@ -66,6 +66,8 @@ export interface IUseMenuProps<T = HTMLButtonElement, M = HTMLElement> {
   focusedValue?: string | null;
   /** Determines focused value on menu initialization */
   defaultFocusedValue?: string;
+  /** Returns focus to the trigger when the menu is collapsed */
+  restoreFocus?: boolean;
   /** Sets the selected values in a controlled menu */
   selectedItems?: ISelectedItem[];
   /**

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -278,18 +278,17 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
       event.stopPropagation();
 
       const changeType = StateChangeTypes.TriggerClick;
-      const nextIsExpanded = !controlledIsExpanded;
 
       dispatch({
         type: changeType,
         payload: {
           ...(!isFocusedValueControlled && { focusedValue: null }),
-          ...(!isExpandedControlled && { isExpanded: nextIsExpanded })
+          ...(!isExpandedControlled && { isExpanded: !controlledIsExpanded })
         }
       });
 
       // Skip focus return when isExpanded === true
-      returnFocusToTrigger(nextIsExpanded && isExpandedControlled);
+      returnFocusToTrigger(!controlledIsExpanded && isExpandedControlled);
 
       onChange({
         type: changeType,

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -48,6 +48,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
   onChange = () => undefined,
   isExpanded,
   defaultExpanded = false,
+  restoreFocus = true,
   selectedItems,
   focusedValue,
   defaultFocusedValue
@@ -134,11 +135,11 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
 
   const returnFocusToTrigger = useCallback(
     (skip?: boolean) => {
-      if (!skip && triggerRef.current) {
+      if (!skip && restoreFocus && triggerRef.current) {
         triggerRef.current.focus();
       }
     },
-    [triggerRef]
+    [triggerRef, restoreFocus]
   );
 
   const closeMenu = useCallback(
@@ -288,7 +289,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
       });
 
       // Skip focus return when isExpanded === true
-      returnFocusToTrigger(!controlledIsExpanded && isExpandedControlled);
+      returnFocusToTrigger(!controlledIsExpanded);
 
       onChange({
         type: changeType,
@@ -336,7 +337,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
           }
         });
 
-        returnFocusToTrigger(isExpandedControlled);
+        returnFocusToTrigger();
 
         onChange({
           type: changeType,
@@ -419,7 +420,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
         }
       });
 
-      returnFocusToTrigger(isTransitionItem && isExpandedControlled);
+      returnFocusToTrigger(isTransitionItem);
 
       onChange({
         type: changeType,
@@ -481,7 +482,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
           triggerLink(event.target as HTMLAnchorElement, environment || window);
         }
 
-        returnFocusToTrigger(isTransitionItem && isExpandedControlled);
+        returnFocusToTrigger(isTransitionItem);
       } else if (key === KEYS.RIGHT) {
         if (rtl && isPrevious) {
           changeType = StateChangeTypes.MenuItemKeyDownPrevious;
@@ -593,12 +594,6 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
   useEffect(() => {
     setMenuVisible(controlledIsExpanded);
   }, [controlledIsExpanded]);
-
-  useEffect(() => {
-    if (isExpandedControlled && isExpanded === false) {
-      returnFocusToTrigger();
-    }
-  }, [isExpandedControlled, isExpanded, returnFocusToTrigger]);
 
   /**
    * Respond to clicks outside the  open menu

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -289,7 +289,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
       });
 
       // Skip focus return when isExpanded === true
-      returnFocusToTrigger(nextIsExpanded);
+      returnFocusToTrigger(nextIsExpanded && isExpandedControlled);
 
       onChange({
         type: changeType,
@@ -337,7 +337,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
           }
         });
 
-        returnFocusToTrigger();
+        returnFocusToTrigger(isExpandedControlled);
 
         onChange({
           type: changeType,
@@ -366,8 +366,8 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
 
         const type = StateChangeTypes[key === KEYS.ESCAPE ? 'MenuKeyDownEscape' : 'MenuKeyDownTab'];
 
-        // Skip focus return on TAB key. Focus should go to the next element in the tab order.
-        returnFocusToTrigger(KEYS.TAB === key);
+        // TODO: Investigate why focus goes to body instead of next interactive element on TAB keydown. Meanwhile, returning focus to trigger.
+        returnFocusToTrigger();
 
         closeMenu(type);
       }
@@ -420,7 +420,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
         }
       });
 
-      returnFocusToTrigger(isTransitionItem);
+      returnFocusToTrigger(isTransitionItem && isExpandedControlled);
 
       onChange({
         type: changeType,
@@ -482,7 +482,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
           triggerLink(event.target as HTMLAnchorElement, environment || window);
         }
 
-        returnFocusToTrigger(isTransitionItem);
+        returnFocusToTrigger(isTransitionItem && isExpandedControlled);
       } else if (key === KEYS.RIGHT) {
         if (rtl && isPrevious) {
           changeType = StateChangeTypes.MenuItemKeyDownPrevious;
@@ -594,6 +594,12 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
   useEffect(() => {
     setMenuVisible(controlledIsExpanded);
   }, [controlledIsExpanded]);
+
+  useEffect(() => {
+    if (isExpandedControlled && isExpanded === false) {
+      returnFocusToTrigger();
+    }
+  }, [isExpandedControlled, isExpanded, returnFocusToTrigger]);
 
   /**
    * Respond to clicks outside the  open menu


### PR DESCRIPTION
## Description
Improve the logic for returning focus to trigger. Adds optional `restoreFocus` prop to manager focus return to trigger. 

## 💥 BREAKING CHANGE: 

A new `restoreFocus` prop has been added. By default `restoreFocus` is `true` and will return the focus to the trigger on menu item selection, `ESC` / `TAB` key press, and clicking outside the menu dropdown. User who need to keep the dropdown open on selection must set `restoreFocus={false}` and manually handle the focus return.

## Detail
- Returning focus to trigger is now executed synchronously before calling the `onChange` callback. Now, when a menu item triggers Garden's [Modal](https://garden.zendesk.com/components/modal) open, the focus will automatically be restored to the menu trigger after the modal has closed.

https://github.com/user-attachments/assets/ce921dbf-1c40-4d01-9950-83156155107d

- The focus return logic follows ARIA guidelines set for [Actions Menu Button](https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/examples/menu-button-actions/).
- Adds `restoreFocus` prop which defaults to `true`. Disabling it gives users more flexibility with managing focus return to the trigger. See demo Story in https://github.com/zendeskgarden/react-containers/pull/661.

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
