### PR TITLE
fix(combobox): don't auto-activate first option while editing autocomplete

### DIFF
--- a/packages/combobox/src/ComboboxContainer.spec.tsx
+++ b/packages/combobox/src/ComboboxContainer.spec.tsx
@@ -457,6 +457,23 @@ describe('ComboboxContainer', () => {
             listboxOptions[0].getAttribute('id')
           );
         });
+
+        it('decouples activation from expansion — opens without activating, then activates on arrow', async () => {
+          // Expansion must not imply activation: opening the listbox leaves
+          // `aria-activedescendant` empty, and only an explicit arrow press
+          // activates an option.
+          await user.click(input);
+
+          expect(input).toHaveAttribute('aria-expanded', 'true');
+          expect(input).toHaveAttribute('aria-activedescendant', '');
+
+          await user.keyboard('{ArrowDown}');
+
+          expect(input).toHaveAttribute(
+            'aria-activedescendant',
+            listboxOptions[0].getAttribute('id')
+          );
+        });
       });
 
       describe('on selection', () => {

--- a/packages/combobox/src/ComboboxContainer.spec.tsx
+++ b/packages/combobox/src/ComboboxContainer.spec.tsx
@@ -476,6 +476,30 @@ describe('ComboboxContainer', () => {
         });
       });
 
