### PR TITLE
fix(dropdowns): include inputValue in input:change event

### DIFF
--- a/packages/combobox/src/ComboboxContainer.spec.tsx
+++ b/packages/combobox/src/ComboboxContainer.spec.tsx
@@ -892,6 +892,21 @@ describe('ComboboxContainer', () => {
           expect(changeTypes).toMatchObject(['input:change', 'input:change']);
         });
 
+        it('includes inputValue in input:change payload for controlled input', () => {
+          fireEvent.change(input, { target: { value: 'a' } });
+
+          const inputChangeCall = handleChange.mock.calls.find(
+            ([change]) => change.type === 'input:change'
+          );
+
+          expect(inputChangeCall).toBeDefined();
+          expect(inputChangeCall![0]).toMatchObject({
+            type: 'input:change',
+            isExpanded: true,
+            inputValue: 'a'
+          });
+        });
+
         it('handles controlled selection as expected', () => {
           const _options = [{ value: 'test-1' }, { value: 'test-2' }, { value: 'test-3' }];
 

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -27,7 +27,7 @@ import {
   UseComboboxStateChangeTypes as IDownshiftStateChangeType
 } from 'downshift';
 import { IOption, IUseComboboxProps, IUseComboboxReturnValue, OptionValue } from './types';
-import { toLabel, toType } from './utils';
+import { EXPANSION_CHANGE_TYPE, INPUT_CHANGE_TYPE, toLabel, toType } from './utils';
 
 export const useCombobox = <
   T extends HTMLElement = HTMLElement,
@@ -78,6 +78,7 @@ export const useCombobox = <
   const [downshiftInputValue, setDownshiftInputValue] = useState(inputValue);
   const [matchValue, setMatchValue] = useState('');
   const useInputValueRef = useRef(true);
+  const skipNextInputChangeRef = useRef(false);
   const matchTimeoutRef = useRef<number>();
   const previousStateRef = useRef<IPreviousState>();
   const prefix = useId(idPrefix);
@@ -187,15 +188,36 @@ export const useCombobox = <
   const handleDownshiftStateChange = useCallback<
     NonNullable<IUseDownshiftProps<OptionValue | OptionValue[]>['onStateChange']>
   >(
-    ({ type, isOpen, selectedItem, inputValue: _inputValue, highlightedIndex }) =>
+    ({ type, isOpen, selectedItem, inputValue: _inputValue, highlightedIndex }) => {
+      const mappedType = toType(type);
+
+      if (mappedType === EXPANSION_CHANGE_TYPE && isOpen === undefined) {
+        return;
+      }
+
+      if (mappedType === INPUT_CHANGE_TYPE && skipNextInputChangeRef.current) {
+        skipNextInputChangeRef.current = false;
+
+        return;
+      }
+
+      const resolvedInputValue =
+        mappedType === INPUT_CHANGE_TYPE
+          ? (_inputValue ?? inputRef.current?.value ?? downshiftInputValue)
+          : _inputValue;
+      // Omit inputValue when closing via fn:setExpansion to avoid overwriting the controlled value.
+      const shouldIncludeInputValue = mappedType !== EXPANSION_CHANGE_TYPE || isOpen === true;
+
       onChange({
-        type: toType(type),
+        type: mappedType,
         ...(isOpen !== undefined && { isExpanded: isOpen }),
         ...(selectedItem !== undefined && { selectionValue: selectedItem }),
-        ...(_inputValue !== undefined && { inputValue: _inputValue }),
+        ...(shouldIncludeInputValue &&
+          resolvedInputValue !== undefined && { inputValue: resolvedInputValue }),
         ...(highlightedIndex !== undefined && { activeIndex: highlightedIndex })
-      }),
-    [onChange]
+      });
+    },
+    [downshiftInputValue, inputRef, onChange]
   );
 
   const stateReducer: IUseDownshiftProps<any /* vs. state/changes `selectedItem` type flipping */>['stateReducer'] =
@@ -675,6 +697,15 @@ export const useCombobox = <
                 type: useDownshift.stateChangeTypes.InputChange,
                 inputValue: event.target.value
               });
+            } else {
+              // For controlled inputs, Downshift omits inputValue from onStateChange.
+              // Call onChange directly and suppress the subsequent Downshift mirror event.
+              skipNextInputChangeRef.current = true;
+              onChange({
+                type: INPUT_CHANGE_TYPE,
+                isExpanded: true,
+                inputValue: event.target.value
+              });
             }
           }
         };
@@ -746,6 +777,7 @@ export const useCombobox = <
       hasMessage,
       inputValue,
       inputRef,
+      onChange,
       triggerRef,
       disabled,
       isAutocomplete,

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -78,7 +78,7 @@ export const useCombobox = <
   const [downshiftInputValue, setDownshiftInputValue] = useState(inputValue);
   const [matchValue, setMatchValue] = useState('');
   const useInputValueRef = useRef(true);
