### PR TITLE
feat(container-menu)!: Add getAnchorProps for explicit anchor handling

### DIFF
--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -18,6 +18,8 @@ Check out [storybook](https://zendeskgarden.github.io/react-containers) for live
 
 ### useMenu
 
+#### Menu items
+
 ```jsx
 import { useMenu } from '@zendeskgarden/container-menu';
 
@@ -50,6 +52,40 @@ const Menu = () => {
 };
 ```
 
+#### Menu links
+
+```jsx
+import { useMenu } from '@zendeskgarden/container-menu';
+
+const Menu = () => {
+  const triggerRef = useRef();
+  const menuRef = useRef();
+  const items = [
+    { value: 'home', label: 'Home', href="#", selected: true },
+    { value: 'about', label: 'About', href="www.example.com/about" },
+    { value: 'support', label: 'Support', href="www.support.example.com", external: true }
+  ];
+  const { isExpanded, getTriggerProps, getMenuProps, getItemProps, getAnchorProps } = useMenu({
+    triggerRef,
+    menuRef,
+    items
+  });
+
+  return (
+    <>
+      <button {...getTriggerProps()}>Menu</button>
+      <ul {...getMenuProps()} style={{ visibility: isExpanded ? 'visible' : 'hidden' }}>
+        {items.map(item => (
+          <li key={item.value} {...getItemProps({ item })}>
+            <a {...getAnchorProps({ item })}>{item.label}</a>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+};
+```
+
 ### MenuContainer
 
 ```jsx
@@ -61,27 +97,20 @@ const Menu = () => {
   const items = [
     { value: 'value-1', label: 'One' },
     { value: 'value-2', label: 'Two' },
-    { value: 'value-3', label: 'Three', href: '#0' },
-    { value: 'value-4', label: 'Four' }
+    { value: 'value-3', label: 'Three' }
   ];
 
   return (
     <MenuContainer triggerRef={triggerRef} menuRef={menuRef} items={items}>
-      {({ isExpanded, getTriggerProps, getMenuProps, getItemProps, getSeparatorProps }) => (
+      {({ isExpanded, getTriggerProps, getMenuProps, getItemProps }) => (
         <>
           <button {...getTriggerProps()}>Menu</button>
           <ul {...getMenuProps()} style={{ visibility: isExpanded ? 'visible' : 'hidden' }}>
-            {items.map(item =>
-              item.href ? (
-                <li key={item.value} role="none">
-                  <a {...getItemProps({ item })}>{item.label}</a>
-                </li>
-              ) : (
-                <li key={item.value} {...getItemProps({ item })}>
-                  {item.label}
-                </li>
-              )
-            )}
+            {items.map(item => (
+              <li key={item.value} {...getItemProps({ item })}>
+                {item.label}
+              </li>
+            ))}
           </ul>
         </>
       )}

--- a/packages/menu/demo/menu.stories.tsx
+++ b/packages/menu/demo/menu.stories.tsx
@@ -48,6 +48,8 @@ export const Controlled: Story = {
     return (
       <MenuStory
         {...args}
+        // Storybook sets args to null when they are removed from controls. This breaks useMenu since getControlledValue treats null as intentional input.
+        selectedItems={args.selectedItems === null ? undefined : args.selectedItems}
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         onChange={({ type, ...rest }) => {
           updateArgs(rest);

--- a/packages/menu/demo/stories/MenuStory.tsx
+++ b/packages/menu/demo/stories/MenuStory.tsx
@@ -33,6 +33,15 @@ type MenuItemProps = {
   isSelected?: boolean;
 };
 
+/**
+ * [1] For a disabled link to be valid, it must have:
+ *  - `aria-disabled="true"`
+ *  - `role="link"`, or `role="menuitem"` if within a menu
+ *  - an `undefined` `href`
+ *
+ * @example <a role="link" aria-disabled="true">Learn something!</a>
+ * @see https://www.scottohara.me/blog/2021/05/28/disabled-links.html
+ */
 const Item = ({ item, getItemProps, focusedValue, isSelected }: MenuItemProps) => {
   const itemProps = getItemProps({ item });
 
@@ -60,7 +69,14 @@ const Item = ({ item, getItemProps, focusedValue, isSelected }: MenuItemProps) =
       {itemProps.href ? (
         <a
           {...(itemProps as AnchorHTMLAttributes<HTMLAnchorElement>)}
-          className="w-full rounded-sm outline-offset-0 transition-none border-width-none"
+          href={item.disabled ? undefined : itemProps.href}
+          className={classNames(
+            ' w-full rounded-sm outline-offset-0 transition-none border-width-none',
+            {
+              'text-grey-400': item.disabled,
+              'cursor-default': item.disabled
+            }
+          )}
         >
           {itemChildren}
           {!!item.isExternal && (

--- a/packages/menu/demo/stories/MenuStory.tsx
+++ b/packages/menu/demo/stories/MenuStory.tsx
@@ -41,8 +41,8 @@ const Item = ({ item, getAnchorProps, getItemProps, focusedValue, isSelected }: 
   const itemChildren = (
     <>
       <span className="inline-flex justify-center items-center w-4">
-        {item?.type === 'radio' && !!isSelected && '•'}
-        {item?.type === 'checkbox' && !!isSelected && '✓'}
+        {!!isSelected && item.type === 'radio' && '•'}
+        {!!isSelected && (item.type === 'checkbox' || !!item.href) && '✓'}
       </span>
       {item.label || item.value}
     </>
@@ -159,6 +159,7 @@ const Component = ({
               focusedValue={focusedValue}
               getItemProps={getItemProps}
               getAnchorProps={getAnchorProps}
+              isSelected={selectedValues.includes(item.value)}
             />
           );
         })}

--- a/packages/menu/demo/stories/MenuStory.tsx
+++ b/packages/menu/demo/stories/MenuStory.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { StoryFn } from '@storybook/react';
 import classNames from 'classnames';
 import {
@@ -98,7 +98,7 @@ const Component = ({
 }: MenuReturnValue & UseMenuProps) => {
   const selectedValues = selection.map(item => item.value);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const originalWindowOpen = window.open;
     window.open = () => null;
     return () => {

--- a/packages/menu/demo/stories/MenuStory.tsx
+++ b/packages/menu/demo/stories/MenuStory.tsx
@@ -33,15 +33,6 @@ type MenuItemProps = {
   isSelected?: boolean;
 };
 
-/**
- * [1] For a disabled link to be valid, it must have:
- *  - `aria-disabled="true"`
- *  - `role="link"`, or `role="menuitem"` if within a menu
- *  - an `undefined` `href`
- *
- * @example <a role="link" aria-disabled="true">Learn something!</a>
- * @see https://www.scottohara.me/blog/2021/05/28/disabled-links.html
- */
 const Item = ({ item, getItemProps, focusedValue, isSelected }: MenuItemProps) => {
   const itemProps = getItemProps({ item });
 
@@ -63,13 +54,12 @@ const Item = ({ item, getItemProps, focusedValue, isSelected }: MenuItemProps) =
         'cursor-pointer': !item.disabled,
         'cursor-default': item.disabled
       })}
-      role={itemProps.href ? 'none' : undefined}
-      {...(!itemProps.href && (itemProps as LiHTMLAttributes<HTMLLIElement>))}
+      role={item.href ? 'none' : undefined}
+      {...(!item.href && (itemProps as LiHTMLAttributes<HTMLLIElement>))}
     >
-      {itemProps.href ? (
+      {item.href ? (
         <a
           {...(itemProps as AnchorHTMLAttributes<HTMLAnchorElement>)}
-          href={item.disabled ? undefined : itemProps.href}
           className={classNames(
             ' w-full rounded-sm outline-offset-0 transition-none border-width-none',
             {
@@ -79,7 +69,7 @@ const Item = ({ item, getItemProps, focusedValue, isSelected }: MenuItemProps) =
           )}
         >
           {itemChildren}
-          {!!item.isExternal && (
+          {!!item.external && (
             <>
               <span aria-hidden="true"> ↗</span>
               <span className="sr-only">(opens in new window)</span>

--- a/packages/menu/demo/stories/data.ts
+++ b/packages/menu/demo/stories/data.ts
@@ -16,9 +16,16 @@ export const ITEMS: MenuItem[] = [
     value: 'plant-04',
     label: 'Aloe Vera',
     href: 'https://en.wikipedia.org/wiki/Aloe_vera',
-    isExternal: false
+    external: false
   },
-  { value: 'plant-05', label: 'Succulent' },
+  {
+    value: 'plant-05',
+    label: 'Palm tree',
+    href: 'https://en.wikipedia.org/wiki/Palm_tree',
+    external: true,
+    disabled: true
+  },
+  { value: 'plant-06', label: 'Succulent' },
   {
     label: 'Choose favorites',
     items: [

--- a/packages/menu/src/MenuContainer.spec.tsx
+++ b/packages/menu/src/MenuContainer.spec.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useCallback, useRef, useState } from 'react';
-import { RenderResult, render, act, waitFor } from '@testing-library/react';
+import { act, createEvent, fireEvent, render, RenderResult, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MenuItem, IMenuItemBase, IUseMenuProps, IUseMenuReturnValue } from './types';
 import { MenuContainer } from './';
@@ -1314,6 +1314,31 @@ describe('MenuContainer', () => {
           await user.click(trigger);
         });
 
+        expect(link).toHaveAttribute('aria-current', 'page');
+      });
+
+      it('prevents default when clicking a selected link', async () => {
+        const { getByTestId, getByText } = render(
+          <TestMenu
+            items={[
+              { value: 'link-1', href: '#1' },
+              { value: 'link-2', href: '#2' }
+            ]}
+            selectedItems={[{ value: 'link-2' }]}
+          />
+        );
+        const trigger = getByTestId('trigger');
+        const link = getByText('link-2');
+
+        await waitFor(async () => {
+          await user.click(trigger);
+        });
+
+        const event = createEvent.click(link);
+        event.preventDefault = jest.fn();
+        fireEvent(link, event);
+
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
         expect(link).toHaveAttribute('aria-current', 'page');
       });
     });

--- a/packages/menu/src/MenuContainer.spec.tsx
+++ b/packages/menu/src/MenuContainer.spec.tsx
@@ -283,14 +283,44 @@ describe('MenuContainer', () => {
       expect(menu).not.toBeVisible();
     });
 
-    it('applies external anchor attributes', () => {
-      const { getByTestId } = render(
-        <TestMenu items={[{ value: 'item', href: '#0', isExternal: true }]} />
-      );
-      const menu = getByTestId('menu');
+    describe('navigational menu items (links)', () => {
+      it('applies external anchor attributes, only if not disabled', () => {
+        const { getByTestId } = render(
+          <TestMenu
+            items={[
+              { value: 'link-1', href: '#1', isExternal: true },
+              { value: 'link-2', href: '#2', isExternal: true, disabled: true }
+            ]}
+          />
+        );
+        const menu = getByTestId('menu');
 
-      expect(menu.firstChild).toHaveAttribute('target', '_blank');
-      expect(menu.firstChild).toHaveAttribute('rel', 'noopener noreferrer');
+        expect(menu.firstChild).toHaveAttribute('target', '_blank');
+        expect(menu.firstChild).toHaveAttribute('rel', 'noopener noreferrer');
+
+        expect(menu.childNodes[1]).not.toHaveAttribute('target', '_blank');
+        expect(menu.childNodes[1]).not.toHaveAttribute('rel', 'noopener noreferrer');
+      });
+
+      it('applies the correct aria-current attribute to active link', async () => {
+        const { getByTestId, getByText } = render(
+          <TestMenu
+            items={[
+              { value: 'link-1', href: '#1' },
+              { value: 'link-2', href: '#2' }
+            ]}
+          />
+        );
+        const trigger = getByTestId('trigger');
+        const link = getByText('link-2');
+
+        await waitFor(async () => {
+          await user.click(trigger);
+          await user.click(link);
+        });
+
+        expect(link).toHaveAttribute('aria-current', 'page');
+      });
     });
 
     describe('focus', () => {
@@ -1263,6 +1293,28 @@ describe('MenuContainer', () => {
         const changeTypes = onChange.mock.calls.map(([change]) => change.type);
 
         expect(changeTypes).toContain(StateChangeTypes.MenuItemKeyDownPrevious);
+      });
+    });
+
+    describe('navigational menu items (links)', () => {
+      it('applies the correct aria-current attribute to selected link', async () => {
+        const { getByTestId, getByText } = render(
+          <TestMenu
+            items={[
+              { value: 'link-1', href: '#1' },
+              { value: 'link-2', href: '#2' }
+            ]}
+            selectedItems={[{ value: 'link-2' }]}
+          />
+        );
+        const trigger = getByTestId('trigger');
+        const link = getByText('link-2');
+
+        await waitFor(async () => {
+          await user.click(trigger);
+        });
+
+        expect(link).toHaveAttribute('aria-current', 'page');
       });
     });
   });

--- a/packages/menu/src/types.ts
+++ b/packages/menu/src/types.ts
@@ -14,7 +14,7 @@ export interface ISelectedItem {
   type?: 'radio' | 'checkbox';
   disabled?: boolean;
   href?: string;
-  isExternal?: boolean;
+  external?: boolean;
 }
 
 export interface IMenuItemBase extends ISelectedItem {
@@ -42,8 +42,10 @@ export interface IUseMenuProps<T = HTMLButtonElement, M = HTMLElement> {
    * @param {string} item.value Unique item value
    * @param {string} item.label Optional human-readable text value (defaults to `item.value`)
    * @param {string} item.name A shared name corresponding to an item radio group
+   * @param {string} item.href The URL to navigate to when the link item is clicked
+   * @param {boolean} item.external Indicates that link item is an external link
    * @param {boolean} item.disabled Indicates the item is not interactive
-   * @param {boolean} item.selected Sets initial selection for the option
+   * @param {boolean} item.selected Sets initial selection for the option. The initial selection persists for link items.
    * @param {boolean} item.isNext - Indicates the item transitions to a nested menu
    * @param {boolean} item.isPrevious - Indicates the item will transition back from a nested menu
    * @param {boolean} item.separator Indicates the item is a placeholder for a separator

--- a/packages/menu/src/types.ts
+++ b/packages/menu/src/types.ts
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import { ButtonHTMLAttributes, HTMLProps, ReactNode, RefObject } from 'react';
+import { AnchorHTMLAttributes, ButtonHTMLAttributes, HTMLProps, ReactNode, RefObject } from 'react';
 
 export interface ISelectedItem {
   value: string;
@@ -116,9 +116,16 @@ export interface IUseMenuReturnValue {
   getItemProps: <T extends Element>(
     props: Omit<HTMLProps<T>, 'role'> & {
       item: IMenuItemBase;
-      role?: 'menuitem' | 'menuitemradio' | 'menuitemcheckbox' | null;
+      role?: 'menuitem' | 'menuitemradio' | 'menuitemcheckbox' | 'none' | null;
     }
   ) => HTMLProps<T>;
+  getAnchorProps: (
+    props: Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'role'> & {
+      item: IMenuItemBase;
+      role?: 'link' | null;
+    }
+  ) => AnchorHTMLAttributes<HTMLAnchorElement> | undefined;
+
   getSeparatorProps: <T extends Element>(
     props?: HTMLProps<T> & {
       role?: 'separator' | 'none' | null;
@@ -133,6 +140,7 @@ export interface IMenuContainerProps<T = HTMLElement, M = HTMLElement> extends I
    * @param {function} [options.getTriggerProps] Trigger props getter
    * @param {function} [options.getMenuProps] Menu props getter
    * @param {function} [options.getItemProps] Menu item props getter
+   * @param {function} [options.getAnchorProps] Menu link item props getter
    * @param {function} [options.getSeparatorProps] Separator item props getter
    * @param {boolean} [options.isExpanded] Current menu expansion
    * @param {ISelectedItem[]} [options.selection] Current selection
@@ -143,6 +151,7 @@ export interface IMenuContainerProps<T = HTMLElement, M = HTMLElement> extends I
     getTriggerProps: IUseMenuReturnValue['getTriggerProps'];
     getMenuProps: IUseMenuReturnValue['getMenuProps'];
     getItemProps: IUseMenuReturnValue['getItemProps'];
+    getAnchorProps: IUseMenuReturnValue['getAnchorProps'];
     getSeparatorProps: IUseMenuReturnValue['getSeparatorProps'];
     /* state */
     isExpanded: IUseMenuReturnValue['isExpanded'];

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -817,7 +817,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
         name,
         value,
         href,
-        isExternal,
+        external,
         isNext = false,
         isPrevious = false,
         label = value
@@ -860,10 +860,18 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
           anchorItemError(item);
         }
 
-        elementProps.href = href;
-
+        /**
+         * For a disabled link to be valid, it must have:
+         *  - `aria-disabled="true"`
+         *  - `role="link"`, or `role="menuitem"` if within a menu
+         *  - an `undefined` `href`
+         *
+         * @see https://www.scottohara.me/blog/2021/05/28/disabled-links.html
+         */
         if (!itemDisabled) {
-          if (isExternal) {
+          elementProps.href = href;
+
+          if (external) {
             elementProps.target = '_blank';
             elementProps.rel = 'noopener noreferrer';
           }

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -225,7 +225,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
     ({ value, type, name, label, selected, href }: IMenuItemBase) => {
       let changes: ISelectedItem[] | null = [...controlledSelectedItems];
 
-      if (!(type || href)) return null;
+      if (!type || href) return null;
 
       const selectedItem = {
         value,
@@ -240,7 +240,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
         } else {
           changes.push(selectedItem);
         }
-      } else if (type === 'radio' || href) {
+      } else if (type === 'radio') {
         const index = changes.findIndex(item => item.name === name);
 
         if (index > -1) {

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -73,9 +73,12 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
   );
   const initialSelectedItems = useMemo(
     () =>
-      menuItems.filter(
-        item => !!(item.type && ['radio', 'checkbox'].includes(item.type) && item.selected)
-      ),
+      menuItems.filter(item => {
+        return !!(
+          (item.href || item.type === 'radio' || item.type === 'checkbox') &&
+          item.selected
+        );
+      }),
     [menuItems]
   );
   const values = useMemo(() => menuItems.map(item => item.value), [menuItems]);
@@ -165,14 +168,19 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
 
         isSelected = match?.value === value;
       } else if (href) {
-        const current = controlledSelectedItems[0];
+        const selection =
+          Array.isArray(selectedItems) && selectedItems.length
+            ? selectedItems
+            : initialSelectedItems;
+
+        const current = selection.filter(item => item.name === name)[0];
 
         isSelected = current?.value === value;
       }
 
       return isSelected;
     },
-    [controlledSelectedItems]
+    [controlledSelectedItems, initialSelectedItems, selectedItems]
   );
 
   const getNextFocusedValue = useCallback(
@@ -472,6 +480,7 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
       });
     },
     [
+      selectedItems,
       getSelectedItems,
       state.nestedPathIds,
       isExpandedControlled,

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -164,8 +164,12 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
 
       if (type === 'checkbox') {
         isSelected = !!controlledSelectedItems.find(item => item.value === value);
-      } else if (type === 'radio' || href) {
+      } else if (type === 'radio') {
         const match = controlledSelectedItems.filter(item => item.name === name)[0];
+
+        isSelected = match?.value === value;
+      } else if (href) {
+        const match = controlledSelectedItems.filter(item => item.value === value)[0];
 
         isSelected = match?.value === value;
       }

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -163,24 +163,15 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
 
       if (type === 'checkbox') {
         isSelected = !!controlledSelectedItems.find(item => item.value === value);
-      } else if (type === 'radio') {
+      } else if (type === 'radio' || href) {
         const match = controlledSelectedItems.filter(item => item.name === name)[0];
 
         isSelected = match?.value === value;
-      } else if (href) {
-        const selection =
-          Array.isArray(selectedItems) && selectedItems.length
-            ? selectedItems
-            : initialSelectedItems;
-
-        const current = selection.filter(item => item.name === name)[0];
-
-        isSelected = current?.value === value;
       }
 
       return isSelected;
     },
-    [controlledSelectedItems, initialSelectedItems, selectedItems]
+    [controlledSelectedItems]
   );
 
   const getNextFocusedValue = useCallback(
@@ -231,9 +222,10 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
 
   const getSelectedItems = useCallback(
     ({ value, type, name, label, selected, href }: IMenuItemBase) => {
-      let changes: ISelectedItem[] | null = [...controlledSelectedItems];
+      if (href) return controlledSelectedItems;
+      if (!type) return null;
 
-      if (!type || href) return null;
+      let changes: ISelectedItem[] | null = [...controlledSelectedItems];
 
       const selectedItem = {
         value,
@@ -480,7 +472,6 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
       });
     },
     [
-      selectedItems,
       getSelectedItems,
       state.nestedPathIds,
       isExpandedControlled,

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -432,15 +432,17 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
   }, [onChange]);
 
   const handleItemClick = useCallback(
-    (item: IMenuItemBase) => {
+    (event: React.MouseEvent, item: IMenuItemBase) => {
       let changeType = StateChangeTypes.MenuItemClick;
-      const { isNext, isPrevious } = item;
+      const { isNext, isPrevious, href, selected } = item;
       const isTransitionItem = isNext || isPrevious;
 
       if (isNext) {
         changeType = StateChangeTypes.MenuItemClickNext;
       } else if (isPrevious) {
         changeType = StateChangeTypes.MenuItemClickPrevious;
+      } else if (href && selected) {
+        event.preventDefault();
       }
 
       const nextSelection = getSelectedItems(item);
@@ -872,8 +874,8 @@ export const useMenu = <T extends HTMLElement = HTMLElement, M extends HTMLEleme
       const itemProps = getElementProps({
         value: value as any,
         ...elementProps,
-        onClick: composeEventHandlers(onClick, () =>
-          handleItemClick({ ...item, label, selected, isNext, isPrevious })
+        onClick: composeEventHandlers(onClick, (e: React.MouseEvent) =>
+          handleItemClick(e, { ...item, label, selected, isNext, isPrevious })
         ),
         onKeyDown: composeEventHandlers(onKeyDown, (e: React.KeyboardEvent) =>
           handleItemKeyDown(e, { ...item, label, selected, isNext, isPrevious })

--- a/packages/menu/src/utils.ts
+++ b/packages/menu/src/utils.ts
@@ -7,7 +7,13 @@
 
 import { Reducer } from 'react';
 import { KEYS } from '@zendeskgarden/container-utilities';
-import { MenuItem, IMenuItemBase, IMenuItemSeparator, ISelectedItem } from './types';
+import {
+  MenuItem,
+  IMenuItemBase,
+  IMenuItemSeparator,
+  ISelectedItem,
+  IMenuItemGroup
+} from './types';
 
 export const triggerLink = (element: HTMLAnchorElement, view: Window) => {
   const event = new MouseEvent('click', {
@@ -46,9 +52,9 @@ export const StateChangeTypes: Record<string, string> = {
   MenuItemKeyDownEnd: `menuItem:keyDown:${KEYS.END}`
 };
 
-export const isItemGroup = (item: MenuItem) => Object.hasOwn(item, 'items');
+export const isItemGroup = (item: MenuItem): item is IMenuItemGroup => Object.hasOwn(item, 'items');
 
-export const isValidItem = (item: MenuItem) =>
+export const isValidItem = (item: MenuItem): item is IMenuItemBase =>
   !(item as IMenuItemBase).disabled &&
   !(item as IMenuItemSeparator).separator &&
   !isItemGroup(item);


### PR DESCRIPTION
## Description

This PR updates the `useMenu` API by decoupling anchor-related logic from `getItemProps`. It introduces a new `getAnchorProps` getter for handling anchor-specific attributes in navigational menus. This PR is to supersede #693.

## BREAKING CHANGES

- `getItemProps` no longer includes anchor-related props. Use `getAnchorProps` for `<a>` tags.
- Continue using `getItemProps` for `<li>`-level attributes around anchor items.
- `useMenu` no longer tracks selected link state internally. Consumers must now:
  - Mark items as selected by default with `selected: true`, or
  - Use `props.selectedItems` (overrides items selected by default)

## Details

`getAnchorProps` behavior:
- Returns anchor attributes (href, target, rel, etc.) for items with an `href`.
- Adds `target="_blank"` and `rel="noreferrer noopener"` when `external` is `true`.
- Omits anchor attributes for disabled items.
- Disables interactions (click, keydown) for selected anchors.
- Enforces a single selected anchor per menu.

See https://github.com/zendeskgarden/react-components/pull/2019 for implementation preview in `Menu`.

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
