### PR TITLE
docs: demo restoreFocus with controlled menu [ DO NOT MERGE! ]

### DIFF
--- a/packages/menu/demo/menu.stories.tsx
+++ b/packages/menu/demo/menu.stories.tsx
@@ -85,16 +85,16 @@ export const ControlledManagedFocus: Story = {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { type, isExpanded, ...rest } = _args;
           const { selectedItems } = rest;
-          let nextArgs: any = rest;
+          const nextArgs: typeof rest & { isExpanded?: boolean } = rest;
 
           const lastItem = selectedItems?.[selectedItems.length - 1];
           const isNonCheckboxItem = !selectedItems || lastItem?.type !== 'checkbox';
 
           if (isExpanded !== undefined && isNonCheckboxItem) {
-            nextArgs = { ...nextArgs, isExpanded };
+            nextArgs.isExpanded = isExpanded;
           }
 
-          if (!args.restoreFocus && isExpanded === false && triggerRef.current) {
+          if (!args.restoreFocus && nextArgs.isExpanded === false && triggerRef.current) {
             triggerRef.current.focus();
           }
           updateArgs(nextArgs);

--- a/packages/menu/demo/menu.stories.tsx
+++ b/packages/menu/demo/menu.stories.tsx
@@ -63,6 +63,54 @@ export const Controlled: Story = {
   },
   args: {
     isExpanded: false,
+    restoreFocus: true,
+    focusedValue: 'plant-01',
+    selectedItems: [{ value: 'Cherry', type: 'checkbox' }]
+  }
+};
+
+export const ControlledManagedFocus: Story = {
+  render: function Render(args) {
+    const updateArgs = useArgs()[1];
+    const triggerRef = React.useRef<HTMLButtonElement>(null);
+
+    return (
+      <MenuStory
+        {...args}
+        triggerRef={triggerRef}
+        onChange={_args => {
+          // eslint-disable-next-line no-console
+          console.log('onChange:', _args);
+
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { type, isExpanded, ...rest } = _args;
+          const { selectedItems } = rest;
+          let nextArgs: any = rest;
+
+          const lastItem = selectedItems?.[selectedItems.length - 1];
+          const isNonCheckboxItem = !selectedItems || lastItem?.type !== 'checkbox';
+
+          if (isExpanded !== undefined && isNonCheckboxItem) {
+            nextArgs = { ...nextArgs, isExpanded };
+          }
+
+          if (!args.restoreFocus && isExpanded === false && triggerRef.current) {
+            triggerRef.current.focus();
+          }
+          updateArgs(nextArgs);
+        }}
+      />
+    );
+  },
+  name: 'Controlled + Managed Focus',
+  argTypes: {
+    defaultFocusedValue: { control: false },
+    defaultExpanded: { control: false },
+    focusedValue: { control: { type: 'text' } }
+  },
+  args: {
+    isExpanded: false,
+    restoreFocus: false,
     focusedValue: 'plant-01',
     selectedItems: [{ value: 'Cherry', type: 'checkbox' }]
   }

--- a/packages/menu/demo/stories/MenuStory.tsx
+++ b/packages/menu/demo/stories/MenuStory.tsx
@@ -91,60 +91,71 @@ const Component = ({
   const selectedValues = selection.map(item => item.value);
 
   return (
-    <div className="relative">
-      <button className="px-2 py-1" type="button" {...getTriggerProps()}>
-        Produce
-      </button>
+    <div>
+      <div>
+        <div className="relative">
+          <button className="px-2 py-1" type="button" {...getTriggerProps()}>
+            Produce
+          </button>
 
-      <ul
-        className={classNames('border border-grey-400 border-solid w-32 absolute', {
-          invisible: !isExpanded
-        })}
-        {...getMenuProps()}
-      >
-        {items.map((item: MenuItem) => {
-          if ('items' in item) {
-            return (
-              <li key={item.label} role="none">
-                <b aria-hidden="true" className="block mt-1 ms-1">
-                  {item.label}
-                </b>
-                <hr aria-hidden="true" className="my-1 border-grey-200" {...getSeparatorProps()} />
-                <ul {...getItemGroupProps({ 'aria-label': item.label })}>
-                  {item.items.map(groupItem => (
-                    <Item
-                      key={groupItem.value}
-                      item={{ ...groupItem }}
-                      getItemProps={getItemProps}
-                      focusedValue={focusedValue}
-                      isSelected={selectedValues.includes(groupItem.value)}
+          <ul
+            className={classNames('bg-white border border-grey-400 border-solid w-32 absolute', {
+              invisible: !isExpanded
+            })}
+            {...getMenuProps()}
+          >
+            {items.map((item: MenuItem) => {
+              if ('items' in item) {
+                return (
+                  <li key={item.label} role="none">
+                    <b aria-hidden="true" className="block mt-1 ms-1">
+                      {item.label}
+                    </b>
+                    <hr
+                      aria-hidden="true"
+                      className="my-1 border-grey-200"
+                      {...getSeparatorProps()}
                     />
-                  ))}
-                </ul>
-              </li>
-            );
-          }
+                    <ul {...getItemGroupProps({ 'aria-label': item.label })}>
+                      {item.items.map(groupItem => (
+                        <Item
+                          key={groupItem.value}
+                          item={{ ...groupItem }}
+                          getItemProps={getItemProps}
+                          focusedValue={focusedValue}
+                          isSelected={selectedValues.includes(groupItem.value)}
+                        />
+                      ))}
+                    </ul>
+                  </li>
+                );
+              }
 
-          if ('separator' in item) {
-            return (
-              <li
-                key={item.value}
-                className="my-1 border-0 border-b border-solid border-grey-200"
-                {...getSeparatorProps()}
-              />
-            );
-          }
+              if ('separator' in item) {
+                return (
+                  <li
+                    key={item.value}
+                    className="my-1 border-0 border-b border-solid border-grey-200"
+                    {...getSeparatorProps()}
+                  />
+                );
+              }
 
-          return (
-            <Item
-              key={item.value}
-              item={item}
-              focusedValue={focusedValue}
-              getItemProps={getItemProps}
-            />
-          );
-        })}
-      </ul>
+              return (
+                <Item
+                  key={item.value}
+                  item={item}
+                  focusedValue={focusedValue}
+                  getItemProps={getItemProps}
+                />
+              );
+            })}
+          </ul>
+        </div>
+        <div>
+          <button style={{ marginTop: 80 }}>click me</button>
+        </div>
+      </div>
     </div>
   );
 };
@@ -167,16 +178,16 @@ interface IArgs extends MenuContainerProps {
   as: 'hook' | 'container';
 }
 
-export const MenuStory: StoryFn<IArgs> = ({ as, ...props }) => {
-  const triggerRef = useRef<HTMLButtonElement>(null);
+export const MenuStory: StoryFn<IArgs> = ({ as, triggerRef, ...props }) => {
+  const _triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLUListElement>(null);
 
   switch (as) {
     case 'container':
-      return <Container {...props} triggerRef={triggerRef} menuRef={menuRef} />;
+      return <Container {...props} triggerRef={triggerRef || _triggerRef} menuRef={menuRef} />;
 
     case 'hook':
     default:
-      return <Hook {...props} triggerRef={triggerRef} menuRef={menuRef} />;
+      return <Hook {...props} triggerRef={triggerRef || _triggerRef} menuRef={menuRef} />;
   }
 };

--- a/packages/menu/src/MenuContainer.tsx
+++ b/packages/menu/src/MenuContainer.tsx
@@ -29,5 +29,12 @@ MenuContainer.propTypes = {
   defaultExpanded: PropTypes.bool,
   selectedItems: PropTypes.arrayOf(PropTypes.any),
   focusedValue: PropTypes.oneOfType([PropTypes.string]),
-  defaultFocusedValue: PropTypes.oneOfType([PropTypes.string])
+  defaultFocusedValue: PropTypes.oneOfType([PropTypes.string]),
+  restoreFocus: PropTypes.bool
+};
+
+MenuContainer.defaultProps = {
+  defaultExpanded: false,
+  restoreFocus: true,
+  rtl: false
 };

--- a/packages/menu/src/types.ts
+++ b/packages/menu/src/types.ts
@@ -66,6 +66,8 @@ export interface IUseMenuProps<T = HTMLButtonElement, M = HTMLElement> {
   focusedValue?: string | null;
   /** Determines focused value on menu initialization */
   defaultFocusedValue?: string;
+  /** Returns focus to the trigger when the menu is collapsed */
+  restoreFocus?: boolean;
   /** Sets the selected values in a controlled menu */
   selectedItems?: ISelectedItem[];
   /**

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -48,6 +48,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
   onChange = () => undefined,
   isExpanded,
   defaultExpanded = false,
+  restoreFocus = true,
   selectedItems,
   focusedValue,
   defaultFocusedValue
@@ -134,11 +135,11 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
 
   const returnFocusToTrigger = useCallback(
     (skip?: boolean) => {
-      if (!skip && triggerRef.current) {
+      if (!skip && restoreFocus && triggerRef.current) {
         triggerRef.current.focus();
       }
     },
-    [triggerRef]
+    [triggerRef, restoreFocus]
   );
 
   const closeMenu = useCallback(
@@ -288,7 +289,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
       });
 
       // Skip focus return when isExpanded === true
-      returnFocusToTrigger(!controlledIsExpanded && isExpandedControlled);
+      returnFocusToTrigger(!controlledIsExpanded);
 
       onChange({
         type: changeType,
@@ -419,7 +420,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
         }
       });
 
-      returnFocusToTrigger(isTransitionItem && isExpandedControlled);
+      returnFocusToTrigger(isTransitionItem);
 
       onChange({
         type: changeType,
@@ -481,7 +482,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
           triggerLink(event.target as HTMLAnchorElement, environment || window);
         }
 
-        returnFocusToTrigger(isTransitionItem && isExpandedControlled);
+        returnFocusToTrigger(isTransitionItem);
       } else if (key === KEYS.RIGHT) {
         if (rtl && isPrevious) {
           changeType = StateChangeTypes.MenuItemKeyDownPrevious;
@@ -593,12 +594,6 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
   useEffect(() => {
     setMenuVisible(controlledIsExpanded);
   }, [controlledIsExpanded]);
-
-  useEffect(() => {
-    if (isExpandedControlled && isExpanded === false) {
-      returnFocusToTrigger();
-    }
-  }, [isExpandedControlled, isExpanded, returnFocusToTrigger]);
 
   /**
    * Respond to clicks outside the  open menu

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -337,7 +337,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
           }
         });
 
-        returnFocusToTrigger(isExpandedControlled);
+        returnFocusToTrigger();
 
         onChange({
           type: changeType,

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -278,18 +278,17 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
       event.stopPropagation();
 
       const changeType = StateChangeTypes.TriggerClick;
-      const nextIsExpanded = !controlledIsExpanded;
 
       dispatch({
         type: changeType,
         payload: {
           ...(!isFocusedValueControlled && { focusedValue: null }),
-          ...(!isExpandedControlled && { isExpanded: nextIsExpanded })
+          ...(!isExpandedControlled && { isExpanded: !controlledIsExpanded })
         }
       });
 
       // Skip focus return when isExpanded === true
-      returnFocusToTrigger(nextIsExpanded && isExpandedControlled);
+      returnFocusToTrigger(!controlledIsExpanded && isExpandedControlled);
 
       onChange({
         type: changeType,

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -289,7 +289,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
       });
 
       // Skip focus return when isExpanded === true
-      returnFocusToTrigger(nextIsExpanded);
+      returnFocusToTrigger(nextIsExpanded && isExpandedControlled);
 
       onChange({
         type: changeType,
@@ -337,7 +337,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
           }
         });
 
-        returnFocusToTrigger();
+        returnFocusToTrigger(isExpandedControlled);
 
         onChange({
           type: changeType,
@@ -366,8 +366,8 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
 
         const type = StateChangeTypes[key === KEYS.ESCAPE ? 'MenuKeyDownEscape' : 'MenuKeyDownTab'];
 
-        // Skip focus return on TAB key. Focus should go to the next element in the tab order.
-        returnFocusToTrigger(KEYS.TAB === key);
+        // TODO: Investigate why focus goes to body instead of next interactive element on TAB keydown. Meanwhile, returning focus to trigger.
+        returnFocusToTrigger();
 
         closeMenu(type);
       }
@@ -420,7 +420,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
         }
       });
 
-      returnFocusToTrigger(isTransitionItem);
+      returnFocusToTrigger(isTransitionItem && isExpandedControlled);
 
       onChange({
         type: changeType,
@@ -482,7 +482,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
           triggerLink(event.target as HTMLAnchorElement, environment || window);
         }
 
-        returnFocusToTrigger(isTransitionItem);
+        returnFocusToTrigger(isTransitionItem && isExpandedControlled);
       } else if (key === KEYS.RIGHT) {
         if (rtl && isPrevious) {
           changeType = StateChangeTypes.MenuItemKeyDownPrevious;
@@ -594,6 +594,12 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
   useEffect(() => {
     setMenuVisible(controlledIsExpanded);
   }, [controlledIsExpanded]);
+
+  useEffect(() => {
+    if (isExpandedControlled && isExpanded === false) {
+      returnFocusToTrigger();
+    }
+  }, [isExpandedControlled, isExpanded, returnFocusToTrigger]);
 
   /**
    * Respond to clicks outside the  open menu


### PR DESCRIPTION
# FOR DEMO PURPOSES ONLY - DO NOT MERGE ❗ 

## Description

Adds a "Controlled + Managed Focus" Story to demo the `restoreFocus` behavior featured in https://github.com/zendeskgarden/react-containers/pull/659 with a controlled menu.