-  const skipNextInputChangeRef = useRef(false);
+  const skipNextInputChangeRef = useRef<string | null>(null);
   const matchTimeoutRef = useRef<number>();
   const previousStateRef = useRef<IPreviousState>();
   const prefix = useId(idPrefix);
@@ -195,10 +195,13 @@ export const useCombobox = <
         return;
       }
 
-      if (mappedType === INPUT_CHANGE_TYPE && skipNextInputChangeRef.current) {
-        skipNextInputChangeRef.current = false;
+      if (mappedType === INPUT_CHANGE_TYPE && skipNextInputChangeRef.current !== null) {
+        const resolvedForSkipCheck = _inputValue ?? inputRef.current?.value ?? downshiftInputValue;
+        const skip = skipNextInputChangeRef.current === resolvedForSkipCheck;
 
-        return;
+        skipNextInputChangeRef.current = null;
+
+        if (skip) return;
       }
 
       const resolvedInputValue =
@@ -700,7 +703,7 @@ export const useCombobox = <
             } else {
               // For controlled inputs, Downshift omits inputValue from onStateChange.
               // Call onChange directly and suppress the subsequent Downshift mirror event.
-              skipNextInputChangeRef.current = true;
+              skipNextInputChangeRef.current = event.target.value;
               onChange({
                 type: INPUT_CHANGE_TYPE,
                 isExpanded: true,

--- a/packages/combobox/src/utils.ts
+++ b/packages/combobox/src/utils.ts
@@ -46,6 +46,9 @@ export const toType = (downshiftType: string) => {
   return typeMap[downshiftType] || downshiftType;
 };
 
+export const EXPANSION_CHANGE_TYPE = toType(useDownshift.stateChangeTypes.FunctionOpenMenu);
+export const INPUT_CHANGE_TYPE = toType(useDownshift.stateChangeTypes.InputChange);
+
 /**
  * Convert the given option value to a label.
  *


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(selection):
     add keydown event to handle rtl". the title informs the semantic
     version bump if this PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

An event body mismatch was found in Garden v9 compared to Garden v8 for the `input:change` and `fn:setExpansion` events. This mismatch breaks existing UI behaviour., blocking migration from Garden v8 to v9.

Specifically:
- `input:change`: `inputValue` was missing from the event body for controlled inputs
- `fn:setExpansion`: the event fires twice when closing — the second instance incorrectly includes `inputValue`, overwriting the controlled value on the consumer side

Event body:

**Garden v8**:
<img width="497" height="250" alt="Screenshot 2026-06-22 at 7 26 05 PM" src="https://github.com/user-attachments/assets/09739ff5-b61f-45ca-a5e2-3d1a9a534fc8" />

**Garden v9**: (`inputValue` is missing from the `input:change` event, and the `fn:setExpansion` event fires twice, with the second instance containing `inputValue`, which breaks existing UI behavior.):
<img width="507" height="197" alt="Screenshot 2026-06-22 at 2 08 25 PM" src="https://github.com/user-attachments/assets/212fa038-1f85-4e27-9502-41d2387a3217" />


## Detail

**`input:change` for controlled inputs**
- For controlled inputs, Downshift's `onStateChange` omits `inputValue` from the event payload
- Fixed by calling `onChange` directly from the native input handler with the correct `inputValue: event.target.value`
- A `skipNextInputChangeRef` flag suppresses the subsequent Downshift mirror event to avoid duplicate emissions
- `resolvedInputValue` now falls back to `inputRef.current?.value` or `downshiftInputValue` if Downshift omits the value, ensuring `inputValue` is always present in the event body

**`fn:setExpansion` when closing**
- When closing via `fn:setExpansion`, `inputValue` was incorrectly included in the event body, overwriting the controlled value on the consumer side
- Added a `shouldIncludeInputValue` guard to omit `inputValue` from the event when `fn:setExpansion` is closing the combobox (`isOpen !== true`)

**Misc**
- Extracted `EXPANSION_CHANGE_TYPE` and `INPUT_CHANGE_TYPE` as named constants in `utils.ts` to avoid repeated `toType()` calls

**Test coverage note**
- Unit tests cannot cover these scenarios — jsdom processes all updates synchronously and cannot simulate the real browser's async re-rendering that causes the bug. The issues only surface in downstream services consuming the controlled props in a real browser.

<!-- closes GITHUB_ISSUE -->

## Checklist

<!-- check the items below that will be completed prior to merge.
     strikethrough any item text that does not apply to this PR. -->

- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [ ] ~~:guardsman: includes new unit tests~~
- [ ] ~~:wheelchair: tested for [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA compliance~~
- [ ] ~~:memo: tested in Chrome, Firefox, Safari, and Edge~~