+      describe('when editing with a controlled active index', () => {
+        // A controlled `activeIndex` must take precedence over the (now
+        // opt-in) `defaultActiveIndex` layer that the deleted-character fix
+        // changed. Removing the auto-activate default only affects uncontrolled
+        // usage: an editable autocomplete combobox driven by a controlled
+        // `activeIndex` still activates that option, so the fix does not
+        // interfere with controlled comboboxes.
+        it('activates the controlled option on open', async () => {
+          const { getByTestId, getAllByRole } = render(
+            <TestCombobox layout={layout} options={options} activeIndex={0} />
+          );
+          const input = getByTestId('input');
+          const listboxOptions = getAllByRole('option');
+
+          await user.click(input);
+
+          expect(input).toHaveAttribute('aria-expanded', 'true');
+          expect(input).toHaveAttribute(
+            'aria-activedescendant',
+            listboxOptions[0].getAttribute('id')
+          );
+        });
+      });
+
       describe('on selection', () => {
         let input: HTMLElement;
         let listboxOptions: HTMLElement[];

--- a/packages/combobox/src/ComboboxContainer.spec.tsx
+++ b/packages/combobox/src/ComboboxContainer.spec.tsx
@@ -458,6 +458,27 @@ describe('ComboboxContainer', () => {
           );
         });
 
+        it('clears activation when editing resumes after keyboard navigation', async () => {
+          // Resuming editing after arrowing into the listbox must clear
+          // `aria-activedescendant` again so assistive technology echoes the
+          // edited character instead of the active option.
+          await user.click(input);
+          await user.keyboard('{ArrowDown}');
+
+          expect(input).toHaveAttribute(
+            'aria-activedescendant',
+            listboxOptions[0].getAttribute('id')
+          );
+
+          await user.keyboard('T');
+
+          expect(input).toHaveAttribute('aria-activedescendant', '');
+
+          await user.keyboard('{Backspace}');
+
+          expect(input).toHaveAttribute('aria-activedescendant', '');
+        });
+
         it('decouples activation from expansion — opens without activating, then activates on arrow', async () => {
           // Expansion must not imply activation: opening the listbox leaves
           // `aria-activedescendant` empty, and only an explicit arrow press
@@ -493,6 +514,38 @@ describe('ComboboxContainer', () => {
           await user.click(input);
 
           expect(input).toHaveAttribute('aria-expanded', 'true');
+          expect(input).toHaveAttribute(
+            'aria-activedescendant',
+            listboxOptions[0].getAttribute('id')
+          );
+        });
+      });
+
+      describe('when editing with an opt-in default active index', () => {
+        // `defaultActiveIndex={0}` is the documented escape hatch for restoring
+        // the pre-fix auto-activation on a fresh, uncontrolled combobox. It is
+        // NOT accessible for editable autocomplete: it keeps
+        // `aria-activedescendant` populated while typing, which is the
+        // char-echo regression the fix removed (APG list autocomplete with
+        // manual selection). Asserted here so the tradeoff is explicit.
+        it('activates the default option on open and keeps it active while typing', async () => {
+          const { getByTestId, getAllByRole } = render(
+            <TestCombobox layout={layout} options={options} defaultActiveIndex={0} />
+          );
+          const input = getByTestId('input');
+          const listboxOptions = getAllByRole('option');
+
+          await user.click(input);
+
+          expect(input).toHaveAttribute('aria-expanded', 'true');
+          expect(input).toHaveAttribute(
+            'aria-activedescendant',
+            listboxOptions[0].getAttribute('id')
+          );
+
+          // Tradeoff: activation persists through editing rather than clearing.
+          await user.keyboard('Te');
+
           expect(input).toHaveAttribute(
             'aria-activedescendant',
             listboxOptions[0].getAttribute('id')

--- a/packages/combobox/src/ComboboxContainer.spec.tsx
+++ b/packages/combobox/src/ComboboxContainer.spec.tsx
@@ -405,6 +405,60 @@ describe('ComboboxContainer', () => {
         });
       });
 
+      describe('when editing with list autocomplete', () => {
+        // For an editable autocomplete combobox, `aria-activedescendant` must
+        // stay empty while the user types and deletes so assistive technology
+        // echoes the edited character. It becomes populated only once the user
+        // arrows into the listbox — the APG "list autocomplete with manual
+        // selection" behavior:
+        // https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/
+        let input: HTMLElement;
+        let listboxOptions: HTMLElement[];
+
+        beforeEach(() => {
+          const { getByTestId, getAllByRole } = render(
+            <TestCombobox layout={layout} options={options} />
+          );
+
+          input = getByTestId('input');
+          listboxOptions = getAllByRole('option');
+
+          input.focus();
+        });
+
+        it('activates no option when the listbox opens', async () => {
+          await user.click(input);
+
+          expect(input).toHaveAttribute('aria-expanded', 'true');
+          expect(input).toHaveAttribute('aria-activedescendant', '');
+        });
+
+        it('activates no option while typing', async () => {
+          await user.click(input);
+          await user.keyboard('Test');
+
+          expect(input).toHaveAttribute('aria-activedescendant', '');
+        });
+
+        it('activates no option while deleting', async () => {
+          await user.click(input);
+          await user.keyboard('Test');
+          await user.keyboard('{Backspace}');
+
+          expect(input).toHaveAttribute('aria-activedescendant', '');
+        });
+
+        it('activates the first option once the user arrows into the listbox', async () => {
+          await user.click(input);
+          await user.keyboard('{ArrowDown}');
+
+          expect(input).toHaveAttribute(
+            'aria-activedescendant',
+            listboxOptions[0].getAttribute('id')
+          );
+        });
+      });
+
       describe('on selection', () => {
         let input: HTMLElement;
         let listboxOptions: HTMLElement[];

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -145,10 +145,11 @@ export const useCombobox = <
   const initialInputValue = isMultiselectable
     ? ''
     : toLabel(cache.labels, initialSelectionValue as string);
-  // Do not auto-activate the first option for editable autocomplete:
+  // Do not auto-activate the first option for editable autocomplete.
   // `aria-activedescendant` must stay empty while typing/deleting so AT
   // echoes edited characters (APG list autocomplete with manual selection).
-  // Consumers can still opt in via `defaultActiveIndex`.
+  // Consumers can restore automatic first-option activation by passing defaultActiveIndex={0};
+  // the active index remains uncontrolled afterward.
   const _defaultActiveIndex = defaultActiveIndex;
 
   if (useInputValueRef.current && inputValue !== downshiftInputValue) {

--- a/packages/combobox/src/useCombobox.ts
+++ b/packages/combobox/src/useCombobox.ts
@@ -145,13 +145,11 @@ export const useCombobox = <
   const initialInputValue = isMultiselectable
     ? ''
     : toLabel(cache.labels, initialSelectionValue as string);
-  const _defaultActiveIndex = useMemo(() => {
-    if (defaultActiveIndex === undefined) {
-      return isAutocomplete && isEditable ? 0 : undefined;
-    }
-
-    return defaultActiveIndex;
-  }, [defaultActiveIndex, isAutocomplete, isEditable]);
+  // Do not auto-activate the first option for editable autocomplete:
+  // `aria-activedescendant` must stay empty while typing/deleting so AT
+  // echoes edited characters (APG list autocomplete with manual selection).
+  // Consumers can still opt in via `defaultActiveIndex`.
+  const _defaultActiveIndex = defaultActiveIndex;
 
   if (useInputValueRef.current && inputValue !== downshiftInputValue) {
     // Update local state with Downshift `inputValue` for non-buggy cases.


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?**

Editable autocomplete comboboxes no longer auto-activate the first matching option on expansion. Auto-highlight is now opt-in via the existing `defaultActiveIndex` prop. To restore the previous behavior, pass `defaultActiveIndex={0}`. 

> [!NOTE]  
> Opting in on an editable autocomplete combobox reintroduces the screen-reader issue this change fixes — the first option stays active while the user types, so the edited character is not reliably announced (see Description). Prefer leaving it unset for editable autocomplete.

`react-components` branch for previewing Combobox component changes: [jgorfine/combobox-autocomplete-bug-fix](https://github.com/zendeskgarden/react-components/tree/jgorfine/combobox-autocomplete-bug-fix)

## Description

A blind screen reader user reported that, when using an editable combobox with list autocomplete, deleting characters from the input was not announced while matching options were still available. Announcements resumed only once the input no longer matched any option (i.e. once "No matches found" was the only item left).

The cause: the container auto-activated the first matching option on expansion, so `aria-activedescendant` stayed populated while the user typed and deleted. With an active descendant present, assistive technology tracks the active option instead of echoing the edited character, suppressing the expected per-character feedback.

This change stops auto-activating the first option for editable autocomplete comboboxes. `aria-activedescendant` now stays empty while the user types and deletes — so the edited character is announced — and becomes populated only once the user arrows into the listbox. This matches the ARIA APG "list autocomplete with manual selection" behavior. Auto-highlight remains available opt-in through `defaultActiveIndex`, and controlled comboboxes (driven by `activeIndex`) are unaffected.

## Detail

Fix is in the `useCombobox` container hook: the first-option activation default was removed so activation is decoupled from expansion. A pre-selected option is still activated on open, and consumers can opt back into first-option highlighting via `defaultActiveIndex`.

New unit tests cover, across both the Garden and Downshift layouts:
- no option is activated on open, while typing, or while deleting;
- an option is activated once the user arrows into the listbox;
- `aria-activedescendant` clears again when editing resumes after keyboard navigation (arrow-in activates, then typing/deleting clears it);
- a controlled `activeIndex` still takes precedence (uncontrolled-only change);
- the `defaultActiveIndex={0}` opt-in activates the first option on open and keeps it active while typing — documenting the accessibility tradeoff of the migration escape hatch.

### Screen reader verification

Verified that the edited character is announced identically whether matching options remain **or** only "No matches found" is left, on:

- JAWS 2025.2503.39 + Chrome, Windows (via AssistivLabs)
- NVDA 2026.1.1 + Chrome, Windows (via AssistivLabs)
- VoiceOver + Safari 26.5 (21624.2.5.11.4), macOS Tahoe 26.5

#### JAWS

##### Before

https://github.com/user-attachments/assets/48994d86-e2c0-4ca0-b8c9-89eff67da25a

##### After

https://github.com/user-attachments/assets/0a0a040e-c46e-4209-9746-afa796a03579

#### NVDA

##### Before

https://github.com/user-attachments/assets/48ce61c0-f038-4c2e-8214-af3ad3993f48

##### After

https://github.com/user-attachments/assets/ef17a703-fc1e-4ea1-820b-6c4484f4d774

#### VoiceOver

##### Before

https://github.com/user-attachments/assets/523e0dca-946a-4f32-bf52-4709ae56f891

##### After

https://github.com/user-attachments/assets/a774b055-3a5e-44f2-ae55-9af7abc9aa29

## Checklist

- [x] :globe_with_meridians: demo is up-to-date (`npm start`)
- [x] :guardsman: includes new unit tests
- [x] :wheelchair: tested for [WCAG 2.2](https://www.w3.org/TR/WCAG22) AA compliance
- [x] :memo: tested in Chrome, Firefox, Safari, and Edge
