### PR TITLE
fix(menu): correctly identify menu item link with same URL as web page

### DIFF
--- a/packages/menu/demo/stories/MenuStory.tsx
+++ b/packages/menu/demo/stories/MenuStory.tsx
@@ -33,6 +33,15 @@ type MenuItemProps = {
   isSelected?: boolean;
 };
 
+/**
+ * [1] For a disabled link to be valid, it must have:
+ *  - `aria-disabled="true"`
+ *  - `role="link"`, or `role="menuitem"` if within a menu
+ *  - an `undefined` `href`
+ *
+ * @example <a role="link" aria-disabled="true">Learn something!</a>
+ * @see https://www.scottohara.me/blog/2021/05/28/disabled-links.html
+ */
 const Item = ({ item, getItemProps, focusedValue, isSelected }: MenuItemProps) => {
   const itemProps = getItemProps({ item });
 
@@ -60,7 +69,14 @@ const Item = ({ item, getItemProps, focusedValue, isSelected }: MenuItemProps) =
       {itemProps.href ? (
         <a
           {...(itemProps as AnchorHTMLAttributes<HTMLAnchorElement>)}
-          className="w-full rounded-sm outline-offset-0 transition-none border-width-none"
+          href={item.disabled ? undefined : itemProps.href}
+          className={classNames(
+            ' w-full rounded-sm outline-offset-0 transition-none border-width-none',
+            {
+              'text-grey-400': item.disabled,
+              'cursor-default': item.disabled
+            }
+          )}
         >
           {itemChildren}
           {!!item.isExternal && (

--- a/packages/menu/src/MenuContainer.spec.tsx
+++ b/packages/menu/src/MenuContainer.spec.tsx
@@ -283,14 +283,44 @@ describe('MenuContainer', () => {
       expect(menu).not.toBeVisible();
     });
 
-    it('applies external anchor attributes', () => {
-      const { getByTestId } = render(
-        <TestMenu items={[{ value: 'item', href: '#0', isExternal: true }]} />
-      );
-      const menu = getByTestId('menu');
+    describe('navigational menu items (links)', () => {
+      it('applies external anchor attributes, only if not disabled', () => {
+        const { getByTestId } = render(
+          <TestMenu
+            items={[
+              { value: 'link-1', href: '#1', isExternal: true },
+              { value: 'link-2', href: '#2', isExternal: true, disabled: true }
+            ]}
+          />
+        );
+        const menu = getByTestId('menu');
 
-      expect(menu.firstChild).toHaveAttribute('target', '_blank');
-      expect(menu.firstChild).toHaveAttribute('rel', 'noopener noreferrer');
+        expect(menu.firstChild).toHaveAttribute('target', '_blank');
+        expect(menu.firstChild).toHaveAttribute('rel', 'noopener noreferrer');
+
+        expect(menu.childNodes[1]).not.toHaveAttribute('target', '_blank');
+        expect(menu.childNodes[1]).not.toHaveAttribute('rel', 'noopener noreferrer');
+      });
+
+      it('applies the correct aria-current attribute to active link', async () => {
+        const { getByTestId, getByText } = render(
+          <TestMenu
+            items={[
+              { value: 'link-1', href: '#1' },
+              { value: 'link-2', href: '#2' }
+            ]}
+          />
+        );
+        const trigger = getByTestId('trigger');
+        const link = getByText('link-2');
+
+        await waitFor(async () => {
+          await user.click(trigger);
+          await user.click(link);
+        });
+
+        expect(link).toHaveAttribute('aria-current', 'page');
+      });
     });
 
     describe('focus', () => {
@@ -1263,6 +1293,28 @@ describe('MenuContainer', () => {
         const changeTypes = onChange.mock.calls.map(([change]) => change.type);
 
         expect(changeTypes).toContain(StateChangeTypes.MenuItemKeyDownPrevious);
+      });
+    });
+
+    describe('navigational menu items (links)', () => {
+      it('applies the correct aria-current attribute to selected link', async () => {
+        const { getByTestId, getByText } = render(
+          <TestMenu
+            items={[
+              { value: 'link-1', href: '#1' },
+              { value: 'link-2', href: '#2' }
+            ]}
+            selectedItems={[{ value: 'link-2' }]}
+          />
+        );
+        const trigger = getByTestId('trigger');
+        const link = getByText('link-2');
+
+        await waitFor(async () => {
+          await user.click(trigger);
+        });
+
+        expect(link).toHaveAttribute('aria-current', 'page');
       });
     });
   });


### PR DESCRIPTION

## Description

`useMenu` correctly identifies the menu item link with the same URL as the current web page.

## Detail
- `getItemProps` sets `aria-current="page"` to the menu item link with the same URL as the current web page.
- Disabled menu item links to not get unnecessary `target` and `ref` attributes.

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
