### PR TITLE
fix(container-menu): improve menu dropdown expansion and focus behavior on blur

### DIFF
--- a/packages/menu/src/MenuContainer.spec.tsx
+++ b/packages/menu/src/MenuContainer.spec.tsx
@@ -241,16 +241,39 @@ describe('MenuContainer', () => {
       expect(menu).not.toBeVisible();
     });
 
-    it('closes menu on blur', async () => {
+    it('closes menu on blur and restores focus to trigger if focus was moved to non-focusabe element', async () => {
       const { getByTestId } = render(<TestMenu items={ITEMS} />);
       const trigger = getByTestId('trigger');
       const menu = getByTestId('menu');
 
       await waitFor(async () => {
         await user.click(trigger);
+      });
+      expect(menu).toBeVisible();
+
+      await waitFor(async () => {
         await user.click(document.body);
       });
+      expect(trigger).toHaveFocus();
+      expect(menu).not.toBeVisible();
+    });
 
+    it('closes menu on blur and moves focus focus to focusabe element', async () => {
+      const { getByTestId } = render(
+        <>
+          <TestMenu items={ITEMS} />
+          <button data-test-id="focusable">Click me</button>
+        </>
+      );
+      const trigger = getByTestId('trigger');
+      const menu = getByTestId('menu');
+      const button = getByTestId('focusable');
+
+      await waitFor(async () => {
+        await user.click(trigger);
+        await user.click(button);
+      });
+      expect(button).toHaveFocus();
       expect(menu).not.toBeVisible();
     });
 


### PR DESCRIPTION
## Description

This PR addresses a bug where the Menu’s dropdown remained open when the user clicked outside its iframe. The dropdown now correctly closes when focus is moved outside the iframe.

## Detail

This [PR](https://github.com/zendeskgarden/react-components/pull/2011) implements the fix in `Menu` for manual testing in [Storybook](https://67e5f572d407126fc9ca533c--zendeskgarden-react-components.netlify.app/?path=/story/packages-dropdowns-menu--uncontrolled).

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [ ] :memo: tested in Chrome, Firefox, Safari, and Edge
