### PR TITLE
feat(tooltip)!: prevent a tooltip from interfering with a trigger's expanded popup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28313,6 +28313,48 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
@@ -28352,6 +28394,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/netlify-cli/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "20.14.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
@@ -28367,11 +28415,33 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "extraneous": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/netlify-cli/node_modules/@types/yargs-parser": {
       "version": "20.2.1",
@@ -28751,6 +28821,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "extraneous": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/netlify-cli/node_modules/ajv-formats": {
@@ -32040,6 +32126,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "extraneous": true
+    },
     "node_modules/netlify-cli/node_modules/fast-json-stringify": {
       "version": "5.15.1",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.15.1.tgz",
@@ -33734,6 +33826,15 @@
         "ipx": "bin/ipx.mjs"
       }
     },
+    "node_modules/netlify-cli/node_modules/ipx/node_modules/@netlify/blobs": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-6.5.0.tgz",
+      "integrity": "sha512-wRFlNnL/Qv3WNLZd3OT/YYqF1zb6iPSo8T31sl9ccL1ahBxW1fBqKgF4b1XL7Z+6mRIkatvcsVPkWBcO+oJMNA==",
+      "extraneous": true,
+      "engines": {
+        "node": "^14.16.0 || >=16.0.0"
+      }
+    },
     "node_modules/netlify-cli/node_modules/ipx/node_modules/lru-cache": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
@@ -34288,6 +34389,12 @@
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       }
+    },
+    "node_modules/netlify-cli/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "extraneous": true
     },
     "node_modules/netlify-cli/node_modules/jsonc-parser": {
       "version": "3.2.0",
@@ -48082,6 +48189,9 @@
         "@zendeskgarden/container-utilities": "^2.0.2",
         "react-uid": "^2.2.0"
       },
+      "devDependencies": {
+        "@zendeskgarden/container-menu": "^1.0.0"
+      },
       "peerDependencies": {
         "prop-types": "^15.6.1",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
@@ -54350,6 +54460,7 @@
       "version": "file:packages/tooltip",
       "requires": {
         "@babel/runtime": "^7.8.4",
+        "@zendeskgarden/container-menu": "^1.0.0",
         "@zendeskgarden/container-utilities": "^2.0.2",
         "react-uid": "^2.2.0"
       }
@@ -68077,6 +68188,47 @@
           "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
           "dev": true
         },
+        "@types/body-parser": {
+          "version": "1.19.2",
+          "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+          "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+          "extraneous": true,
+          "requires": {
+            "@types/connect": "*",
+            "@types/node": "*"
+          }
+        },
+        "@types/connect": {
+          "version": "3.4.35",
+          "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+          "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+          "extraneous": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/express": {
+          "version": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+          "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+          "extraneous": true,
+          "requires": {
+            "@types/body-parser": "*",
+            "@types/express-serve-static-core": "^4.17.18",
+            "@types/qs": "*",
+            "@types/serve-static": "*"
+          }
+        },
+        "@types/express-serve-static-core": {
+          "version": "4.17.28",
+          "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+          "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+          "extraneous": true,
+          "requires": {
+            "@types/node": "*",
+            "@types/qs": "*",
+            "@types/range-parser": "*"
+          }
+        },
         "@types/http-cache-semantics": {
           "version": "4.0.4",
           "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
@@ -68116,6 +68268,12 @@
             "@types/istanbul-lib-report": "*"
           }
         },
+        "@types/mime": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+          "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+          "extraneous": true
+        },
         "@types/node": {
           "version": "20.14.8",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
@@ -68131,11 +68289,33 @@
           "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
           "dev": true
         },
+        "@types/qs": {
+          "version": "6.9.7",
+          "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+          "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+          "extraneous": true
+        },
+        "@types/range-parser": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+          "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+          "extraneous": true
+        },
         "@types/retry": {
           "version": "0.12.1",
           "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
           "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
           "dev": true
+        },
+        "@types/serve-static": {
+          "version": "1.13.10",
+          "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+          "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+          "extraneous": true,
+          "requires": {
+            "@types/mime": "^1",
+            "@types/node": "*"
+          }
         },
         "@types/yargs-parser": {
           "version": "20.2.1",
@@ -68416,6 +68596,17 @@
               "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
               "dev": true
             }
