### PR TITLE
fix(menu): prevents `defaultFocusedValue` on trigger click

### DIFF
--- a/packages/menu/src/MenuContainer.spec.tsx
+++ b/packages/menu/src/MenuContainer.spec.tsx
@@ -285,13 +285,13 @@ describe('MenuContainer', () => {
             <TestMenu items={ITEMS} defaultFocusedValue="plant-04" />
           );
           const trigger = getByTestId('trigger');
-          const firstItem = getByText('Petunia');
+          const item = getByText('Succulent');
 
           await act(async () => {
             await user.click(trigger);
           });
 
-          expect(firstItem).not.toHaveFocus();
+          expect(item).not.toHaveFocus();
         });
 
         it('focuses defaultFocusedValue on ArrowDown keydown', async () => {

--- a/packages/menu/src/MenuContainer.spec.tsx
+++ b/packages/menu/src/MenuContainer.spec.tsx
@@ -280,6 +280,20 @@ describe('MenuContainer', () => {
           expect(firstItem).toHaveFocus();
         });
 
+        it('does not focus default value on click', async () => {
+          const { getByTestId, getByText } = render(
+            <TestMenu items={ITEMS} defaultFocusedValue="plant-04" />
+          );
+          const trigger = getByTestId('trigger');
+          const firstItem = getByText('Petunia');
+
+          await act(async () => {
+            await user.click(trigger);
+          });
+
+          expect(firstItem).not.toHaveFocus();
+        });
+
         it('focuses defaultFocusedValue on ArrowDown keydown', async () => {
           const { getByText, getByTestId } = render(
             <TestMenu items={ITEMS} defaultFocusedValue="plant-04" />

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -97,7 +97,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
   const focusTriggerRef = useRef<boolean>(false);
 
   const [state, dispatch] = useReducer(stateReducer, {
-    focusedValue: focusedValue || defaultFocusedValue,
+    focusedValue,
     isExpanded: isExpanded || defaultExpanded,
     selectedItems: initialSelectedItems,
     valuesRef: values,


### PR DESCRIPTION
## Description

Currently, setting a `defaultFocusedValue` causes unexpected focus into the menu when the trigger is clicked with a mouse.

## Detail

The way `defaultFocusedValue` should operate today is to only focus an item when the menu opens with keyboard interaction (from the trigger).

Instead, because `useReducer` initializes with `defaultFocusedValue`, a menu first opens with that value selected, including mouse interaction.

This behavior is intended to match [APG examples](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/examples/menubar-editor/) which prefer moving focus into menus only when an item is hovered. 

Note the below demonstration that showcases `Hydrangea` as the default focused value before and after the fix.

Before:

https://github.com/user-attachments/assets/ebcc853b-39a1-4c0d-af18-c2c8c6c3f6fa

After:

https://github.com/user-attachments/assets/6e60850f-9970-40b1-b4cf-bc0c450e3fbe

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
