### PR TITLE
feat(menu): allow users to specify both window and document env

### DIFF
--- a/packages/menu/src/types.ts
+++ b/packages/menu/src/types.ts
@@ -86,8 +86,19 @@ export interface IUseMenuProps<T = HTMLButtonElement, M = HTMLElement> {
     focusedValue?: string | null;
     selectedItems?: ISelectedItem[];
   }) => void;
-  /** Sets the environment where the menu is rendered */
+  /**
+   * Sets the environment where the menu is rendered
+   * @deprecated use `window` prop instead.
+   * */
   environment?: Window;
+  /**
+   * Sets the window where the menu is rendered
+   * */
+  window?: Window;
+  /**
+   * Sets the document where the menu is rendered
+   * */
+  document?: Document | ShadowRoot;
 }
 
 export interface IUseMenuReturnValue {


### PR DESCRIPTION
## Description

This PR updates `useMenu` to allow users to specify both `window` and `document` environment independently.

## Detail
- Adds `optional` window and `document` prop
- Deprecates `environment` prop in favor on `window` prop to improve clarity
- Fallbacks to `window` and `window.document` if `props.window` and/or `props.document` are `undefined`.
- Coming soon: See implementation preview [here](#).


## Checklist

- [ ] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] :guardsman: includes new unit tests
- [ ] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [ ] :memo: tested in Chrome, Firefox, Safari, and Edge
