### PR TITLE
fix(container-utilities): coerce useId return value to string

### DIFF
--- a/packages/utilities/src/utils/useId.ts
+++ b/packages/utilities/src/utils/useId.ts
@@ -16,4 +16,4 @@ let idCounter = 0;
  *
  * @returns A generated ID that can be passed to accessibility attributes
  */
-export const useId = (id?: any) => useReachId(id) || `id:${idCounter++}`;
+export const useId = (id?: any) => `${useReachId(id)}` || `id:${idCounter++}`;


### PR DESCRIPTION
## Description

This PR ensures that useId consistently returns a string value. Previously, it could be either a string or a number, which could lead to confusion.

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] ~:guardsman: includes new unit tests~
- [ ] ~:wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance~
- [ ] ~:memo: tested in Chrome, Firefox, Safari, and Edge~