+          }
+        },
+        "ajv": {
+          "version": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "extraneous": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
           }
         },
         "ajv-formats": {
@@ -70784,6 +70975,12 @@
             "micromatch": "^4.0.4"
           }
         },
+        "fast-json-stable-stringify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+          "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+          "extraneous": true
+        },
         "fast-json-stringify": {
           "version": "5.15.1",
           "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.15.1.tgz",
@@ -72048,6 +72245,11 @@
             "xss": "^1.0.14"
           },
           "dependencies": {
+            "@netlify/blobs": {
+              "version": "https://registry.npmjs.org/@netlify/blobs/-/blobs-6.5.0.tgz",
+              "integrity": "sha512-wRFlNnL/Qv3WNLZd3OT/YYqF1zb6iPSo8T31sl9ccL1ahBxW1fBqKgF4b1XL7Z+6mRIkatvcsVPkWBcO+oJMNA==",
+              "extraneous": true
+            },
             "lru-cache": {
               "version": "10.2.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
@@ -72390,6 +72592,12 @@
           "requires": {
             "fast-deep-equal": "^3.1.3"
           }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "extraneous": true
         },
         "jsonc-parser": {
           "version": "3.2.0",

--- a/packages/tooltip/demo/stories/TooltipStory.tsx
+++ b/packages/tooltip/demo/stories/TooltipStory.tsx
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { createRef } from 'react';
 import { StoryFn } from '@storybook/react';
 import classNames from 'classnames';
 import {
@@ -60,12 +60,14 @@ interface IArgs extends ITooltipContainerProps {
 }
 
 export const TooltipStory: StoryFn<IArgs> = ({ as, ...props }) => {
+  const triggerRef = createRef<HTMLButtonElement>();
+
   switch (as) {
     case 'container':
-      return <Container {...props} />;
+      return <Container {...props} triggerRef={triggerRef} />;
 
     case 'hook':
     default:
-      return <Hook {...props} />;
+      return <Hook {...props} triggerRef={triggerRef} />;
   }
 };

--- a/packages/tooltip/demo/~patterns/patterns.mdx
+++ b/packages/tooltip/demo/~patterns/patterns.mdx
@@ -12,3 +12,9 @@ Demonstrate `openTooltip` and `closeTooltip` overrides.
 <Canvas>
   <Story of={PatternsStories.Focus} />
 </Canvas>
+
+## Menu
+
+<Canvas>
+  <Story of={PatternsStories.Menu} />
+</Canvas>

--- a/packages/tooltip/demo/~patterns/patterns.stories.tsx
+++ b/packages/tooltip/demo/~patterns/patterns.stories.tsx
@@ -8,12 +8,18 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { FocusStory } from './stories/FocusStory';
+import { MenuStory } from './stories/MenuStory';
 
-const meta: Meta<typeof FocusStory> = { title: 'Packages/Tooltip/[patterns]' };
+const meta: Meta = { title: 'Packages/Tooltip/[patterns]' };
 
 export default meta;
 
 export const Focus: StoryObj<typeof FocusStory> = {
   render: args => <FocusStory {...args} />,
   name: 'Focus'
+};
+
+export const Menu: StoryObj<typeof MenuStory> = {
+  render: args => <MenuStory {...args} />,
+  name: 'Menu'
 };

--- a/packages/tooltip/demo/~patterns/stories/FocusStory.tsx
+++ b/packages/tooltip/demo/~patterns/stories/FocusStory.tsx
@@ -5,13 +5,16 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { useRef } from 'react';
 import { StoryFn } from '@storybook/react';
 import classNames from 'classnames';
 import { useTooltip } from '@zendeskgarden/container-tooltip';
 
 export const FocusStory: StoryFn = () => {
-  const { getTooltipProps, getTriggerProps, isVisible, openTooltip, closeTooltip } = useTooltip();
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const { getTooltipProps, getTriggerProps, isVisible, openTooltip, closeTooltip } = useTooltip({
+    triggerRef
+  });
   const onFocus = () => openTooltip();
   const onBlur = () => closeTooltip(0);
 

--- a/packages/tooltip/demo/~patterns/stories/MenuStory.tsx
+++ b/packages/tooltip/demo/~patterns/stories/MenuStory.tsx
@@ -1,0 +1,56 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import React, { useRef } from 'react';
+import { StoryFn } from '@storybook/react';
+import classNames from 'classnames';
+import { useTooltip } from '@zendeskgarden/container-tooltip';
+import { MenuItem, useMenu } from '@zendeskgarden/container-menu';
+
+export const MenuStory: StoryFn = () => {
+  const items: MenuItem[] = [];
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLUListElement>(null);
+  const {
+    getMenuProps,
+    getTriggerProps: getMenuTriggerProps,
+    isExpanded
+  } = useMenu({ items, triggerRef, menuRef });
+  const { getTooltipProps, getTriggerProps, isVisible } = useTooltip({ triggerRef });
+
+  return (
+    <div className="relative">
+      <button className="px-2 py-1" {...getTriggerProps()} {...getMenuTriggerProps()} type="button">
+        Menu trigger
+      </button>
+      <span
+        className={classNames(
+          'bg-grey-800',
+          'inline-block',
+          'ml-1',
+          'px-2',
+          'py-0.5',
+          'rounded-sm',
+          'text-sm',
+          'text-white',
+          isVisible ? 'visible' : 'invisible'
+        )}
+        {...getTooltipProps()}
+      >
+        Tooltip
+      </span>
+      <ul
+        className={classNames('border border-grey-400 border-solid w-32 absolute', {
+          invisible: !isExpanded
+        })}
+        {...getMenuProps()}
+      >
+        <span className={classNames('inline-block', 'p-3', 'text-grey-600')}>Empty menu</span>
+      </ul>
+    </div>
+  );
+};

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -29,6 +29,9 @@
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
+  "devDependencies": {
+    "@zendeskgarden/container-menu": "^1.0.0"
+  },
   "keywords": [
     "a11y",
     "accessible",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -21,8 +21,7 @@
   "types": "dist/typings/index.d.ts",
   "dependencies": {
     "@babel/runtime": "^7.8.4",
-    "@zendeskgarden/container-utilities": "^2.0.2",
-    "react-uid": "^2.2.0"
+    "@zendeskgarden/container-utilities": "^2.0.2"
   },
   "peerDependencies": {
     "prop-types": "^15.6.1",

--- a/packages/tooltip/src/TooltipContainer.tsx
+++ b/packages/tooltip/src/TooltipContainer.tsx
@@ -5,24 +5,15 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import React from 'react';
+import React, { FC } from 'react';
 import PropTypes from 'prop-types';
+import { useTooltip } from './useTooltip';
+import { ITooltipContainerProps } from './types';
 
-import { useTooltip, IUseTooltipProps, IUseTooltipReturnValue } from './useTooltip';
+export const TooltipContainer: FC<ITooltipContainerProps> = props => {
+  const { children, render = children, ...options } = props;
 
-export interface ITooltipContainerProps extends IUseTooltipProps {
-  /** A render prop function which receives tooltip state and prop getters */
-  render?: (options: IUseTooltipReturnValue) => React.ReactNode;
-  /** A children render prop function which receives tooltip state and prop getters */
-  children?: (options: IUseTooltipReturnValue) => React.ReactNode;
-}
-
-export const TooltipContainer: React.FunctionComponent<ITooltipContainerProps> = ({
-  children,
-  render = children,
-  ...options
-}) => {
-  return <>{render!(useTooltip(options)) as React.ReactElement}</>;
+  return <>{render!(useTooltip(options))}</>;
 };
 
 TooltipContainer.defaultProps = {
@@ -33,5 +24,7 @@ TooltipContainer.propTypes = {
   children: PropTypes.func,
   render: PropTypes.func,
   delayMilliseconds: PropTypes.number,
-  isVisible: PropTypes.bool
+  id: PropTypes.string,
+  isVisible: PropTypes.bool,
+  triggerRef: PropTypes.any.isRequired
 };

--- a/packages/tooltip/src/index.ts
+++ b/packages/tooltip/src/index.ts
@@ -6,7 +6,9 @@
  */
 
 /* Hooks */
-export { useTooltip, type IUseTooltipProps, type IUseTooltipReturnValue } from './useTooltip';
+export { useTooltip } from './useTooltip';
 
 /* Render-props */
-export { TooltipContainer, type ITooltipContainerProps } from './TooltipContainer';
+export { TooltipContainer } from './TooltipContainer';
+
+export type { ITooltipContainerProps, IUseTooltipProps, IUseTooltipReturnValue } from './types';

--- a/packages/tooltip/src/types.ts
+++ b/packages/tooltip/src/types.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import { HTMLProps, RefObject } from 'react';
+
+export interface IUseTooltipProps<T = HTMLElement> {
+  /** Sets delay to the opening and closing of the tooltip */
+  delayMilliseconds?: number;
+  /** Specifies the tooltip ID */
+  id?: string;
+  /** Controls visibility state of the tooltip */
+  isVisible?: boolean;
+  /** Provides ref access to the underlying trigger element */
+  triggerRef: RefObject<T>;
+}
+
+export interface IUseTooltipReturnValue {
+  getTooltipProps: <T extends Element>(props?: HTMLProps<T>) => HTMLProps<T>;
+  getTriggerProps: <T extends Element>(props?: HTMLProps<T>) => HTMLProps<T>;
+  isVisible?: boolean;
+  openTooltip: (delayMs?: number) => void;
+  closeTooltip: (delayMs?: number) => void;
+}
+
+export interface ITooltipContainerProps<T = HTMLElement> extends IUseTooltipProps<T> {
+  /**
+   * Provides tooltip render prop functions, state, and actions
+   *
+   * @param {function} [options.getTooltipProps] Tooltip props getter
+   * @param {function} [options.getTriggerProps] Trigger props getter
+   * @param {boolean} options.isVisible Current tooltip visibility
+   * @param {function} [options.openTooltip] Open the tooltip with an optional delay
+   * @param {function} [options.closeTooltip] Close the tooltip with an optional delay
+   */
+  render?: (options: {
+    /* prop getters */
+    getTooltipProps: IUseTooltipReturnValue['getTooltipProps'];
+    getTriggerProps: IUseTooltipReturnValue['getTriggerProps'];
+    /* state */
+    isVisible?: boolean;
+    /* actions */
+    openTooltip: IUseTooltipReturnValue['openTooltip'];
+    closeTooltip: IUseTooltipReturnValue['closeTooltip'];
+  }) => React.ReactNode;
+  /** @ignore */
+  children?: (options: IUseTooltipReturnValue) => React.ReactNode;
+}

--- a/packages/tooltip/src/types.ts
+++ b/packages/tooltip/src/types.ts
@@ -12,7 +12,7 @@ export interface IUseTooltipProps<T = HTMLElement> {
   delayMilliseconds?: number;
   /** Specifies the tooltip ID */
   id?: string;
-  /** Controls visibility state of the tooltip */
+  /** Displays the tooltip on initial render */
   isVisible?: boolean;
   /** Provides ref access to the underlying trigger element */
   triggerRef: RefObject<T>;

--- a/packages/tooltip/src/useTooltip.ts
+++ b/packages/tooltip/src/useTooltip.ts
@@ -79,14 +79,16 @@ export const useTooltip = <T extends HTMLElement = HTMLElement>({
     // Prevent tooltip from competing with a trigger popup (i.e. menu, dialog, etc.)
     const triggerElement = triggerRef?.current;
 
-    const mutationObserver = new MutationObserver(() => {
+    const updateTriggerPopupExpandedState = () => {
       if (triggerElement) {
         setIsTriggerPopupExpanded(
           triggerElement.getAttribute('aria-haspopup') === 'true' &&
             triggerElement.getAttribute('aria-expanded') === 'true'
         );
       }
-    });
+    };
+
+    const mutationObserver = new MutationObserver(updateTriggerPopupExpandedState);
 
     if (triggerElement) {
       mutationObserver.observe(triggerElement, {
@@ -94,6 +96,8 @@ export const useTooltip = <T extends HTMLElement = HTMLElement>({
         attributeFilter: ['aria-expanded']
       });
     }
+
+    updateTriggerPopupExpandedState(); // initial render
 
     return () => mutationObserver.disconnect();
   }, [triggerRef]);


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

The main point of this PR is to suppress a tooltip when it's trigger has opened a menu or dialog so that the tooltip doesn't interfere visually or compete for `z-index` stacking. The new `Menu` story demonstrates tooltip hiding on menu expansion. Please see details below for additional quality-of-life package updates.

## Detail

- The typing for this component was a bit outdated and chaotic. This PR brings `tooltip` up-to-date with other more current containers (`combobox`, `menu`) and improves memoization capabilities
- Types were moved to a dedicated `types.ts`

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
